### PR TITLE
JVMTI GetThreadInfo fixed to return NULL when Thread is TERMINATED

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1249,11 +1249,19 @@ JvmtiEnv::GetThreadInfo(jthread thread, jvmtiThreadInfo* info_ptr) {
     }
     priority = (ThreadPriority)JVMTI_THREAD_NORM_PRIORITY;
     is_daemon = true;
-    thread_group = Handle(current_thread, java_lang_Thread_VirtualThreads::get_THREAD_GROUP());
+    if (java_lang_VirtualThread::state(thread_obj()) == java_lang_VirtualThread::TERMINATED) {
+      thread_group = Handle(current_thread, NULL);
+    } else {
+      thread_group = Handle(current_thread, java_lang_Thread_VirtualThreads::get_THREAD_GROUP());
+    }
   } else {
     priority = java_lang_Thread::priority(thread_obj());
     is_daemon = java_lang_Thread::is_daemon(thread_obj());
-    thread_group = Handle(current_thread, java_lang_Thread::threadGroup(thread_obj()));
+    if (java_lang_Thread::get_thread_status(thread_obj()) == java_lang_Thread::TERMINATED) {
+      thread_group = Handle(current_thread, NULL);
+    } else {
+      thread_group = Handle(current_thread, java_lang_Thread::threadGroup(thread_obj()));
+    }
   }
 
   oop loader = java_lang_Thread::context_class_loader(thread_obj());
@@ -2321,7 +2329,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
                                  current_thread, depth);
     VMThread::execute(&op);
     err = op.result();
-    if (err == JVMTI_ERROR_NONE) { 
+    if (err == JVMTI_ERROR_NONE) {
       *value_ptr = op.value().l;
     }
   } else {
@@ -2334,7 +2342,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
     VM_GetReceiver op(java_thread, current_thread, depth);
     VMThread::execute(&op);
     err = op.result();
-    if (err == JVMTI_ERROR_NONE) { 
+    if (err == JVMTI_ERROR_NONE) {
       *value_ptr = op.value().l;
     }
   }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001.java
@@ -74,6 +74,15 @@ public class thrinfo001 {
             t_b.join();
         } catch (InterruptedException e) {}
         checkInfo(t_b, t_b.getThreadGroup(), 2);
+
+        Thread t_c = Thread.builder().task(new thrinfo001c()).name("vthread").virtual().build();
+        checkInfo(t_c, t_c.getThreadGroup(), 3);
+        t_c.start();
+        try {
+            t_c.join();
+        } catch (InterruptedException e) {}
+        checkInfo(t_c, t_c.getThreadGroup(), 3);
+
         return getRes();
     }
 }
@@ -93,5 +102,12 @@ class thrinfo001b extends Thread {
     public void run() {
         Thread currThr = Thread.currentThread();
         thrinfo001.checkInfo(currThr, currThr.getThreadGroup(), 2);
+    }
+}
+
+class thrinfo001c implements Runnable {
+    public void run() {
+        Thread currThr = Thread.currentThread();
+        thrinfo001.checkInfo(currThr, currThr.getThreadGroup(), 3);
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001/thrinfo001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadInfo/thrinfo001/thrinfo001.cpp
@@ -45,7 +45,8 @@ static jvmtiThreadInfo inf;
 static info threads[] = {
     { "main", JVMTI_THREAD_NORM_PRIORITY, 0 },
     { "thread1", JVMTI_THREAD_MIN_PRIORITY + 2, 1 },
-    { "Thread-", JVMTI_THREAD_MIN_PRIORITY, 1 }
+    { "Thread-", JVMTI_THREAD_MIN_PRIORITY, 1 },
+    { "vthread", JVMTI_THREAD_NORM_PRIORITY, 1 }
 };
 
 #ifdef STATIC_BUILD
@@ -61,6 +62,7 @@ JNIEXPORT jint JNI_OnLoad_thrinfo001(JavaVM *jvm, char *options, void *reserved)
 #endif
 jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
+    jvmtiCapabilities caps;
 
     res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
@@ -68,6 +70,13 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
     }
 
+    memset(&caps, 0, sizeof(caps));
+    caps.can_support_virtual_threads = 1;
+    res = jvmti->AddCapabilities(&caps);
+    if (res != JVMTI_ERROR_NONE) {
+      printf("error in JVMTI AddCapabilities: %d\n", res);
+      return JNI_ERR;
+    }
     return JNI_OK;
 }
 


### PR DESCRIPTION
JVMTI GetThreadInfo fixed to return NULL when Thread is TERMINATED
It is a fix for both Kernel and Virtual threads
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/loom pull/12/head:pull/12`
`$ git checkout pull/12`
