### PR TITLE
j.l.Thread::exit() updated to don't call ThreadGroup.threadTerminated() if it is already destroyed.

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -137,7 +137,7 @@ public class Thread implements Runnable {
         }
     }
     private final FieldHolder holder;
-    
+
     // interrupt status (read/written by VM)
     volatile boolean interrupted;
 
@@ -178,7 +178,7 @@ public class Thread implements Runnable {
         private static final Unsafe U = Unsafe.getUnsafe();
         private static final long nextTidOffset =
             U.objectFieldOffset(ThreadIdentifiers.class, "nextTid");
-        private static final long TID_MASK = (1L << 48) - 1; 
+        private static final long TID_MASK = (1L << 48) - 1;
         private static volatile long nextTid = 2;
         private static long next() {
             return U.getAndAddLong(ThreadIdentifiers.class, nextTidOffset, 1);
@@ -365,7 +365,7 @@ public class Thread implements Runnable {
             sleepMillis(millis);
         }
     }
-	
+
 	private static void sleepMillis(long millis) throws InterruptedException {
 		VirtualThread vthread = currentCarrierThread().getVirtualThread();
         if (vthread != null) {
@@ -373,8 +373,8 @@ public class Thread implements Runnable {
         } else {
             sleep0(millis);
         }
-	}	
-	
+	}
+
     private static native void sleep0(long millis) throws InterruptedException;
 
     /**
@@ -631,7 +631,7 @@ public class Thread implements Runnable {
      *     };
      * }</pre>
      *
-     * @see Thread.Builder#virtual(Executor) 
+     * @see Thread.Builder#virtual(Executor)
      * @since 99
      */
     public interface VirtualThreadTask {
@@ -1656,7 +1656,7 @@ public class Thread implements Runnable {
             TerminatingThreadLocal.threadTerminated();
         }
         ThreadGroup group = holder.group;
-        if (group != null) {
+        if (group != null && !group.isDestroyed()) {
             group.threadTerminated(this);
         }
         /* Aggressively null out all reference fields: see bug 4006245 */

--- a/test/hotspot/jtreg/ProblemList-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-vthread.txt
@@ -191,13 +191,13 @@ gc/TestAgeOutput.java#id0
 
 vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
 
+####
+## Functionality not supported for vthreads (incorrect resuls)
+vmTestbase/nsk/jdb/set/set002/set002.java
 
 ####
-## Exception wasn't caught by jdb
+## jdb caught InvocationTargetException caused by expected TenMultipleException
 
-vmTestbase/nsk/jdb/set/set002/set002.java
-vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
-vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
 vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java
@@ -51,8 +51,11 @@ public class threadgroup002a {
         Thread holder [] = new Thread[numThreads];
         Lock lock = new Lock();
 
-        for (int i = 0; i < numThreadGroups ; i++ )
+        for (int i = 0; i < numThreadGroups; i++) {
             tgHolder[i] = new ThreadGroup(THREADGROUP_NAME + i);
+        }
+
+        tgHolder[0].setDaemon(true);
 
         try {
             lock.setLock();


### PR DESCRIPTION
The ThreadGroup.destroy() fails with IllegalThreadStateException if already destroyed. Earlier Thread.group was set to null in Thread.exit() to prevent this issue.

The issue is hit for daemon ThreadGroups only.

Test vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002a.java was updated to check daemon threads.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/loom pull/13/head:pull/13`
`$ git checkout pull/13`
