### PR TITLE
8246039: SSLSocket HandshakeCompletedListeners are run on virtual threads

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/TransportContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/TransportContext.java
@@ -637,13 +637,11 @@ final class TransportContext implements ConnectionContext {
                 !sslConfig.handshakeListeners.isEmpty()) {
             HandshakeCompletedEvent hce =
                 new HandshakeCompletedEvent((SSLSocket)transport, conSession);
-            Thread thread = new Thread(
-                null,
-                new NotifyHandshake(sslConfig.handshakeListeners, hce),
-                "HandshakeCompletedNotify-Thread",
-                0,
-                false);
-            thread.start();
+            Thread.builder()
+                    .virtual()
+                    .name("HandshakeCompletedNotify-Thread")
+                    .task(new NotifyHandshake(sslConfig.handshakeListeners, hce))
+                    .start();
         }
 
         return HandshakeStatus.FINISHED;


### PR DESCRIPTION
Previously each `SSLSocket.addHandshakeCompletedListener(HandshakeCompletedListener)`
resulted in a new OS thread for each handshake which causes spikes in
resource utilization and bottlenecks in high throughput systems.

Virtual threads should reduce the overhead while preserving behavior to
the extent possible.

Reported to openjdk security-dev here:
https://mail.openjdk.java.net/pipermail/security-dev/2020-July/022220.html
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Bradford Wetmore](https://openjdk.java.net/census#wetmore) (@bradfordwetmore - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/loom pull/16/head:pull/16`
`$ git checkout pull/16`
