### PR TITLE
Slightly simpler way of waiting for a specific time

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -631,11 +631,9 @@ class VirtualThread extends Thread {
                 }
                 return true;
             } else {
-                long startNanos = System.nanoTime();
                 long remainingNanos = nanos;
                 while (remainingNanos > 0 && state() != TERMINATED) {
-                    condition.await(remainingNanos, NANOSECONDS);
-                    remainingNanos = nanos - (System.nanoTime() - startNanos);
+                    remainingNanos = condition.awaitNanos(remainingNanos);
                 }
                 return (state() == TERMINATED);
             }


### PR DESCRIPTION
Instead of writing the logic for calling System.nanoTime() etc. ourselves, could we perhaps use awaitNanos() instead?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/loom pull/19/head:pull/19`
`$ git checkout pull/19`
