### PR TITLE
OSX build fails with Xcode 12 due to missing parantheses around sizeo…

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2885,7 +2885,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       // accesses. For native_wrappers we need a constant.
       buffer.initialize_consts_size(8);
 #endif
-      buffer.stubs()->initialize_shared_locs((relocInfo*)stubs_locs_buf, sizeof(stubs_locs_buf) / sizeof(relocInfo));
+      buffer.stubs()->initialize_shared_locs((relocInfo*)stubs_locs_buf, sizeof(stubs_locs_buf) / (sizeof(relocInfo)));
       MacroAssembler _masm(&buffer);
 
       // Fill in the signature array, for the calling-convention call.


### PR DESCRIPTION
…f(relocInfo)
For some reason, OS X 10.15.7 Catalina with Xcode 12 fails to compile the sharedRuntime.cpp without these extra parentheses. The tests pass on Linux and OS X with this small change.

Output from the compiler:
```
* For target hotspot_variant-server_libjvm_objs_sharedRuntime.o:
/Users/heinz/git/loom/src/hotspot/share/runtime/sharedRuntime.cpp:2888:97: error: expression does not compute the number of elements in this array; element type is 'double', not 'relocInfo' [-Werror,-Wsizeof-array-div]
      buffer.stubs()->initialize_shared_locs((relocInfo*)stubs_locs_buf, sizeof(stubs_locs_buf) / sizeof(relocInfo));
                                                                                ~~~~~~~~~~~~~~  ^
/Users/heinz/git/loom/src/hotspot/share/runtime/sharedRuntime.cpp:2880:14: note: array 'stubs_locs_buf' declared here
      double stubs_locs_buf[20];
             ^
/Users/heinz/git/loom/src/hotspot/share/runtime/sharedRuntime.cpp:2888:97: note: place parentheses around the 'sizeof(relocInfo)' expression to silence this warning
      buffer.stubs()->initialize_shared_locs((relocInfo*)stubs_locs_buf, sizeof(stubs_locs_buf) / sizeof(relocInfo));
                                                                                                ^
1 error generated.
```