### PR TITLE
Add support for running trace001 using vthreads.

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -101,7 +101,7 @@ public class trace001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        threads = jdb.getThreadIdsByName(MYTHREAD);
 
         if (threads.length != 2) {
             log.complain("jdb should report 2 instance of " + DEBUGGEE_THREAD);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
@@ -29,7 +29,7 @@ import nsk.share.jdb.*;
 
 import java.io.*;
 
-/* This is debuggee aplication */
+/* This is the debuggee application */
 public class trace001a {
     public static void main(String args[]) {
        trace001a _trace001a = new trace001a();
@@ -38,7 +38,7 @@ public class trace001a {
 
     static void lastBreak () {}
 
-    static final String MYTHREAD  = "MyThread";
+    static final String MYTHREAD  = nsk.jdb.trace.trace001.trace001.MYTHREAD;
     static final int numThreads   = 2;   // number of threads.
 
     static Object waitnotify = new Object();
@@ -54,7 +54,9 @@ public class trace001a {
 
         for (i = 0; i < numThreads ; i++) {
             locks[i]  = new Object();
-            holder[i] = new MyThread(locks[i],MYTHREAD + "-" + i);
+            String name = MYTHREAD + "-" + i;
+            int characteristics = Thread.VIRTUAL; // set to 0 to test with regular Threads intead of VThreads
+            holder[i] = Thread.unstartedThread(name, characteristics, new MyThread(locks[i], name));
         }
 
         synchronized (waitnotify) {
@@ -95,7 +97,7 @@ public class trace001a {
 }
 
 
-class MyThread extends Thread {
+class MyThread implements Runnable {
     Object lock;
     String name;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
@@ -803,7 +803,33 @@ public class Jdb extends LocalProcess implements Finalizable {
     }
 
     /**
-     * Returns as string array all id's for a given <i>threadName</i>.
+     * Returns as string array all id's for a given thread name of <i>threadName</i>.
+     */
+    public String[] getThreadIdsByName(String threadName) {
+        Vector<String> v = new Vector<String>();
+        String[] reply = receiveReplyFor(JdbCommand.threads);
+        Paragrep grep = new Paragrep(reply);
+
+        String[] found = grep.findStrings(threadName);
+        for (int i = 0; i < found.length; i++) {
+            String string = found[i];
+            // Check for "(java.lang.Thread)" or "(java.lang.VirtualThread)"
+            String searchString = "Thread)";
+            int j = string.indexOf(searchString);
+            if (j >= 0) {
+               j += searchString.length(); // The threadID is right after the thread type
+               String threadId = string.substring(j, string.indexOf(" ", j));
+               v.add(threadId);
+            }
+        }
+
+        String[] result = new String[v.size()];
+        v.toArray(result);
+        return result;
+    }
+
+    /**
+     * Returns as string array all id's for a given class type of <i>threadName</i>.
      */
     public String[] getThreadIds(String threadName) {
 


### PR DESCRIPTION
Added support for running trace001 using vthreads instead of platform threads. In order to revert back to platform threads, change `characteristics` to `0`.

            int characteristics = Thread.VIRTUAL; // set to 0 to test with regular Threads instead of VThreads

We need add a way to do this using something like a property, or possibly with a test argument. This would allow the test to be run in vthread or product thread mode without any edits.

The reason for the addition of `Jdb.getThreadIdsByName()` is because `Jdb.getThreadIds()` looks for threads of the specified type, but the type of vthreads is always the same and can't be controlled by the test, so instead we look for the thread name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * @MrABKhan (no known github.com user name / role)


### Download
`$ git fetch https://git.openjdk.java.net/loom pull/24/head:pull/24`
`$ git checkout pull/24`
