### PR TITLE
Adjustments to derived-pointer handling to make it work with Shenandoah GC

### DIFF
--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -199,7 +199,7 @@ void InstanceStackChunkKlass::iterate_derived_pointers(oop chunk, const StackChu
           continue;
       }
 #endif
-#if INCLUDE_ZGC
+#if INCLUDE_SHENANDOAHGC
       if (concurrent_gc && UseShenandoahGC) {
         if (!ShenandoahHeap::heap()->in_collection_set(base)) {
           continue;

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -194,9 +194,16 @@ void InstanceStackChunkKlass::iterate_derived_pointers(oop chunk, const StackChu
       assert (!CompressedOops::is_base(base), "");
 
 #if INCLUDE_ZGC
-      if (concurrent_gc) { //  && UseZG
+      if (concurrent_gc && UseZGC) {
         if (ZAddress::is_good(cast_from_oop<uintptr_t>(base))) 
           continue;
+      }
+#endif
+#if INCLUDE_ZGC
+      if (concurrent_gc && UseShenandoahGC) {
+        if (!ShenandoahHeap::heap()->in_collection_set(base)) {
+          continue;
+        }
       }
 #endif
 
@@ -392,7 +399,7 @@ NOINLINE void InstanceStackChunkKlass::fix_chunk(oop chunk) {
     num_oops += f.oopmap()->num_oops();
 
     f.cb()->as_compiled_method()->run_nmethod_entry_barrier();
-    if (UseZGC) {
+    if (UseZGC || UseShenandoahGC) {
       iterate_derived_pointers<true>(chunk, f);
       fix_oops(f);
       OrderAccess::loadload();
@@ -504,8 +511,8 @@ bool InstanceStackChunkKlass::verify(oop chunk, oop cont, size_t* out_size, int*
       log_develop_trace(jvmcont)("debug_verify_stack_chunk narrow: %d reg: %d p: " INTPTR_FORMAT, omv.type() == OopMapValue::narrowoop_value, omv.reg()->is_reg(), p2i(p));
       assert (omv.type() == OopMapValue::oop_value || omv.type() == OopMapValue::narrowoop_value, "");
       assert (UseCompressedOops || omv.type() == OopMapValue::oop_value, "");
-      
-      oop obj = omv.type() == OopMapValue::narrowoop_value ? (oop)HeapAccess<>::oop_load((narrowOop*)p) : (oop)HeapAccess<>::oop_load((oop*)p);
+      intptr_t val = *(intptr_t*)p;
+      oop obj = omv.type() == OopMapValue::narrowoop_value ? (oop)NativeAccess<>::oop_load((narrowOop*)&val) : (oop)NativeAccess<>::oop_load((oop*)&val);
       if (!SafepointSynchronize::is_at_safepoint()) {
         assert (oopDesc::is_oop_or_null(obj), "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT, p2i(p), p2i((oopDesc*)obj));
       }
@@ -527,7 +534,7 @@ bool InstanceStackChunkKlass::verify(oop chunk, oop cont, size_t* out_size, int*
       assert (f.is_in_oops(base_loc), "not found: " INTPTR_FORMAT, p2i(base_loc));
       assert (!f.is_in_oops(derived_loc), "found: " INTPTR_FORMAT, p2i(derived_loc));
       log_develop_trace(jvmcont)("debug_verify_stack_chunk base: " INTPTR_FORMAT " derived: " INTPTR_FORMAT, p2i(base_loc), p2i(derived_loc));
-      oop base = (oop)NativeAccess<>::oop_load((oop*)base_loc); // *(oop*)base_loc;
+      oop base = *base_loc;
       if (base != (oop)NULL) {
         assert (!CompressedOops::is_base(base), "");
         assert (oopDesc::is_oop(base), "");

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -41,6 +41,9 @@
 #include "gc/z/zAddress.inline.hpp"
 #define FIX_DERIVED_POINTERS true
 #endif
+#if INCLUDE_SHENANDOAHGC
+#define FIX_DERIVED_POINTERS true
+#endif
 
 class StackChunkFrameStream : public StackObj {
  private:
@@ -196,7 +199,7 @@ void InstanceStackChunkKlass::oop_oop_iterate(oop obj, OopClosureType* closure) 
   if (Devirtualizer::do_metadata(closure)) {
     Devirtualizer::do_klass(closure, this);
   }
-  UseZGC
+  (UseZGC || UseShenandoahGC)
     ? oop_oop_iterate_stack<OopClosureType, true> (obj, closure)
     : oop_oop_iterate_stack<OopClosureType, false>(obj, closure);
   oop_oop_iterate_header<T>(obj, closure);
@@ -206,7 +209,7 @@ template <typename T, class OopClosureType>
 void InstanceStackChunkKlass::oop_oop_iterate_reverse(oop obj, OopClosureType* closure) {
   assert(!Devirtualizer::do_metadata(closure), "Code to handle metadata is not implemented");
 
-  UseZGC
+  (UseZGC || UseShenandoahGC)
     ? oop_oop_iterate_stack<OopClosureType, true> (obj, closure)
     : oop_oop_iterate_stack<OopClosureType, false>(obj, closure);
   oop_oop_iterate_header<T>(obj, closure);


### PR DESCRIPTION
This adjusts derived-pointer handling to make it work with Shenandoah GC:
- Much of it adds INCLUDE_SHENANDOAHGC and/or UseShenandoahGC where INCLUDE_ZGC and/or UseZGC already is to take the same code paths. We need to think about proper GC interfaces there.
- In InstanceStackChunkKlass::verify(..) I changed the first load of oops to load from a local variable instead of the real field. I had troubles there because one side-effect of loading with Shenandoah barriers is that the barriers would update the field with the correct to-space reference. This throws off derived pointers which are checked later in the method.
- Similar situation later: when loading the base of derived pointer, we may get back an updated base pointer, while the derived pointer is not yet there. Loading the raw memory seems the right way to do it.

Testing:
 - [x] java/lang/Continuation (-XX:+UseShenandoahGC -XX:ShenandoahGCMode=aggressive)
 - [x] java/lang/Thread/virtual (-XX:+UseShenandoahGC -XX:ShenandoahGCMode=aggressive)
 - [x] java/lang/Continuation (-XX:+UseZGC -XX:ZCollectionInterval=0.01)
 - [x] java/lang/Thread/virtual (-XX:+UseZGC -XX:ZCollectionInterval=0.01)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/loom pull/30/head:pull/30`
`$ git checkout pull/30`
