### PR TITLE
Fix merge error in ShenandoahFullGC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -956,9 +956,8 @@ void ShenandoahFullGC::compact_humongous_objects() {
       assert(old_start != new_start, "must be real move");
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());
 
-      Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
-                                   heap->get_region(new_start)->bottom(),
-                                   words_size);
+      old_obj->copy_conjoint(heap->get_region(new_start)->bottom(),
+                             words_size);
 
       oop new_obj = oop(heap->get_region(new_start)->bottom());
       new_obj->init_mark();


### PR DESCRIPTION
In the code section that is changed here, we originally had in Loom:

```
old_obj->copy_conjoint(heap->get_region(new_start)->bottom(),
                                       ShenandoahHeapRegion::region_size_words()*num_regions);
```

However this was wrong because the size exceeded the object size. This apparently came from original upstream:
```
Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
                                   heap->get_region(new_start)->bottom(),
                                   ShenandoahHeapRegion::region_size_words()*num_regions);

```

I recently fixed that in upstream to use the object size instead:

```
Copy::aligned_conjoint_words(heap->get_region(old_start)->bottom(),
                                   heap->get_region(new_start)->bottom(),
                                   words_size);

```

Which has been wrongly merged as-is into loom. This patch restores the original version that has been in Loom, with the change to use object size instead of region size.

Testing:
 - [ ] hotspot_gc_shenandoah
 - [x] java/lang/Continuation (-XX:+UseShenandoahGC)
 - [x] java/lang/Thread/virtual (-XX:+UseShenandoahGC)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/loom pull/31/head:pull/31`
`$ git checkout pull/31`
