### PR TITLE
In rare cases, the unlock() on join() might fail, causing an IllegalMonitorStateException

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -663,7 +663,13 @@ class VirtualThread extends Thread {
                 return (state() == TERMINATED);
             }
         } finally {
-            lock.unlock();
+            // Unlike synchronized/wait, the Condition.await() method does not
+            // necessarily reacquire the lock on exit, for example if the thread
+            // is stopped or if CTRL+C is caused in jshell. In that case we
+            // would enter the finally block without the lock held and unlocking
+            // would cause an IllegalMonitorStateException
+            if (lock.isHeldByCurrentThread())
+                lock.unlock();
         }
     }
 


### PR DESCRIPTION
Unlike synchronized/wait, the Condition.await() method does not necessarily reacquire the lock on exit, for example if the thread is stopped or if CTRL+C is caused in jshell. In that case we would enter the finally block without the lock held and unlocking would cause an IllegalMonitorStateException.

For example, run the following code from jshell and then press CTRL+C:

```
Object monitor = new Object();
for (int i = 0; i < 10_000; i++) {
  Thread.startVirtualThread(() -> {
    synchronized (monitor) {
      try {
        monitor.wait();
      } catch (InterruptedException ignore) {}
    }
  });
}
Thread.startVirtualThread(() -> System.out.println("done")).join();
```

Output is:

```
|  Exception java.lang.IllegalMonitorStateException
|        at ReentrantLock$Sync.tryRelease (ReentrantLock.java:175)
|        at AbstractQueuedSynchronizer.release (AbstractQueuedSynchronizer.java:1007)
|        at ReentrantLock.unlock (ReentrantLock.java:494)
|        at VirtualThread.joinNanos (VirtualThread.java:635)
|        at Thread.join (Thread.java:2281)
|        at Thread.join (Thread.java:2366)
|        at (#3:1)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/loom pull/32/head:pull/32`
`$ git checkout pull/32`
