### PR TITLE
Fix typo in HotSpotDiagnostic

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -161,7 +161,7 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
     public void dumpThreads(String outputFile, ThreadDumpFormat format) throws IOException {
         Path file = Path.of(outputFile);
         if (!file.isAbsolute())
-            throw new IllegalArgumentException("'outptuFile' not absolute path");
+            throw new IllegalArgumentException("'outputFile' not absolute path");
 
         // need ManagementPermission("control")
         SecurityManager sm = System.getSecurityManager();


### PR DESCRIPTION
This PR simply fixes a small typo in the error message thrown by `HotSpotDiagnostic#dumpThreads`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/loom pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/36.diff">https://git.openjdk.java.net/loom/pull/36.diff</a>

</details>
