### PR TITLE
Replace BacktraceBuilder and allocation safepoints in async_get_stack_trace

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2285,7 +2285,7 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
     GrowableArray<int>*     _bcis;
     GrowableArray<oop>*  _continuations;
 
-    GetStackTraceClosure(Handle java_thread) : 
+    GetStackTraceClosure(Handle java_thread) :
       HandshakeClosure("GetStackTraceClosure"), _java_thread(java_thread), _depth(0) {
       // Pick some initial length
       int init_length = MaxJavaStackTraceDepth/2;
@@ -2309,7 +2309,7 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
       oop vthread_scope = java_lang_VirtualThread::vthread_scope();
       if (java_lang_VirtualThread::is_instance(_java_thread())) {
         // if (thread->vthread() != _java_thread()) // We might be inside a System.executeOnCarrierThread
-        if (thread->last_continuation(vthread_scope)->cont_oop() != 
+        if (thread->last_continuation(vthread_scope)->cont_oop() !=
               java_lang_VirtualThread::continuation(_java_thread())) {
           return; // not mounted
         }
@@ -2317,13 +2317,13 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
         if (thread->last_continuation(vthread_scope) != NULL)
           carrier = true;
       }
-      
+
       const int max_depth = MaxJavaStackTraceDepth;
       const bool skip_hidden = !ShowHiddenFrames;
 
       int total_count = 0;
       for (vframeStream vfst(thread, false, false, carrier);
-           !vfst.at_end() && (max_depth == 0 || max_depth != total_count); 
+           !vfst.at_end() && (max_depth == 0 || max_depth != total_count);
            vfst.next()) {
 
         if (skip_hidden && (vfst.method()->is_hidden() ||
@@ -2370,8 +2370,8 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
 
     methodHandle method(THREAD, gstc._methods->at(i));
     oop element = java_lang_StackTraceElement::create(method,
-                                                      gstc._bcis->at(i), 
-                                                      cont_handles->at(i), 
+                                                      gstc._bcis->at(i),
+                                                      cont_handles->at(i),
                                                       CHECK_NULL);
     trace->obj_at_put(i, element);
   }

--- a/test/jdk/ProblemList-vthread.txt
+++ b/test/jdk/ProblemList-vthread.txt
@@ -18,8 +18,6 @@ java/lang/invoke/condy/CondyNestedTest.java                                     
 
 java/util/stream/boottest/java.base/java/util/stream/SpinedBufferTest.java                      8254093 generic-all
 
-java/lang/Thread/GenerifyStackTraces.java                                                       8253918 generic-all
-java/lang/Thread/NullStackTrace.java                                                            8253918 generic-all
 java/lang/Thread/UncaughtExceptionsTest.java                                                    0000000 generic-all
 
 java/lang/Thread/virtual/stress/PinALot.java#id2                                                8255275 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -886,7 +886,6 @@ javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8260331 linux-x64
 java/lang/Continuation/Basic.java#id2                           8253570 generic-all
 java/lang/Thread/virtual/stress/PinALot.java#id1                8253523 generic-all
 java/lang/Thread/virtual/stress/PinALot.java#id3                8253523 generic-all
-java/lang/Thread/virtual/stress/GetStackTraceALot.java#id2      8254188 generic-all
 
 com/sun/jdi/EATests.java#id0                                    8264699 generic-all
 


### PR DESCRIPTION
Something like this.  I'm still running tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - Committer) ⚠️ Review applies to 50e516c12ad8e6eefaf5bd86787254c6157efd05


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/loom pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/40.diff">https://git.openjdk.java.net/loom/pull/40.diff</a>

</details>
