### PR TITLE
Remove _keepalive WeakHandle remnants.

### DIFF
--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -56,8 +56,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
   : CodeBlob(name, type, layout, frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
     _mark_for_deoptimization_status(not_marked),
     _method(method),
-    _gc_data(NULL),
-    _keepalive(NULL)
+    _gc_data(NULL)
 {
   init_defaults();
 }
@@ -69,8 +68,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
              frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments, compiled),
     _mark_for_deoptimization_status(not_marked),
     _method(method),
-    _gc_data(NULL),
-    _keepalive(NULL)
+    _gc_data(NULL)
 {
   init_defaults();
 }
@@ -372,7 +370,7 @@ void CompiledMethod::preserve_callee_argument_oops(frame fr, const RegisterMap *
       // assert (method()->is_native(), "");
       return;
     }
-    
+
     if (!method()->is_native()) {
       address pc = fr.pc();
       bool has_receiver, has_appendix;
@@ -628,8 +626,8 @@ void CompiledMethod::cleanup_inline_caches(bool clean_all) {
   }
 }
 
-address* CompiledMethod::orig_pc_addr(const frame* fr) { 
-  return (address*) ((address)fr->unextended_sp() + orig_pc_offset()); 
+address* CompiledMethod::orig_pc_addr(const frame* fr) {
+  return (address*) ((address)fr->unextended_sp() + orig_pc_offset());
 }
 
 // Called to clean up after class unloading for live nmethods and from the sweeper

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -174,7 +174,6 @@ protected:
 
   virtual void flush() = 0;
 
-  oop* _keepalive; // allocated and maintained by Continuation::weak_storage().
 protected:
   CompiledMethod(Method* method, const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled);
   CompiledMethod(Method* method, const char* name, CompilerType type, int size, int header_size, CodeBuffer* cb, int frame_complete_offset, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments, bool compiled);
@@ -412,10 +411,6 @@ public:
 
   bool unload_nmethod_caches(bool class_unloading_occurred);
   virtual void do_unloading(bool unloading_occurred) = 0;
-
-  oop* get_keepalive();
-  oop* set_keepalive(oop* keepalive);
-  bool clear_keepalive(oop* old);
 
 private:
   PcDesc* find_pc_desc(address pc, bool approximate) {

--- a/src/hotspot/share/code/compiledMethod.inline.hpp
+++ b/src/hotspot/share/code/compiledMethod.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,16 +64,6 @@ inline address CompiledMethod::get_deopt_original_pc(const frame* fr) {
     return cm->get_original_pc(fr);
 
   return NULL;
-}
-
-inline oop* CompiledMethod::get_keepalive() { return _keepalive; }
-
-inline oop* CompiledMethod::set_keepalive(oop* obj) {
-  return Atomic::cmpxchg(&_keepalive, (oop*) NULL, obj);
-}
-
-inline bool CompiledMethod::clear_keepalive(oop* old) {
-  return Atomic::cmpxchg(&_keepalive, old, (oop*) NULL) == old;
 }
 
 // class ExceptionCache methods

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1223,15 +1223,7 @@ bool nmethod::is_not_on_continuation_stack() {
   // after that concurrent GC. Each GC increments the marking cycle twice - once when
   // it starts and once when it ends. So we can only be sure there are no new continuations
   // when they have not been encountered from before a GC to after a GC.
-  bool not_on_new_vthread_stack = CodeCache::marking_cycle() >= align_up(_marking_cycle, 2) + 2;
-
-  // As for old vthread stacks, they are kept alive by a WeakHandle.
-  bool not_on_old_vthread_stack = false;
-  if (_keepalive != NULL) {
-    WeakHandle wh = WeakHandle::from_raw(_keepalive);
-    not_on_old_vthread_stack = wh.resolve() == NULL;
-  }
-  return not_on_new_vthread_stack && not_on_old_vthread_stack;
+  return CodeCache::marking_cycle() >= align_up(_marking_cycle, 2) + 2;
 }
 
 // Tell if a non-entrant method can be converted to a zombie (i.e.,
@@ -1934,18 +1926,9 @@ void nmethod::do_unloading(bool unloading_occurred) {
   }
 }
 
-void nmethod::oops_do(OopClosure* f, bool allow_dead, bool allow_null, bool keepalive_is_strong) {
+void nmethod::oops_do(OopClosure* f, bool allow_dead, bool allow_null) {
   // make sure the oops ready to receive visitors
   assert(allow_dead || is_alive(), "should not call follow on dead nmethod");
-
-  if (keepalive_is_strong) {
-    if (_keepalive != NULL) {
-      WeakHandle wh = WeakHandle::from_raw(_keepalive);
-      if (wh.resolve() != NULL) {
-        f->do_oop(_keepalive);
-      }
-    }
-  }
 
   // Prevent extra code cache walk for platforms that don't have immediate oops.
   if (relocInfo::mustIterateImmediateOopsInCode()) {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -605,9 +605,8 @@ public:
 #endif
 
  public:
-  void oops_do_keepalive(OopClosure* f, bool keepalive) { oops_do(f, false, false, keepalive); }
   void oops_do(OopClosure* f) { oops_do(f, false, false); }
-  void oops_do(OopClosure* f, bool allow_dead, bool allow_null = false, bool keepalive_is_strong = false);
+  void oops_do(OopClosure* f, bool allow_dead, bool allow_null = false);
 
   // All-in-one claiming of nmethods: returns true if the caller successfully claimed that
   // nmethod.

--- a/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ void G1CodeBlobClosure::do_evacuation_and_fixup(nmethod* nm) {
   if (_keepalive_is_strong) {
     nm->mark_as_maybe_on_continuation();
   }
-  nm->oops_do_keepalive(&_oc, _keepalive_is_strong);
+  nm->oops_do(&_oc);
   nm->fix_oop_relocations();
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != NULL) {

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -56,8 +56,8 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
   }
 
   // Heal oops
-    ZNMethod::nmethod_oops_barrier(nm, true /* keepalive_is_strong */);
-    nm->mark_as_maybe_on_continuation();
+  ZNMethod::nmethod_oops_barrier(nm);
+  nm->mark_as_maybe_on_continuation();
 
   // Disarm
   disarm(nm);

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -256,7 +256,7 @@ public:
     // all nmethods have been processed before visiting the oops.
     _bs_nm->nmethod_entry_barrier(nm);
 
-    ZNMethod::nmethod_oops_do(nm, _cl, false /* keepalive_is_strong */);
+    ZNMethod::nmethod_oops_do(nm, _cl);
   }
 };
 

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -652,7 +652,7 @@ public:
     }
 
     if (ZNMethod::is_armed(nm)) {
-      ZNMethod::nmethod_oops_do_inner(nm, _cl, true /* keepalive_is_strong */);
+      ZNMethod::nmethod_oops_do_inner(nm, _cl);
       nm->mark_as_maybe_on_continuation();
       ZNMethod::disarm(nm);
     }

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,10 @@ public:
   static void disarm(nmethod* nm);
   static void arm(nmethod* nm, int arm_value);
 
-  static void nmethod_oops_do(nmethod* nm, OopClosure* cl, bool keepalive_is_strong);
-  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl, bool keepalive_is_strong);
+  static void nmethod_oops_do(nmethod* nm, OopClosure* cl);
+  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl);
 
-  static void nmethod_oops_barrier(nmethod* nm, bool keepalive_is_strong);
+  static void nmethod_oops_barrier(nmethod* nm);
 
   static void nmethods_do_begin();
   static void nmethods_do_end();

--- a/src/hotspot/share/gc/z/zUnload.cpp
+++ b/src/hotspot/share/gc/z/zUnload.cpp
@@ -80,7 +80,7 @@ public:
     ZReentrantLock* const lock = ZNMethod::lock_for_nmethod(nm);
     ZLocker<ZReentrantLock> locker(lock);
     ZIsUnloadingOopClosure cl;
-    ZNMethod::nmethod_oops_do_inner(nm, &cl, false /* keepalive_is_strong */);
+    ZNMethod::nmethod_oops_do_inner(nm, &cl);
     return cl.is_unloading();
   }
 };

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -249,7 +249,7 @@ public:
   virtual void do_nmethod(nmethod* nm) {
     assert(!trust_nmethod_state() || !_bs_nm->is_armed(nm), "Should not encounter any armed nmethods");
 
-    ZNMethod::nmethod_oops_do(nm, _cl, true /* keepalive_is_strong */);
+    ZNMethod::nmethod_oops_do(nm, _cl);
   }
 };
 

--- a/src/hotspot/share/memory/iterator.cpp
+++ b/src/hotspot/share/memory/iterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ void MarkingCodeBlobClosure::do_code_blob(CodeBlob* cb) {
   nmethod* nm = cb->as_nmethod_or_null();
   if (nm != NULL && nm->oops_do_try_claim()) {
     nm->mark_as_maybe_on_continuation();
-    nm->oops_do_keepalive(_cl, _keepalive_nmethods /* keepalive_is_strong */);
+    nm->oops_do(_cl);
     if (_fix_relocations) {
       nm->fix_oop_relocations();
     }

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,15 +58,10 @@ void continuations_init();
 
 class javaVFrame;
 class JavaThread;
-class OopStorage;
 
 class Continuation : AllStatic {
-private:
-  static OopStorage* _weak_handles;
 public:
   static void init();
-
-  static OopStorage* weak_storage() { return _weak_handles; }
 
   static int freeze(JavaThread* thread, intptr_t* sp);
   static int prepare_thaw(JavaThread* thread, bool return_barrier);
@@ -140,7 +135,7 @@ public:
   void verify_cookie() { assert(this->cookie == 0x1234, ""); }
 #endif
 
-public: 
+public:
   static int return_pc_offset; // friend gen_continuation_enter
   static void set_enter_nmethod(nmethod* nm); // friend SharedRuntime::generate_native_wrapper
 
@@ -169,7 +164,7 @@ public:
 
   static ByteSize parent_cont_fastpath_offset()      { return byte_offset_of(ContinuationEntry, _parent_cont_fastpath); }
   static ByteSize parent_held_monitor_count_offset() { return byte_offset_of(ContinuationEntry, _parent_held_monitor_count); }
-  
+
 public:
   static size_t size() { return align_up((int)sizeof(ContinuationEntry), 2*wordSize); }
 


### PR DESCRIPTION
Since I went down the path of looking at _keepalive and found that the code for it was removed, I think the rest of it should be also.
Tested with loom-tier1, 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/loom pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/41.diff">https://git.openjdk.java.net/loom/pull/41.diff</a>

</details>
