### PR TITLE
Fix counter inccurate when creating platform/virtual thread by Thread…

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadBuilders.java
+++ b/src/java.base/share/classes/java/lang/ThreadBuilders.java
@@ -44,8 +44,18 @@ class ThreadBuilders {
      */
     static abstract non-sealed
     class BaseThreadBuilder<T extends Builder> implements Builder {
+        private static final VarHandle COUNTER;
+        static {
+            try {
+                MethodHandles.Lookup l = MethodHandles.lookup();
+                COUNTER = l.findVarHandle(BaseThreadBuilder.class, "counter", long.class);
+            } catch (Exception e) {
+                throw new InternalError(e);
+            }
+        }
+
         private String name;
-        private long counter;
+        private volatile long counter;
         private int characteristics;
         private UncaughtExceptionHandler uhe;
 
@@ -67,7 +77,7 @@ class ThreadBuilders {
 
         String nextThreadName() {
             if (name != null && counter >= 0) {
-                return name + (counter++);
+                return name + (long) COUNTER.getAndAdd(this, 1);
             } else {
                 return name;
             }


### PR DESCRIPTION
Fix counter inccurate when creating platform/virtual thread by ThreadBuilder using mutiple threads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/loom pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/45.diff">https://git.openjdk.java.net/loom/pull/45.diff</a>

</details>
