### PR TITLE
Fix held_monitor_count calculation

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3535,17 +3535,23 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   } else {
     Unimplemented();
   }
-  __ bind(*op->stub()->continuation());
-  
-  NOT_LP64(Register scratch = op->scratch_opr()->as_register();)
-  Register thread = LP64_ONLY(r15_thread) NOT_LP64(scratch);
-  NOT_LP64(__ get_thread(thread);)
   if (op->code() == lir_lock) {
+    // If deoptimization happens in Runtime1::monitorenter, inc_held_monitor_count after backing from slowpath
+    // will be skipped. Solution is
+    // 1. Increase only in fastpath
+    // 2. Runtime1::monitorenter increase count after locking
+    NOT_LP64(Register scratch = op->scratch_opr()->as_register();)
+    Register thread = LP64_ONLY(r15_thread) NOT_LP64(scratch);
+    NOT_LP64(__ get_thread(thread);)
     __ inc_held_monitor_count(thread);
-  } else if (op->code() == lir_unlock) {
+  }
+  __ bind(*op->stub()->continuation());
+  if (op->code() == lir_unlock) {
+    // unlock in slowpath is JRT_Leaf stub, no deoptimization can happen
+    NOT_LP64(Register scratch = op->scratch_opr()->as_register();)
+    Register thread = LP64_ONLY(r15_thread) NOT_LP64(scratch);
+    NOT_LP64(__ get_thread(thread);)
     __ dec_held_monitor_count(thread);
-  } else {
-    Unimplemented();
   }
 }
 

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1170,6 +1170,8 @@ void InterpreterMacroAssembler::remove_activation(
       push(state);
       mov(robj, rmon);   // nop if robj and rmon are the same
       unlock_object(robj);
+      NOT_LP64(get_thread(rthread);)
+      dec_held_monitor_count(rthread);
       pop(state);
 
       if (install_monitor_exception) {

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1242,6 +1242,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
       __ bind(unlock);
       __ unlock_object(regmon);
+      NOT_LP64(__ get_thread(thread);)
+      __ dec_held_monitor_count(thread);
     }
     __ bind(L);
   }

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -707,6 +707,7 @@ JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, 
   }
   assert(obj == lock->obj(), "must match");
   SharedRuntime::monitor_enter_helper(obj, lock->lock(), current);
+  current->inc_held_monitor_count();
 JRT_END
 
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -144,7 +144,7 @@ bool OptoRuntime::generate(ciEnv* env) {
   gen(env, _multianewarray4_Java           , multianewarray4_Type         , multianewarray4_C               ,    0 , true, false);
   gen(env, _multianewarray5_Java           , multianewarray5_Type         , multianewarray5_C               ,    0 , true, false);
   gen(env, _multianewarrayN_Java           , multianewarrayN_Type         , multianewarrayN_C               ,    0 , true, false);
-  gen(env, _complete_monitor_locking_Java  , complete_monitor_enter_Type  , SharedRuntime::complete_monitor_locking_C, 0, false, false);
+  gen(env, _complete_monitor_locking_Java  , complete_monitor_enter_Type  , SharedRuntime::complete_monitor_locking_C_inc_held_monitor_count, 0, false, false);
   gen(env, _monitor_notify_Java            , monitor_notify_Type          , monitor_notify_C                ,    0 , false, false);
   gen(env, _monitor_notifyAll_Java         , monitor_notify_Type          , monitor_notifyAll_C             ,    0 , false, false);
   gen(env, _rethrow_Java                   , rethrow_Type                 , rethrow_C                       ,    2 , true , true );

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1509,7 +1509,7 @@ bool Deoptimization::relock_objects(JavaThread* thread, GrowableArray<MonitorInf
         BasicLock* lock = mon_info->lock();
         ObjectSynchronizer::enter(obj, lock, deoptee_thread);
         assert(mon_info->owner()->is_locked(), "object must be locked now");
-        thread->inc_held_monitor_count();
+        deoptee_thread->inc_held_monitor_count();
       }
     }
   }
@@ -1619,8 +1619,8 @@ void Deoptimization::pop_frames_failed_reallocs(JavaThread* thread, vframeArray*
       for (int j = 0; j < monitors->number_of_monitors(); j++) {
         BasicObjectLock* src = monitors->at(j);
         if (src->obj() != NULL) {
-          thread->dec_held_monitor_count();
           ObjectSynchronizer::exit(src->obj(), src->lock(), thread);
+          thread->dec_held_monitor_count();
         }
       }
       array->element(i)->free_monitors(thread);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2147,6 +2147,11 @@ JRT_BLOCK_ENTRY(void, SharedRuntime::complete_monitor_locking_C(oopDesc* obj, Ba
   SharedRuntime::monitor_enter_helper(obj, lock, current);
 JRT_END
 
+JRT_BLOCK_ENTRY(void, SharedRuntime::complete_monitor_locking_C_inc_held_monitor_count(oopDesc* obj, BasicLock* lock, JavaThread* current))
+  SharedRuntime::monitor_enter_helper(obj, lock, current);
+  current->inc_held_monitor_count();
+JRT_END
+
 void SharedRuntime::monitor_exit_helper(oopDesc* obj, BasicLock* lock, JavaThread* current) {
   assert(JavaThread::current() == current, "invariant");
   // Exit must be non-blocking, and therefore no exceptions can be thrown.

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -492,6 +492,7 @@ class SharedRuntime: AllStatic {
 
   // Slow-path Locking and Unlocking
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
+  static void complete_monitor_locking_C_inc_held_monitor_count(oopDesc* obj, BasicLock* lock, JavaThread* current);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* current);
 
   // Resolving of calls

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1467,6 +1467,8 @@ void JavaThread::exit(bool destroy_vm, ExitType exit_type) {
     assert(!this->has_pending_exception(), "release_monitors should have cleared");
   }
 
+  assert(this->held_monitor_count() == 0, "held monitor count should be zero");
+
   // These things needs to be done while we are still a Java Thread. Make sure that thread
   // is in a consistent state, in case GC happens
   JFR_ONLY(Jfr::on_thread_exit(this);)

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1186,8 +1186,7 @@ private:
   int held_monitor_count() { return _held_monitor_count; }
   void reset_held_monitor_count() { _held_monitor_count = 0; }
   void inc_held_monitor_count() { _held_monitor_count++; }
-  void dec_held_monitor_count() { /* assert (_held_monitor_count > 0, ""); -- TODO LOOM: currently this does not hold because we don't handle nesting well */
-                                  _held_monitor_count--; }
+  void dec_held_monitor_count() { assert (_held_monitor_count > 0, ""); _held_monitor_count--; }
 
  private:
   // Support for thread handshake operations


### PR DESCRIPTION
Problem and fixes includes and we (Tencent team) would like to fixing further related issues.

- C1/C2 locking when deoptimize happen might lost counter inc.
  -  increase held monitor count in JIT code slow path runtime method  (Runtime1::monitorenter/SharedRuntime::complete_monitor_locking_C_inc_held_monitor_count),
  - JIT code only increases held monitor count for fastpath.
- Deoptimization::relock_objects should update count in deoptee thread instead of current rhead.
- Add missing dec_held_monitor_count in interpreter.
- Enable assert ion in runtime dec_held_monitor_count and no assert triggers.
- Assert when Thread assert held_monitor_count should be zero.
   - No assertion happens with above fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Rickard Bäckman](https://openjdk.java.net/census#rbackman) (@rickard - Committer)
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/loom pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/47.diff">https://git.openjdk.java.net/loom/pull/47.diff</a>

</details>
