### PR TITLE
Fix linkage failure due to missing frame::oops_interpreted_do template instantiation

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -925,6 +925,11 @@ void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool quer
   oops_interpreted_do0<relative>(f, map, m, bci, mask);
 }
 
+// Initialize explicitly so that these can be used only with definitions.
+// TODO: Rectify as Loom stabilizes...
+template void frame::oops_interpreted_do<true> (OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const;
+template void frame::oops_interpreted_do<false>(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const;
+
 template <bool relative>
 void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, const InterpreterOopMap& mask) const {
   Thread *thread = Thread::current();


### PR DESCRIPTION
On one of my CI servers, current linux-x86_64-server-release build fails with:

```
home/buildbot/worker/build-jdkX-loom-linux/build/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/instanceStackChunkKlass.o: In function `void InstanceStackChunkKlass::fix_thawed_frame<SmallRegisterMap>(stackChunkOopDesc*, frame const&, SmallRegisterMap const*)':
/home/buildbot/worker/build-jdkX-loom-linux/build/./src/hotspot/share/oops/instanceStackChunkKlass.cpp:784: undefined reference to `void frame::oops_interpreted_do<false>(OopClosure*, RegisterMap const*, bool) const'
/home/buildbot/worker/build-jdkX-loom-linux/build/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/instanceStackChunkKlass.o: In function `void InstanceStackChunkKlass::fix_thawed_frame<RegisterMap>(stackChunkOopDesc*, frame const&, RegisterMap const*)':
/home/buildbot/worker/build-jdkX-loom-linux/build/./src/hotspot/share/oops/instanceStackChunkKlass.cpp:784: undefined reference to `void frame::oops_interpreted_do<false>(OopClosure*, RegisterMap const*, bool) const'
collect2: error: ld returned 1 exit status
```

The real issue is that `instanceStackChunkKlass.cpp` cannot rely on template instantiation, as the `frame::oops_interpreted_do` is defined in `frame.cpp`. We could instead move `frame::oops_interpreted_do` to `frame.inline.hpp`, but that diverges the source from upstream. I would rather have two explicit instantiations in current prototype, hoping that maybe future code would not even need this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/loom pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/49.diff">https://git.openjdk.java.net/loom/pull/49.diff</a>

</details>
