### PR TITLE
ContMirror::allocate_stack_chunk was using the wrong thread for allocation

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -3214,7 +3214,7 @@ stackChunkOop ContMirror::allocate_stack_chunk(int stack_size, bool is_preempt) 
   assert(is_preempt || _thread == JavaThread::current(), "should be current");
   JavaThread* current = is_preempt ? JavaThread::current() : _thread;
 
-  StackChunkAllocator allocator(klass, size_in_words, stack_size, _thread);
+  StackChunkAllocator allocator(klass, size_in_words, stack_size, current);
   HeapWord* start = current->tlab().allocate(size_in_words);
   if (start != nullptr) {
     return (stackChunkOop)allocator.initialize(start);


### PR DESCRIPTION
Pull request because something wants a password when I push this tiny change directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.java.net/loom pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/51.diff">https://git.openjdk.java.net/loom/pull/51.diff</a>

</details>
