### PR TITLE
Inject jvmti state into Thread.

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2065,7 +2065,6 @@ int java_lang_Thread::_inheritableScopeLocalBindings_offset;
   macro(_contextClassLoader_offset, k, vmSymbols::contextClassLoader_name(), classloader_signature, false); \
   macro(_inheritedAccessControlContext_offset, k, vmSymbols::inheritedAccessControlContext_name(), accesscontrolcontext_signature, false); \
   macro(_eetop_offset,         k, "eetop", long_signature, false); \
-  macro(_jvmti_thread_state_offset,  k, "jvmtiThreadState", long_signature, false); \
   macro(_interrupted_offset,   k, "interrupted", bool_signature, false); \
   macro(_tid_offset,           k, "tid", long_signature, false); \
   macro(_park_blocker_offset,  k, "parkBlocker", object_signature, false); \
@@ -2078,11 +2077,13 @@ void java_lang_Thread::compute_offsets() {
 
   InstanceKlass* k = vmClasses::Thread_klass();
   THREAD_FIELDS_DO(FIELD_COMPUTE_OFFSET);
+  THREAD_INJECTED_FIELDS(INJECTED_FIELD_COMPUTE_OFFSET);
 }
 
 #if INCLUDE_CDS
 void java_lang_Thread::serialize_offsets(SerializeClosure* f) {
   THREAD_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
+  THREAD_INJECTED_FIELDS(INJECTED_FIELD_SERIALIZE_OFFSET);
 }
 #endif
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -400,6 +400,9 @@ class java_lang_Class : AllStatic {
 
 // Interface to java.lang.Thread objects
 
+#define THREAD_INJECTED_FIELDS(macro)                            \
+  macro(java_lang_Thread, jvmti_thread_state, intptr_signature, false)
+
 class java_lang_Thread : AllStatic {
   friend class java_lang_VirtualThread;
  private:
@@ -2005,6 +2008,7 @@ class InjectedField {
   CALLSITECONTEXT_INJECTED_FIELDS(macro)    \
   STACKFRAMEINFO_INJECTED_FIELDS(macro)     \
   MODULE_INJECTED_FIELDS(macro)             \
+  THREAD_INJECTED_FIELDS(macro)             \
   INTERNALERROR_INJECTED_FIELDS(macro)
 
 

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -512,6 +512,7 @@
   template(java_lang_Byte_array_signature,            "[Ljava/lang/Byte;")                        \
   template(java_lang_Boolean_signature,               "Ljava/lang/Boolean;")                      \
   template(url_code_signer_array_void_signature,      "(Ljava/net/URL;[Ljava/security/CodeSigner;)V") \
+  template(jvmti_thread_state_name,                   "jvmti_thread_state")                       \
   template(module_entry_name,                         "module_entry")                             \
   template(resolved_references_name,                  "<resolved_references>")                    \
   template(init_lock_name,                            "<init_lock>")                              \

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -181,9 +181,6 @@ public class Thread implements Runnable {
     /* Reserved for exclusive use by the JVM, TBD: move to FieldHolder */
     private long eetop;
 
-    // used by JVMTI to store JvmtiThreadState link
-    private volatile long jvmtiThreadState;
-
     // holds fields for platform threads
     private static class FieldHolder {
         final ThreadGroup group;


### PR DESCRIPTION
The jvmtiThreadState field should be injected into Thread and not visible to Java code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/loom pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/54.diff">https://git.openjdk.java.net/loom/pull/54.diff</a>

</details>
