### PR TITLE
Add Handle arguments and fix OopHandle

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1906,13 +1906,13 @@ JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   oop thread_obj = NULL;
   JvmtiVTMTDisabler vtmt_disabler;
   ThreadsListHandle tlh;
-  JavaThread* current = JavaThread::current();
 
   err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
 
+  JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle thread_handle(current, thread_obj);
 
@@ -1937,7 +1937,7 @@ JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   }
 
   SetFramePopClosure op(this, state, depth);
-  MutexLocker mu(JvmtiThreadState_lock);
+  MutexLocker mu(current, JvmtiThreadState_lock);
   if (java_thread == current) {
     op.doit(java_thread, true /* self */);
   } else {

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -150,9 +150,10 @@ JvmtiEnv::SetThreadLocalStorage(jthread thread, const void* data) {
   JvmtiThreadState* state = NULL;
   JvmtiVTMTDisabler vtmt_disabler;
   oop thread_obj = NULL;
+  JavaThread* current = JavaThread::current();
 
   if (thread == NULL) {
-    java_thread = JavaThread::current();
+    java_thread = current;
     state = java_thread->jvmti_thread_state();
   } else {
     ThreadsListHandle tlh;
@@ -168,7 +169,9 @@ JvmtiEnv::SetThreadLocalStorage(jthread thread, const void* data) {
       return JVMTI_ERROR_NONE;
     }
     // otherwise, create the state
-    state = JvmtiThreadState::state_for(java_thread, thread_obj);
+    HandleMark hm(current);
+    Handle thread_handle(current, thread_obj);
+    state = JvmtiThreadState::state_for(java_thread, thread_handle);
     if (state == NULL) {
       return JVMTI_ERROR_THREAD_NOT_ALIVE;
     }
@@ -207,7 +210,9 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
       return err;
     }
 
-    JvmtiThreadState* state = JvmtiThreadState::state_for(java_thread, thread_obj);
+    HandleMark hm(current_thread);
+    Handle thread_handle(current_thread, thread_obj);
+    JvmtiThreadState* state = JvmtiThreadState::state_for(java_thread, thread_handle);
     *data_ptr = (state == NULL) ? NULL :
       state->env_thread_state(this)->get_agent_thread_local_storage_data();
   }
@@ -1901,17 +1906,21 @@ JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   oop thread_obj = NULL;
   JvmtiVTMTDisabler vtmt_disabler;
   ThreadsListHandle tlh;
+  JavaThread* current = JavaThread::current();
 
   err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
 
+  HandleMark hm(current);
+  Handle thread_handle(current, thread_obj);
+
   // Support for virtual threads
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     if (java_thread == NULL) {
       // java_thread is NULL if virtual thread is unmounted
-      JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_obj);
+      JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_handle);
       if (state == NULL) {
         return JVMTI_ERROR_THREAD_NOT_ALIVE;
       }
@@ -1922,14 +1931,14 @@ JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
     }
   }
 
-  JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_obj);
+  JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_handle);
   if (state == NULL) {
     return JVMTI_ERROR_THREAD_NOT_ALIVE;
   }
 
   SetFramePopClosure op(this, state, depth);
   MutexLocker mu(JvmtiThreadState_lock);
-  if (java_thread == JavaThread::current()) {
+  if (java_thread == current) {
     op.doit(java_thread, true /* self */);
   } else {
     Handshake::execute(&op, java_thread);

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -122,7 +122,7 @@ class VThreadList : public GrowableArrayCHeap<OopHandle, mtServiceability> {
 //
 // Virtual Threads Suspend/Resume management
 //
-class JvmtiVTSuspender {
+class JvmtiVTSuspender : AllStatic {
  private:
   // Suspend modes for virtual threads
   typedef enum VThreadSuspendMode {
@@ -262,7 +262,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   int count_frames();
 
   inline JavaThread *get_thread()      { return _thread;              }
-  inline JavaThread *get_thread_or_saved(); // return _thread_saved if _thread is NULL 
+  inline JavaThread *get_thread_or_saved(); // return _thread_saved if _thread is NULL
 
   // Needed for virtual threads as they can migrate to different JavaThread's.
   // Also used for carrier threads to clear/restore _thread.
@@ -448,7 +448,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   static JvmtiThreadState *state_for_while_locked(JavaThread *thread, oop thread_oop = NULL);
   // retrieve or create JvmtiThreadState
   // Can return NULL if JavaThread is exiting.
-  static JvmtiThreadState *state_for(JavaThread *thread, oop thread_oop = NULL);
+  static JvmtiThreadState *state_for(JavaThread *thread, Handle thread_handle = Handle());
 
   // JVMTI ForceEarlyReturn support
 


### PR DESCRIPTION
I changed two things in this PR.  Passing oop to a function then having to make it a Handle later is a recipe for naked oop bugs, so I made JvmtiThreadState::state_for pass a Handle. We try to handle-ize oops earlier in the call stack.  I made state_for_while_locked() take an oop however and added a NSV because it doesn't safepoint, and some callers only had oops, not handles.

I changed the suspend_list, resume_list to use JvmtiExport::jvmti_oop_storage rather than vm_globals().  Also rewrote some strange looking OopHandle code.  Moving handles in the GrowableArray does require Nulling them out, but not while creating them.

Tested with mach5 --patch-based --extra-src-dirs /scratch/coleen/hg/loom -j loom-tier1,loom-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/loom pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/55.diff">https://git.openjdk.java.net/loom/pull/55.diff</a>

</details>
