### PR TITLE
Add preempt logging to find bug.

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -140,6 +140,7 @@
   LOG_TAG(phases) \
   LOG_TAG(plab) \
   LOG_TAG(placeholders) \
+  LOG_TAG(preempt) \
   LOG_TAG(preorder)  /* Trace all classes loaded in order referenced (not loaded) */ \
   LOG_TAG(preview)   /* Trace loading of preview feature types */ \
   LOG_TAG(promotion) \

--- a/test/jdk/java/lang/Continuation/Preempt.java
+++ b/test/jdk/java/lang/Continuation/Preempt.java
@@ -25,10 +25,10 @@
 * @test
 * @summary Tests for java.lang.Continuation preemption
 *
-* @run testng/othervm/timeout=60 -Xint Preempt
+* @run testng/othervm/timeout=60 -Xlog:jvmcont+preempt=trace -Xint Preempt
 * @run testng/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=java/lang/Continuation,Preempt Preempt
 * @run testng/othervm -XX:TieredStopAtLevel=3 -Xcomp -XX:CompileOnly=java/lang/Continuation,Preempt Preempt
-* @run testng/othervm -XX:-UseTLAB -Xint Preempt
+* @run testng/othervm -Xlog:jvmcont+preempt=trace -XX:-UseTLAB -Xint Preempt
 */
 
 // * @run testng/othervm -XX:+UnlockExperimentalVMOptions -XX:-TieredCompilation -XX:+UseJVMCICompiler -Xcomp -XX:CompileOnly=java/lang/Continuation,Preempt Preempt
@@ -71,6 +71,7 @@ public class Preempt {
                     int i = 0;
                     do {
                         res = cont.tryPreempt(t0);
+                        Thread.sleep(10);
                         i++;
                     } while (i < 100 && res == Continuation.PreemptStatus.TRANSIENT_FAIL_PINNED_NATIVE);
                     assertEquals(res, Continuation.PreemptStatus.SUCCESS, "res: " + res + " i: " + i);
@@ -81,6 +82,7 @@ public class Preempt {
                     int i = 0;
                     do {
                         res = cont.tryPreempt(t0);
+                        Thread.sleep(10);
                         i++;
                     } while (i < 100 && res == Continuation.PreemptStatus.TRANSIENT_FAIL_PINNED_NATIVE);
                     assertEquals(res, Continuation.PreemptStatus.SUCCESS, "res: " + res + " i: " + i);


### PR DESCRIPTION
I made the logging product level and added the preempt tag for preemption, in order to find out why the Preempt.java test is failing a lot.  It seems to only be failing in the interpreter test cases.  Anyway, if performance is a concern with preemption, we can move this back to log_develop_trace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.java.net/loom pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/56.diff">https://git.openjdk.java.net/loom/pull/56.diff</a>

</details>
