### PR TITLE
avoid extra park of vthread when using fixed thread pool

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/ParkWithFixedThreadPool.java
+++ b/test/jdk/java/lang/Thread/virtual/ParkWithFixedThreadPool.java
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation. THL A29 Limited designates
+ * this particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License version 2 for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test
+ * @run testng ParkWithFixedThreadPool
+ * @summary Test virtual thread park when scheduler is fixed thread pool
+ */
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.LockSupport;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class ParkWithFixedThreadPool {
+    @Test
+    public static void multipleThreadPoolParkTest() throws Exception {
+        try (ExecutorService scheduler = Executors.newFixedThreadPool(8)) {
+            int vt_count = 300;
+            Thread[] vts = new Thread[vt_count];
+            Runnable target = new Runnable() {
+                public void run() {
+                    int myIndex = -1;
+                    for (int i = 0; i < vt_count; i++) {
+                        if (vts[i] == Thread.currentThread()) {
+                            myIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (myIndex > 0) {
+                        LockSupport.unpark(vts[myIndex - 1]);
+                    }
+
+                    if (myIndex != (vt_count - 1)) {
+                        LockSupport.park();
+                    }
+                }
+            };
+
+            ThreadFactory f = Thread.ofVirtual().scheduler(scheduler).name("vt", 0).factory();
+            for (int i = 0; i < vt_count; i++) {
+                vts[i] = f.newThread(target);
+            }
+            for (int i = 0; i < vt_count; i++) {
+                vts[i].start();
+            }
+
+            for (int i = 0; i < vt_count; i++) {
+                vts[i].join();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The test case of ParkWithFixedThreadPool.java create 300 virtual threads, each vthread(exclude latest vthread) park itself and unpark previous vthread. The expected result is any vthread can finish.

Running this test case in slowdebug and the test will random hang.

There are three vthreads which are vt-1, vt-2, vt-3;
(1) vt-1 take the ReentrantLock, and vt-2 try to unpark vt-1, and vt-2 fail to get ReentrantLock so it park itself( the call stack is shown below); 
(2)vt-3 unpark vt-2, and vt-2 try to get ReentrantLock again, but the ReentrantLock is still owned by vt-1, vt-2 park itself again;
(3)vt-1 release the ReentrantLock and unpark vt-2, vt-2 park itself at ParkWithFixedThreadPool.java:55, and it will never unpark.(because the unpark from vt-3 has consumed)

The reason is scheduler.execute() will try to alloc a Reentrant lock when using fix thread pool, the call stack is like:
    at java.lang.VirtualThread.tryPark(VirtualThread.java:472)
    at java.lang.VirtualThread.park(VirtualThread.java:424)
    at java.lang.System$2.parkVirtualThread(System.java:1279)
    at sun.misc.VirtualThreads.park(VirtualThreads.java:56)
    at java.util.concurrent.locks.LockSupport.park(LockSupport.java:183)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
    at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
    at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
    at java.util.concurrent.LinkedBlockingQueue.offer(LinkedBlockingQueue.java:418)
    at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1371)
    at java.lang.VirtualThread.unpark(VirtualThread.java:502)
    at java.lang.System$2.unparkVirtualThread(System.java:1287)
    at sun.misc.VirtualThreads.unpark(VirtualThreads.java:70)
    at ParkWithFixedThreadPool$1.run(ParkWithFixedThreadPool.java:51)


The solution is switch back to carrier thread before call scheduler.execute();

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/loom pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/59.diff">https://git.openjdk.java.net/loom/pull/59.diff</a>

</details>
