### PR TITLE
Ensure vthread has connected to server

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/InterruptHttp.java
+++ b/test/jdk/java/lang/Thread/virtual/InterruptHttp.java
@@ -55,7 +55,9 @@ public class InterruptHttp {
             });
 
             // give time for thread to block waiting for HTTP server
-            Thread.sleep(1000);
+            while (server.connectionCount() == 0) {
+                Thread.sleep(100);
+            }
             thread.interrupt();
             thread.join();
 


### PR DESCRIPTION
I have run the test case of InterruptHttp.java in fast debug version of jdk with options:
-XX:+UseG1GC  -XX:+ScavengeALot -XX:ScavengeALotInterval=200 -XX:-GCALotAtAllSafepoints

And the test case failed, The output is "Execution failed: `main' threw exception: java.lang.RuntimeException: Expected 1 HTTP connection"

The reason is Thread.sleep(1000) can not ensure that vthread has connected to server when using some options and fastdebug version of jdk.

So, I fix this to ensure vthread has connected to server.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/loom pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/60.diff">https://git.openjdk.java.net/loom/pull/60.diff</a>

</details>
