### PR TITLE
Fix Minimal VM build failures

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3890,12 +3890,14 @@ JVM_END
 JVM_ENTRY(void, JVM_VirtualThreadMountBegin(JNIEnv* env, jobject vthread, jboolean first_mount))
 #if INCLUDE_JVMTI
   JvmtiVTMTDisabler::start_VTMT(vthread, 0);
+#else
+  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadMountEnd(JNIEnv* env, jobject vthread, jboolean first_mount))
-  assert(thread->is_in_VTMT(), "VTMT sanity check");
 #if INCLUDE_JVMTI
+  assert(thread->is_in_VTMT(), "VTMT sanity check");
   JvmtiVTMTDisabler::finish_VTMT(vthread, 0);
   oop vt = JNIHandles::resolve(vthread);
 
@@ -3916,6 +3918,8 @@ JVM_ENTRY(void, JVM_VirtualThreadMountEnd(JNIEnv* env, jobject vthread, jboolean
   if (JvmtiExport::should_post_vthread_mount()) {
     JvmtiExport::post_vthread_mount(vthread);
   }
+#else
+  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -3943,12 +3947,16 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountBegin(JNIEnv* env, jobject vthread, jboo
 
   assert(!thread->is_in_VTMT(), "VTMT sanity check");
   JvmtiVTMTDisabler::start_VTMT(vthread, 1);
+#else
+  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount))
-  assert(thread->is_in_VTMT(), "VTMT sanity check");
 #if INCLUDE_JVMTI
+  assert(thread->is_in_VTMT(), "VTMT sanity check");
   JvmtiVTMTDisabler::finish_VTMT(vthread, 1);
+#else
+  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3888,11 +3888,14 @@ JVM_ENTRY_NO_ENV(jint, JVM_FindSignal(const char *name))
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadMountBegin(JNIEnv* env, jobject vthread, jboolean first_mount))
+#if INCLUDE_JVMTI
   JvmtiVTMTDisabler::start_VTMT(vthread, 0);
+#endif
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadMountEnd(JNIEnv* env, jobject vthread, jboolean first_mount))
   assert(thread->is_in_VTMT(), "VTMT sanity check");
+#if INCLUDE_JVMTI
   JvmtiVTMTDisabler::finish_VTMT(vthread, 0);
   oop vt = JNIHandles::resolve(vthread);
 
@@ -3913,9 +3916,11 @@ JVM_ENTRY(void, JVM_VirtualThreadMountEnd(JNIEnv* env, jobject vthread, jboolean
   if (JvmtiExport::should_post_vthread_mount()) {
     JvmtiExport::post_vthread_mount(vthread);
   }
+#endif
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadUnmountBegin(JNIEnv* env, jobject vthread, jboolean last_unmount))
+#if INCLUDE_JVMTI
   HandleMark hm(thread);
   Handle ct(thread, thread->threadObj());
 
@@ -3938,9 +3943,12 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmountBegin(JNIEnv* env, jobject vthread, jboo
 
   assert(!thread->is_in_VTMT(), "VTMT sanity check");
   JvmtiVTMTDisabler::start_VTMT(vthread, 1);
+#endif
 JVM_END
 
 JVM_ENTRY(void, JVM_VirtualThreadUnmountEnd(JNIEnv* env, jobject vthread, jboolean last_unmount))
   assert(thread->is_in_VTMT(), "VTMT sanity check");
+#if INCLUDE_JVMTI
   JvmtiVTMTDisabler::finish_VTMT(vthread, 1);
+#endif
 JVM_END

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -82,8 +82,10 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread, oop thread_oop)
   _earlyret_oop = NULL;
 
   _jvmti_event_queue = NULL;
+#if INCLUDE_JVMTI
   _is_in_VTMT = false;
   _is_virtual = false;
+#endif
 
   _thread_oop_h = OopHandle(JvmtiExport::jvmti_oop_storage(), thread_oop);
 

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -786,3 +786,12 @@ void JvmtiThreadState::set_thread(JavaThread* thread) {
   }
   _thread = thread;
 }
+
+int JvmtiVTMTDisabler::VTMT_disable_count() {
+  return _VTMT_disable_count;
+}
+
+int JvmtiVTMTDisabler::VTMT_count() {
+  return _VTMT_count;
+}
+

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -82,10 +82,8 @@ JvmtiThreadState::JvmtiThreadState(JavaThread* thread, oop thread_oop)
   _earlyret_oop = NULL;
 
   _jvmti_event_queue = NULL;
-#if INCLUDE_JVMTI
   _is_in_VTMT = false;
   _is_virtual = false;
-#endif
 
   _thread_oop_h = OopHandle(JvmtiExport::jvmti_oop_storage(), thread_oop);
 

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -95,8 +95,8 @@ class JvmtiVTMTDisabler {
   void set_self_suspend() { _self_suspend = true; }
   static void start_VTMT(jthread vthread, int callsite_tag);
   static void finish_VTMT(jthread vthread, int callsite_tag);
-  static int  VTMT_disable_count() { return _VTMT_disable_count; };
-  static int  VTMT_count() { return _VTMT_count; }
+  static int  VTMT_disable_count();
+  static int  VTMT_count();
 };
 
 ///////////////////////////////////////////////////////////////

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -24,7 +24,6 @@
 
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
-#include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "oops/instanceStackChunkKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
@@ -74,8 +73,6 @@
 #include "utilities/debug.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
-
-#include "gc/g1/g1CollectedHeap.inline.hpp"
 
 #define CONT_JFR false
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -450,9 +450,16 @@ class frame {
   int adjust_offset(Method* method, int index); // helper for above fn
  public:
   // Memory management
-  void oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map) { oops_do_internal(f, cf, NULL, DerivedPointerTable::is_active() ?
-                                                                                                           DerivedPointerIterationMode::_with_table :
-                                                                                                           DerivedPointerIterationMode::_ignore, map, true); }
+  void oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map) {
+#if COMPILER2_OR_JVMCI
+    DerivedPointerIterationMode dpim = DerivedPointerTable::is_active() ?
+                                       DerivedPointerIterationMode::_with_table :
+                                       DerivedPointerIterationMode::_ignore;
+#else
+    DerivedPointerIterationMode dpim = DerivedPointerIterationMode::_ignore;;
+#endif
+    oops_do_internal(f, cf, NULL, dpim, map, true);
+  }
   void oops_do(OopClosure* f, CodeBlobClosure* cf, DerivedOopClosure* df, const RegisterMap* map) { oops_do_internal(f, cf, df, DerivedPointerIterationMode::_ignore, map, true); }
   void oops_do(OopClosure* f, CodeBlobClosure* cf, const RegisterMap* map, DerivedPointerIterationMode derived_mode) const { oops_do_internal(f, cf, NULL, derived_mode, map, true); }
   void nmethods_do(CodeBlobClosure* cf) const;

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -619,7 +619,7 @@ void HandshakeState::do_self_suspend() {
   assert(_handshakee->thread_state() == _thread_blocked, "Caller should have transitioned to _thread_blocked");
 
   while (is_suspended_or_blocked()) {
-    assert(!_handshakee->is_in_VTMT(), "no suspend allowed in VTMT transition");
+    JVMTI_ONLY(assert(!_handshakee->is_in_VTMT(), "no suspend allowed in VTMT transition");)
     log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
     _lock.wait_without_safepoint_check();
   }
@@ -706,7 +706,7 @@ public:
 };
 
 bool HandshakeState::suspend() {
-  assert(!_handshakee->is_in_VTMT(), "no suspend allowed in VTMT transition");
+  JVMTI_ONLY(assert(!_handshakee->is_in_VTMT(), "no suspend allowed in VTMT transition");)
   JavaThread* self = JavaThread::current();
   if (_handshakee == self) {
     // If target is the current thread we can bypass the handshake machinery

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1777,13 +1777,17 @@ void JavaThread::send_thread_stop(oop java_throwable)  {
 void JavaThread::set_is_in_VTMT(bool val) {
   _is_in_VTMT = val;
   if (val) {
+#if INCLUDE_JVMTI
     assert(JvmtiVTMTDisabler::VTMT_disable_count() == 0, "must be 0");
+#endif
   }
 }
 
 void JavaThread::set_is_VTMT_disabler(bool val) {
   _is_VTMT_disabler = val;
+#if INCLUDE_JVMTI
   assert(JvmtiVTMTDisabler::VTMT_count() == 0, "must be 0");
+#endif
 }
 
 // External suspension mechanism.
@@ -2363,6 +2367,7 @@ void JavaThread::print_stack_on(outputStream* st) {
 
 // Rebind JVMTI thread state from carrier to virtual or from virtual to carrier.
 JvmtiThreadState* JavaThread::rebind_to_jvmti_thread_state_of(oop thread_oop) {
+#if INCLUDE_JVMTI
   set_mounted_vthread(thread_oop);
 
   // unbind current JvmtiThreadState from JavaThread
@@ -2372,6 +2377,10 @@ JvmtiThreadState* JavaThread::rebind_to_jvmti_thread_state_of(oop thread_oop) {
   java_lang_Thread::jvmti_thread_state(thread_oop)->bind_to(this);
 
   return jvmti_thread_state();
+#else
+  ShouldNotReachHere();
+  return NULL;
+#endif
 }
 
 // JVMTI PopFrame support

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1776,26 +1776,19 @@ void JavaThread::send_thread_stop(oop java_throwable)  {
   this->interrupt();
 }
 
-void JavaThread::set_is_in_VTMT(bool val) {
 #if INCLUDE_JVMTI
+void JavaThread::set_is_in_VTMT(bool val) {
   _is_in_VTMT = val;
   if (val) {
     assert(JvmtiVTMTDisabler::VTMT_disable_count() == 0, "must be 0");
   }
-#else
-  fatal("Should only be called with JVMTI enabled");
-#endif
 }
 
 void JavaThread::set_is_VTMT_disabler(bool val) {
-#if INCLUDE_JVMTI
   _is_VTMT_disabler = val;
   assert(JvmtiVTMTDisabler::VTMT_count() == 0, "must be 0");
-#else
-  fatal("Should only be called with JVMTI enabled");
-#endif
 }
-
+#endif
 
 // External suspension mechanism.
 //
@@ -1804,9 +1797,11 @@ void JavaThread::set_is_VTMT_disabler(bool val) {
 //   - Target thread will not enter any new monitors.
 //
 bool JavaThread::java_suspend() {
+#if INCLUDE_JVMTI
   // Suspending a JavaThread in VTMT or disabling VTMT can cause deadlocks.
   assert(!is_in_VTMT(), "no suspend allowed in VTMT transition");
   assert(!is_VTMT_disabler(), "no suspend allowed for VTMT disablers");
+#endif
 
   ThreadsListHandle tlh;
   if (!tlh.includes(this)) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -926,8 +926,10 @@ class JavaThread: public Thread {
   volatile bool         _doing_unsafe_access;    // Thread may fault due to unsafe access
   bool                  _do_not_unlock_if_synchronized;  // Do not unlock the receiver of a synchronized method (since it was
                                                          // never locked) when throwing an exception. Used by interpreter only.
+#if INCLUDE_JVMTI
   bool                  _is_in_VTMT;             // thread is in virtual thread mount transition
   bool                  _is_VTMT_disabler;       // thread currently disabled VTMT
+#endif
 
   // JNI attach states:
   enum JNIAttachStates {
@@ -1247,8 +1249,23 @@ private:
     return (_suspend_flags & _thread_suspended) != 0;
   }
 
-  bool is_VTMT_disabler() const                  { return _is_VTMT_disabler; }
-  bool is_in_VTMT() const                        { return _is_in_VTMT; }
+  bool is_VTMT_disabler() const {
+#if INCLUDE_JVMTI
+    return _is_VTMT_disabler;
+#else
+    fatal("Should only be called with JVMTI enabled");
+    return false;
+#endif
+  }
+
+  bool is_in_VTMT() const {
+#if INCLUDE_JVMTI
+    return _is_in_VTMT;
+#else
+    fatal("Should only be called with JVMTI enabled");
+    return false;
+#endif
+  }
 
   void set_is_in_VTMT(bool val);
   void set_is_VTMT_disabler(bool val);
@@ -1590,8 +1607,10 @@ private:
   JvmtiThreadState *jvmti_thread_state() const                                   { return _jvmti_thread_state; }
   static ByteSize jvmti_thread_state_offset()                                    { return byte_offset_of(JavaThread, _jvmti_thread_state); }
 
+#if INCLUDE_JVMTI
   // Rebind JVMTI thread state from carrier to virtual or from virtual to carrier.
   JvmtiThreadState *rebind_to_jvmti_thread_state_of(oop thread_oop);
+#endif
 
   // JVMTI PopFrame support
   // Setting and clearing popframe_condition

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1249,26 +1249,13 @@ private:
     return (_suspend_flags & _thread_suspended) != 0;
   }
 
-  bool is_VTMT_disabler() const {
 #if INCLUDE_JVMTI
-    return _is_VTMT_disabler;
-#else
-    fatal("Should only be called with JVMTI enabled");
-    return false;
-#endif
-  }
-
-  bool is_in_VTMT() const {
-#if INCLUDE_JVMTI
-    return _is_in_VTMT;
-#else
-    fatal("Should only be called with JVMTI enabled");
-    return false;
-#endif
-  }
+  bool is_VTMT_disabler() const                  { return _is_VTMT_disabler; }
+  bool is_in_VTMT() const                        { return _is_in_VTMT; }
 
   void set_is_in_VTMT(bool val);
   void set_is_VTMT_disabler(bool val);
+#endif
 
   bool is_cont_force_yield() { return cont_preempt(); }
 


### PR DESCRIPTION
Minimal VM configs have no C2 and no JVMTI. New Loom code fails the Minimal VM builds because of this. See for example GHA runs: https://github.com/shipilev/loom/runs/3717293969?check_suite_focus=true

C2 needs just a little bit of protection when reaching to `DerivedPointersTable`.

JVMTI needs a bit more work. `jvmtiExport` and `jvmtiThreadState` headers are usually included even with JVMTI turned off, but `.cpp` would not be compiled without JVMTI. Therefore, non-trivial implementations should go into `.cpp`. Plus, some of the paths that call the actual methods declared but not implemented without JVMTI should be protected with `INCLUDE_JVMTI`.

Additional testing:
 - [x] Linux x86_64 server, `tier1_loom` still passes (includes JVMTI tests)
 - [x] Linux x86_64 minimal now builds, runs `tier1_loom` (cannot pass JVMTI tests without JVMTI)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - Committer) ⚠️ Review applies to 9ba55eda41cb018ba34f8a791fa34a4b0517d318
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/loom pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/67.diff">https://git.openjdk.java.net/loom/pull/67.diff</a>

</details>
