### PR TITLE
Fix Windows builds after oopMapStubGenerator change

### DIFF
--- a/src/hotspot/cpu/x86/oopMapStubGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/oopMapStubGenerator_x86.cpp
@@ -22,10 +22,10 @@
  *
  */
 
+#include "precompiled.hpp"
+
 // Old code. Might be deleted later if no uses appear.
 #if 0
-
-#include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "code/codeCache.hpp"
 #include "code/vmreg.inline.hpp"


### PR DESCRIPTION
Turns out, MSVC still compiles this compilation unit, unless we expose the PCH include. (Sighs)
Seen in GHA here: https://github.com/shipilev/loom/runs/3716995428?check_suite_focus=true -- and reproduced locally.

Additional testing:
 - [x] Local Windows 10 (MSVC 2019) builds now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/loom pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/68.diff">https://git.openjdk.java.net/loom/pull/68.diff</a>

</details>
