### PR TITLE
Fix Optimized builds

### DIFF
--- a/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
@@ -170,7 +170,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rbp(VMReg r) PRODUCT_RETURN 
+  static void assert_is_rbp(VMReg r) NOT_DEBUG({ return; })
                                      DEBUG_ONLY({ assert (r == rbp->as_VMReg() || r == rbp->as_VMReg()->next(), "Reg: %s", r->name()); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
@@ -170,7 +170,7 @@ class SmallRegisterMap {
 public:
   static constexpr SmallRegisterMap* instance = nullptr;
 private:
-  static void assert_is_rbp(VMReg r) NOT_DEBUG({ return; })
+  static void assert_is_rbp(VMReg r) NOT_DEBUG_RETURN
                                      DEBUG_ONLY({ assert (r == rbp->as_VMReg() || r == rbp->as_VMReg()->next(), "Reg: %s", r->name()); })
 public:
   // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -332,9 +332,9 @@ public:
 
 template <bool store, bool compressedOopsWithBitmap>
 class BarrierClosure: public OopClosure {
-  DEBUG_ONLY(intptr_t* _sp;)
+  NOT_PRODUCT(intptr_t* _sp;)
 public:
-  BarrierClosure(intptr_t* sp) DEBUG_ONLY(: _sp(sp)) {}
+  BarrierClosure(intptr_t* sp) NOT_PRODUCT(: _sp(sp)) {}
 
   virtual void do_oop(oop* p)       override { compressedOopsWithBitmap ? do_oop_work((narrowOop*)p) : do_oop_work(p); }
   virtual void do_oop(narrowOop* p) override { do_oop_work(p); }

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -102,9 +102,10 @@ public:
   static inline void assert_mixed_correct(stackChunkOop chunk, bool mixed) PRODUCT_RETURN;
 #ifndef PRODUCT
   void oop_print_on(oop obj, outputStream* st) override;
-  static bool verify(oop obj, size_t* out_size = NULL, int* out_oops = NULL, int* out_frames = NULL, int* out_interpreted_frames = NULL);
 #endif
-  
+
+  static bool verify(oop obj, size_t* out_size = NULL, int* out_oops = NULL, int* out_frames = NULL, int* out_interpreted_frames = NULL) NOT_DEBUG({ return true; });
+
   // Stack offset is an offset into the Heap
   static HeapWord* start_of_stack(oop obj) { return (HeapWord*)(cast_from_oop<intptr_t>(obj) + offset_of_stack()); }
   static inline HeapWord* start_of_bitmap(oop obj);
@@ -206,11 +207,14 @@ class StackChunkFrameStream : public StackObj {
 #ifndef PRODUCT
   stackChunkOop _chunk;
   int _index;
+#endif
+
+#ifdef ASSERT
   int _has_stub;
 #endif
 
- public:
-  StackChunkFrameStream() { NOT_PRODUCT(_chunk = nullptr; _index = -1; _has_stub = false;) }
+public:
+  StackChunkFrameStream() { NOT_PRODUCT(_chunk = nullptr; _index = -1;) DEBUG_ONLY(_has_stub = false;) }
   inline StackChunkFrameStream(stackChunkOop chunk, bool gc = false);
   inline StackChunkFrameStream(stackChunkOop chunk, const frame& f);
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -203,14 +203,14 @@ class StackChunkFrameStream : public StackObj {
   CodeBlob* _cb;
   mutable const ImmutableOopMap* _oopmap;
 
-#ifdef ASSERT
+#ifndef PRODUCT
   stackChunkOop _chunk;
   int _index;
   int _has_stub;
 #endif
 
  public:
-  StackChunkFrameStream() { DEBUG_ONLY(_chunk = nullptr; _index = -1; _has_stub = false;) }
+  StackChunkFrameStream() { NOT_PRODUCT(_chunk = nullptr; _index = -1; _has_stub = false;) }
   inline StackChunkFrameStream(stackChunkOop chunk, bool gc = false);
   inline StackChunkFrameStream(stackChunkOop chunk, const frame& f);
 
@@ -227,7 +227,7 @@ class StackChunkFrameStream : public StackObj {
   inline address   pc() const  { return get_pc(); }
   inline intptr_t* fp() const;
   inline intptr_t* unextended_sp() const { return mixed ? _unextended_sp : _sp; }
-  DEBUG_ONLY(int index() { return _index; })
+  NOT_PRODUCT(int index() { return _index; })
   inline address orig_pc() const;
 
   inline bool is_interpreted() const;

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -32,7 +32,7 @@
 #include "runtime/frame.hpp"
 #include "runtime/registerMap.hpp"
 
-#ifndef PRODUCT
+#ifdef ASSERT
 bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames, int* out_interpreted_frames) {
   return InstanceStackChunkKlass::verify(this, out_size, out_oops, out_frames, out_interpreted_frames);
 }

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -115,7 +115,7 @@ public:
   template <typename OopT> inline OopT* address_for_bit(BitMap::idx_t index) const;
 
   //
-  bool verify(size_t* out_size = NULL, int* out_oops = NULL, int* out_frames = NULL, int* out_interpreted_frames = NULL) PRODUCT_RETURN_(return true;);
+  bool verify(size_t* out_size = NULL, int* out_oops = NULL, int* out_frames = NULL, int* out_interpreted_frames = NULL) NOT_DEBUG({ return true; });
 
   // template <bool mixed, typename RegisterMapT> bool do_frame(const StackChunkFrameStream<mixed>&, const RegisterMapT*);
   template <class StackChunkFrameClosureType> 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -185,7 +185,7 @@ template<int x> NOINLINE static bool do_verify_after_thaw1(JavaThread* thread) {
 static void print_vframe(frame f, const RegisterMap* map = nullptr, outputStream* st = tty);
 void do_deopt_after_thaw(JavaThread* thread);
 
-#ifdef ASSERT
+#ifndef PRODUCT
   template <bool relative>
   static void print_frame_layout(const frame& f, outputStream* st = tty);
   static void print_frames(JavaThread* thread, outputStream* st = tty);
@@ -2242,7 +2242,7 @@ private:
 
   int _align_size;
 
-  DEBUG_ONLY(int _frames;)
+  NOT_PRODUCT(int _frames;)
 
   inline frame new_entry_frame();
   template<typename FKind> frame new_frame(const frame& hf, frame& caller, bool bottom);
@@ -3485,6 +3485,7 @@ void Continuation::describe(FrameValues &values) {
   }
 }
 
+#ifdef ASSERT
 bool Continuation::debug_is_stack_chunk(Klass* k) {
   return k->is_instance_klass() && InstanceKlass::cast(k)->is_stack_chunk_instance_klass();
 }
@@ -3565,6 +3566,7 @@ void Continuation::debug_print_continuation(oop contOop, outputStream* st) {
 
   // st->print_cr("frames: %d interpreted frames: %d oops: %d", cont.num_frames(), cont.num_interpreted_frames(), cont.num_oops());
 }
+#endif // ASSERT
 
 static jlong java_tid(JavaThread* thread) {
   return java_lang_Thread::thread_id(thread->threadObj());

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1299,7 +1299,7 @@ private:
 public:
   FrameValuesOopClosure(FrameValues& values, int frame_no) : _values(values), _frame_no(frame_no) {}
   virtual void do_oop(oop* p) {
-    bool good = *p == nullptr || (dbg_is_safe(*p, -1) && dbg_is_safe((*p)->klass(), -1) && Universe::heap()->is_in_or_null(*p) && oopDesc::is_oop_or_null(*p));
+    bool good = *p == nullptr || (dbg_is_safe(*p, -1) && dbg_is_safe((*p)->klass(), -1) && oopDesc::is_oop_or_null(*p));
     _values.describe(_frame_no, (intptr_t*)p, err_msg("oop%s for #%d", good ? "" : " (BAD)", _frame_no)); 
   }
   virtual void do_oop(narrowOop* p) { _values.describe(_frame_no, (intptr_t*)p, err_msg("narrow oop for #%d", _frame_no)); }

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -82,7 +82,7 @@ class RegisterMap : public StackObj {
   bool        _process_frames;          // Should frames be processed by stack watermark barriers?
   bool        _walk_cont;               // whether to walk frames on a continuation stack
 
-  DEBUG_ONLY(bool  _skip_missing;)
+  NOT_PRODUCT(bool  _skip_missing;)
 
 #ifdef ASSERT
   void check_location_valid();
@@ -91,7 +91,7 @@ class RegisterMap : public StackObj {
 #endif
 
  public:
-  DEBUG_ONLY(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
+  NOT_PRODUCT(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
   RegisterMap(JavaThread *thread, bool update_map = true, bool process_frames = true, bool walk_cont = false);
   RegisterMap(oop continuation, bool update_map = true);
   RegisterMap(const RegisterMap* map);
@@ -157,7 +157,7 @@ class RegisterMap : public StackObj {
   void print_on(outputStream* st) const;
   void print() const;
 
-#ifdef ASSERT
+#ifndef PRODUCT
   void set_skip_missing(bool value) { _skip_missing = value; }
   bool should_skip_missing() const  { return _skip_missing; }
 

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -91,7 +91,7 @@ class RegisterMap : public StackObj {
 #endif
 
  public:
-  NOT_PRODUCT(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
+  DEBUG_ONLY(intptr_t* _update_for_id;) // Assert that RegisterMap is not updated twice for same frame
   RegisterMap(JavaThread *thread, bool update_map = true, bool process_frames = true, bool walk_cont = false);
   RegisterMap(oop continuation, bool update_map = true);
   RegisterMap(const RegisterMap* map);


### PR DESCRIPTION
The usual trap in Hotspot code is the belief that `ASSERT <=> !PRODUCT`, but that's not actually true. You would not see this in regular release (`!ASSERT`, `PRODUCT`) or fastdebug (`ASSERT`, `!PRODUCT`) builds, but you would see it in optimized (`!ASSERT`, `!PRODUCT`) builds. See for example GHA: https://github.com/shipilev/loom/runs/3717294006?check_suite_focus=true

The use of `ASSERT` and `PRODUCT` should be consistent to avoid build failures in optimized builds.

Additional testing:
 - [x] Linux x86_64 optimized now builds
 - [x] Linux x86_64 release still builds
 - [x] Linux x86_64 fastdebug still builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - Committer) ⚠️ Review applies to 9070ba6a6f18bffdc1414f319081122f006bbd37


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/loom pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/69.diff">https://git.openjdk.java.net/loom/pull/69.diff</a>

</details>
