### PR TITLE
Loom: PPC64, S390, ARM32, Zero stubs

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -35,7 +35,7 @@ const int ContinuationHelper::align_wiggle = 1;
 #ifdef ASSERT
 bool Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
-  address pc = *(address*)(sp - SENDER_SP_RET_ADDRESS_OFFSET);
+  address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
   intptr_t* fp = *(intptr_t**)(sp - frame::sender_sp_offset);
   assert (f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
   assert (f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
@@ -418,7 +418,7 @@ intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
   assert((intptr_t)sp % 16 == 0, "");
 
   sp -= ContinuationHelper::frame_metadata;
-  *(address*)(sp - SENDER_SP_RET_ADDRESS_OFFSET) = pc;
+  *(address*)(sp - frame::sender_sp_ret_address_offset()) = pc;
   *(intptr_t**)(sp - frame::sender_sp_offset) = fp;
   return sp;
 }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -399,6 +399,10 @@ inline bool frame::is_interpreted_frame() const {
   return Interpreter::contains(pc());
 }
 
+inline int frame::sender_sp_ret_address_offset() {
+  return frame::sender_sp_offset - frame::return_addr_offset;
+}
+
 inline const ImmutableOopMap* frame::get_oop_map() const {
   if (_cb == NULL) return NULL;
   if (_cb->oop_maps() != NULL) {

--- a/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
@@ -1327,3 +1327,7 @@ void LIRGenerator::volatile_field_load(LIR_Address* address, LIR_Opr result,
   }
   __ load(address, result, info, lir_patch_none);
 }
+
+void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
+  fatal("Continuation.doYield intrinsic is not implemented on this platform");
+}

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ARM_CONTINUATION_ARM_INLINE_HPP
+#define CPU_ARM_CONTINUATION_ARM_INLINE_HPP
+
+#include "oops/instanceStackChunkKlass.inline.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
+
+// TODO: Implement
+const int ContinuationHelper::frame_metadata = 0;
+const int ContinuationHelper::align_wiggle = 0;
+
+#ifdef ASSERT
+bool Frame::assert_frame_laid_out(frame f) {
+  Unimplemented();
+  return false;
+}
+#endif
+
+inline intptr_t** Frame::callee_link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+static inline intptr_t* real_fp(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
+static inline intptr_t** link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address* Interpreted::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline address* Frame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address Frame::real_pc(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void Frame::patch_pc(const frame& f, address pc) {
+  Unimplemented();
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind, typename RegisterMapT>
+inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+template<typename RegisterMapT>
+inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::push_pd(const frame& f) {
+  Unimplemented();
+}
+
+// creates the yield stub frame faster than JavaThread::last_frame
+inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+  Unimplemented();
+  return frame();
+}
+
+frame ContinuationEntry::to_frame() {
+  Unimplemented();
+  return frame();
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind>
+inline frame Freeze<ConfigT>::sender(const frame& f) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+template <typename FKind, bool bottom>
+inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline frame Thaw<ConfigT>::new_entry_frame() {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind, bool bottom>
+inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
+  Unimplemented();
+  return NULL;
+}
+
+#endif // CPU_ARM_CONTINUATION_ARM_INLINE_HPP

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -248,11 +248,6 @@ bool frame::is_interpreted_frame() const  {
   return Interpreter::contains(pc());
 }
 
-int frame::frame_size(RegisterMap* map) const {
-  frame sender = this->sender(map);
-  return sender.sp() - sp();
-}
-
 intptr_t* frame::entry_frame_argument_at(int offset) const {
   assert(is_entry_frame(), "entry frame expected");
   // convert offset to index to deal with tsi
@@ -277,14 +272,6 @@ void frame::set_interpreter_frame_sender_sp(intptr_t* sender_sp) {
 
 BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return (BasicObjectLock*) addr_at(interpreter_frame_monitor_block_bottom_offset);
-}
-
-BasicObjectLock* frame::interpreter_frame_monitor_end() const {
-  BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
-  // make sure the pointer points inside the frame
-  assert((intptr_t) fp() >  (intptr_t) result, "result must <  than frame pointer");
-  assert((intptr_t) sp() <= (intptr_t) result, "result must >= than stack pointer");
-  return result;
 }
 
 void frame::interpreter_frame_set_monitor_end(BasicObjectLock* value) {
@@ -399,6 +386,7 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
   return frame(sender_sp, unextended_sp, link(), sender_pc());
 }
 
+template <bool stub>
 frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   assert(map != NULL, "map must be set");
 
@@ -442,7 +430,7 @@ frame frame::sender(RegisterMap* map) const {
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
 
   if (_cb != NULL) {
-    return sender_for_compiled_frame(map);
+    return sender_for_compiled_frame<false>(map);
   }
 
   assert(false, "should not be called for a C frame");
@@ -547,12 +535,6 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-
-intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
-  int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
-  return &interpreter_frame_tos_address()[index];
-}
-
 #ifndef PRODUCT
 
 #define DESCRIBE_FP_OFFSET(name) \
@@ -576,6 +558,9 @@ frame::frame(void* sp, void* fp, void* pc) {
   init((intptr_t*)sp, (intptr_t*)fp, (address)pc);
 }
 
+void frame::describe_top_pd(FrameValues& values) {
+  Unimplemented();
+}
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {
@@ -606,4 +591,26 @@ intptr_t* frame::real_fp() const {
   // else rely on fp()
   assert(! is_compiled_frame(), "unknown compiled frame size");
   return fp();
+}
+
+// Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
+template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+
+template <bool relative>
+inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+  BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
+  // make sure the pointer points inside the frame
+  assert((intptr_t) fp() >  (intptr_t) result, "result must <  than frame pointer");
+  assert((intptr_t) sp() <= (intptr_t) result, "result must >= than stack pointer");
+  return result;
+}
+
+template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
+
+template <bool relative>
+inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
+  int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
+  return &interpreter_frame_tos_address()[index];
 }

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -90,7 +90,9 @@
   }
 #endif
 
- public:
+  const ImmutableOopMap* get_oop_map() const;
+
+public:
   // Constructors
 
   frame(intptr_t* sp, intptr_t* fp, address pc);
@@ -117,5 +119,8 @@
   static void update_map_with_saved_link(RegisterMap* map, intptr_t** link_addr);
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
+
+  template <bool relative = false>
+  inline intptr_t* interpreter_frame_last_sp() const;
 
 #endif // CPU_ARM_FRAME_ARM_HPP

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -41,6 +41,10 @@ inline frame::frame() {
   _deopt_state = unknown;
 }
 
+inline frame::frame(intptr_t* sp) {
+  Unimplemented();
+}
+
 inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   _sp = sp;
   _unextended_sp = sp;
@@ -170,6 +174,7 @@ inline oop* frame::interpreter_frame_mirror_addr() const {
 }
 
 // top of expression stack
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   intptr_t* last_sp = interpreter_frame_last_sp();
   if (last_sp == NULL ) {
@@ -195,6 +200,7 @@ inline int frame::interpreter_frame_monitor_size() {
 // expression stack
 // (the max_stack arguments are used by the GC; see class FrameClosure)
 
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
   return monitor_end-1;
@@ -211,15 +217,67 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 // Compiled frames
 
 inline oop frame::saved_oop_result(RegisterMap* map) const {
-  oop* result_adr = (oop*) map->location(R0->as_VMReg());
+  oop* result_adr = (oop*) map->location(R0->as_VMReg(), (intptr_t*) NULL);
   guarantee(result_adr != NULL, "bad register save location");
   return (*result_adr);
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
-  oop* result_adr = (oop*) map->location(R0->as_VMReg());
+  oop* result_adr = (oop*) map->location(R0->as_VMReg(), (intptr_t*) NULL);
   guarantee(result_adr != NULL, "bad register save location");
   *result_adr = obj;
+}
+
+inline int frame::frame_size() const {
+  return sender_sp() - sp();
+}
+
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::compiled_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  Unimplemented();
+}
+
+inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool relative>
+inline intptr_t* frame::interpreter_frame_last_sp() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  Unimplemented();
+  return 0;
+}
+
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
+  Unimplemented();
+}
+
+inline void frame::set_unextended_sp(intptr_t* value) {
+  Unimplemented();
+}
+
+inline int frame::offset_unextended_sp() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
 }
 
 #endif // CPU_ARM_FRAME_ARM_INLINE_HPP

--- a/src/hotspot/cpu/arm/instanceStackChunkKlass_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/instanceStackChunkKlass_arm.inline.hpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ARM_INSTANCESTACKCHUNKKLASS_ARM_INLINE_HPP
+#define CPU_ARM_INSTANCESTACKCHUNKKLASS_ARM_INLINE_HPP
+
+#include "interpreter/oopMapCache.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+int InstanceStackChunkKlass::metadata_words() {
+  Unimplemented();
+  return 0;
+}
+
+int InstanceStackChunkKlass::align_wiggle()   {
+  Unimplemented();
+  return 0;
+}
+
+#ifdef ASSERT
+template <bool mixed>
+inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+  Unimplemented();
+  return true;
+}
+#endif
+
+template <bool mixed>
+inline frame StackChunkFrameStream<mixed>::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+template <bool mixed>
+inline address StackChunkFrameStream<mixed>::get_pc() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+  Unimplemented();
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template <bool mixed>
+template <typename RegisterMapT>
+inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+
+// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+class SmallRegisterMap {
+public:
+  static constexpr SmallRegisterMap* instance = nullptr;
+private:
+  static void assert_is_rfp(VMReg r) PRODUCT_RETURN 
+                                     DEBUG_ONLY({ Unimplemented(); })
+public:
+  // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
+  // Consider enhancing SmallRegisterMap to support those cases
+  const RegisterMap* as_RegisterMap() const { return nullptr; }
+  RegisterMap* as_RegisterMap() { return nullptr; }
+
+  RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
+    Unimplemented();
+    return map;
+  }
+  
+  SmallRegisterMap() {}
+
+  SmallRegisterMap(const RegisterMap* map) {
+    Unimplemented();
+  }
+
+  inline address location(VMReg reg, intptr_t* sp) const {
+    Unimplemented();
+    return NULL;
+  }
+
+  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+
+  JavaThread* thread() const {
+  #ifndef ASSERT
+    guarantee (false, ""); 
+  #endif
+    return nullptr;
+  }
+
+  bool update_map()    const { return false; }
+  bool walk_cont()     const { return false; }
+  bool include_argument_oops() const { return false; }
+  void set_include_argument_oops(bool f)  {}
+  bool in_cont()       const { return false; }
+  stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
+  
+#ifdef ASSERT
+  bool should_skip_missing() const  { return false; }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
+    Unimplemented();
+    return NULL;
+  }
+  void print() const { print_on(tty); }
+  void print_on(outputStream* st) const { st->print_cr("Small register map"); }
+#endif
+};
+
+#endif // CPU_ARM_INSTANCESTACKCHUNKKLASS_ARM_INLINE_HPP

--- a/src/hotspot/cpu/arm/nativeInst_arm_32.hpp
+++ b/src/hotspot/cpu/arm/nativeInst_arm_32.hpp
@@ -432,4 +432,35 @@ inline NativeCall* nativeCall_before(address return_address) {
   return (NativeCall *) rawNativeCall_before(return_address);
 }
 
+class NativePostCallNop: public NativeInstruction {
+public:
+  bool check() const { Unimplemented(); return false; }
+  int displacement() const { Unimplemented(); return 0; }
+  void patch(jint diff) { Unimplemented(); }
+  void make_deopt() { Unimplemented(); }
+};
+
+inline NativePostCallNop* nativePostCallNop_at(address address) {
+  Unimplemented();
+  return NULL;
+}
+
+class NativeDeoptInstruction: public NativeInstruction {
+public:
+  address instruction_address() const       { Unimplemented(); return NULL; }
+  address next_instruction_address() const  { Unimplemented(); return NULL; }
+
+  void  verify() { Unimplemented(); }
+
+  static bool is_deopt_at(address instr) {
+    Unimplemented();
+    return false;
+  }
+
+  // MT-safe patching
+  static void insert(address code_pos) {
+    Unimplemented();
+  }
+};
+
 #endif // CPU_ARM_NATIVEINST_ARM_32_HPP

--- a/src/hotspot/cpu/arm/registerMap_arm.hpp
+++ b/src/hotspot/cpu/arm/registerMap_arm.hpp
@@ -37,7 +37,7 @@
   address pd_location(VMReg reg) const {return NULL;}
 
   address pd_location(VMReg base_reg, int slot_idx) const {
-    return location(base_reg->next(slot_idx));
+    return location(base_reg->next(slot_idx), (intptr_t*) NULL);
   }
 
   // no PD state to clear or copy:

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -3086,9 +3086,9 @@ class StubGenerator: public StubCodeGenerator {
 }; // end class declaration
 
 #define UCM_TABLE_MAX_ENTRIES 32
-void StubGenerator_generate(CodeBuffer* code, bool all) {
+void StubGenerator_generate(CodeBuffer* code, int phase) {
   if (UnsafeCopyMemory::_table == NULL) {
     UnsafeCopyMemory::create_table(UCM_TABLE_MAX_ENTRIES);
   }
-  StubGenerator g(code, all);
+  StubGenerator g(code, phase);
 }

--- a/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
@@ -728,6 +728,11 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
 // [ parameter 1        ] <--- Rlocals
 //
 
+address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  Unimplemented();
+  return NULL;
+}
+
 address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   // Code: _aload_0, _getfield, _areturn
   // parameter size = 1

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -1379,3 +1379,7 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
   fatal("vectorizedMismatch intrinsic is not implemented on this platform");
 }
+
+void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
+  fatal("Continuation.doYield intrinsic is not implemented on this platform");
+}

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_PPC_CONTINUATION_PPC_INLINE_HPP
+#define CPU_PPC_CONTINUATION_PPC_INLINE_HPP
+
+#include "oops/instanceStackChunkKlass.inline.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
+
+// TODO: Implement
+const int ContinuationHelper::frame_metadata = 0;
+const int ContinuationHelper::align_wiggle = 0;
+
+#ifdef ASSERT
+bool Frame::assert_frame_laid_out(frame f) {
+  Unimplemented();
+  return false;
+}
+#endif
+
+inline intptr_t** Frame::callee_link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+static inline intptr_t* real_fp(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
+static inline intptr_t** link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address* Interpreted::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline address* Frame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address Frame::real_pc(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void Frame::patch_pc(const frame& f, address pc) {
+  Unimplemented();
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind, typename RegisterMapT>
+inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+template<typename RegisterMapT>
+inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::push_pd(const frame& f) {
+  Unimplemented();
+}
+
+// creates the yield stub frame faster than JavaThread::last_frame
+inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+  Unimplemented();
+  return frame();
+}
+
+frame ContinuationEntry::to_frame() {
+  Unimplemented();
+  return frame();
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind>
+inline frame Freeze<ConfigT>::sender(const frame& f) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+template <typename FKind, bool bottom>
+inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline frame Thaw<ConfigT>::new_entry_frame() {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind, bool bottom>
+inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
+  Unimplemented();
+  return NULL;
+}
+
+#endif // CPU_PPC_CONTINUATION_PPC_INLINE_HPP

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -379,8 +379,10 @@
 
  public:
 
-  // Constructors
-  inline frame(intptr_t* sp);
+  const ImmutableOopMap* get_oop_map() const;
+
+// Constructors
+//  inline frame(intptr_t* sp);
   inline frame(intptr_t* sp, address pc);
   inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp);
 
@@ -399,6 +401,9 @@
   inline void interpreter_frame_set_esp(intptr_t* esp);
   inline void interpreter_frame_set_top_frame_sp(intptr_t* top_frame_sp);
   inline void interpreter_frame_set_sender_sp(intptr_t* sender_sp);
+
+  template <bool relative = false>
+  inline intptr_t* interpreter_frame_last_sp() const;
 
   // Size of a monitor in bytes.
   static int interpreter_frame_monitor_size_in_bytes();

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -87,7 +87,7 @@ inline bool frame::is_older(intptr_t* id) const {
    return this->id() > id;
 }
 
-inline int frame::frame_size(RegisterMap* map) const {
+inline int frame::frame_size() const {
   // Stack grows towards smaller addresses on PPC64: sender is at a higher address.
   return sender_sp() - sp();
 }
@@ -139,11 +139,6 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
   return (intptr_t*) &(get_ijava_state()->mdx);
 }
 
-// Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
-  return (BasicObjectLock*) get_ijava_state()->monitors;
-}
-
 inline BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return (BasicObjectLock*) get_ijava_state();
 }
@@ -176,17 +171,15 @@ inline void frame::interpreter_frame_set_esp(intptr_t* esp)                   { 
 inline void frame::interpreter_frame_set_top_frame_sp(intptr_t* top_frame_sp) { get_ijava_state()->top_frame_sp = (intptr_t) top_frame_sp; }
 inline void frame::interpreter_frame_set_sender_sp(intptr_t* sender_sp)       { get_ijava_state()->sender_sp = (intptr_t) sender_sp; }
 
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   return (intptr_t*)interpreter_frame_monitor_end() - 1;
 }
 
 // top of expression stack
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return ((intptr_t*) get_ijava_state()->esp) + Interpreter::stackElementWords;
-}
-
-inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
-  return &interpreter_frame_tos_address()[offset];
 }
 
 inline int frame::interpreter_frame_monitor_size() {
@@ -214,11 +207,59 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 }
 
 inline oop frame::saved_oop_result(RegisterMap* map) const {
-  return *((oop*)map->location(R3->as_VMReg()));
+  return *((oop*)map->location(R3->as_VMReg(), (intptr_t*) NULL));
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
-  *((oop*)map->location(R3->as_VMReg())) = obj;
+  *((oop*)map->location(R3->as_VMReg(), (intptr_t*) NULL)) = obj;
+}
+
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::compiled_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  Unimplemented();
+}
+
+inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool relative>
+inline intptr_t* frame::interpreter_frame_last_sp() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  Unimplemented();
+  return 0;
+}
+
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
+  Unimplemented();
+}
+
+inline void frame::set_unextended_sp(intptr_t* value) {
+  Unimplemented();
+}
+
+inline int frame::offset_unextended_sp() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
 }
 
 #endif // CPU_PPC_FRAME_PPC_INLINE_HPP

--- a/src/hotspot/cpu/ppc/instanceStackChunkKlass_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/instanceStackChunkKlass_ppc.inline.hpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_PPC_INSTANCESTACKCHUNKKLASS_PPC_INLINE_HPP
+#define CPU_PPC_INSTANCESTACKCHUNKKLASS_PPC_INLINE_HPP
+
+#include "interpreter/oopMapCache.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+int InstanceStackChunkKlass::metadata_words() {
+  Unimplemented();
+  return 0;
+}
+
+int InstanceStackChunkKlass::align_wiggle()   {
+  Unimplemented();
+  return 0;
+}
+
+#ifdef ASSERT
+template <bool mixed>
+inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+  Unimplemented();
+  return true;
+}
+#endif
+
+template <bool mixed>
+inline frame StackChunkFrameStream<mixed>::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+template <bool mixed>
+inline address StackChunkFrameStream<mixed>::get_pc() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+  Unimplemented();
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template <bool mixed>
+template <typename RegisterMapT>
+inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+
+// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+class SmallRegisterMap {
+public:
+  static constexpr SmallRegisterMap* instance = nullptr;
+private:
+  static void assert_is_rfp(VMReg r) PRODUCT_RETURN 
+                                     DEBUG_ONLY({ Unimplemented(); })
+public:
+  // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
+  // Consider enhancing SmallRegisterMap to support those cases
+  const RegisterMap* as_RegisterMap() const { return nullptr; }
+  RegisterMap* as_RegisterMap() { return nullptr; }
+
+  RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
+    Unimplemented();
+    return map;
+  }
+  
+  SmallRegisterMap() {}
+
+  SmallRegisterMap(const RegisterMap* map) {
+    Unimplemented();
+  }
+
+  inline address location(VMReg reg, intptr_t* sp) const {
+    Unimplemented();
+    return NULL;
+  }
+
+  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+
+  JavaThread* thread() const {
+  #ifndef ASSERT
+    guarantee (false, ""); 
+  #endif
+    return nullptr;
+  }
+
+  bool update_map()    const { return false; }
+  bool walk_cont()     const { return false; }
+  bool include_argument_oops() const { return false; }
+  void set_include_argument_oops(bool f)  {}
+  bool in_cont()       const { return false; }
+  stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
+  
+#ifdef ASSERT
+  bool should_skip_missing() const  { return false; }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
+    Unimplemented();
+    return NULL;
+  }
+  void print() const { print_on(tty); }
+  void print_on(outputStream* st) const { st->print_cr("Small register map"); }
+#endif
+};
+
+#endif // CPU_PPC_INSTANCESTACKCHUNKKLASS_PPC_INLINE_HPP

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
@@ -503,4 +503,35 @@ class NativeMovRegMem: public NativeInstruction {
   }
 };
 
+class NativePostCallNop: public NativeInstruction {
+public:
+  bool check() const { Unimplemented(); return false; }
+  int displacement() const { Unimplemented(); return 0; }
+  void patch(jint diff) { Unimplemented(); }
+  void make_deopt() { Unimplemented(); }
+};
+
+inline NativePostCallNop* nativePostCallNop_at(address address) {
+  Unimplemented();
+  return NULL;
+}
+
+class NativeDeoptInstruction: public NativeInstruction {
+public:
+  address instruction_address() const       { Unimplemented(); return NULL; }
+  address next_instruction_address() const  { Unimplemented(); return NULL; }
+
+  void  verify() { Unimplemented(); }
+
+  static bool is_deopt_at(address instr) {
+    Unimplemented();
+    return false;
+  }
+
+  // MT-safe patching
+  static void insert(address code_pos) {
+    Unimplemented();
+  }
+};
+
 #endif // CPU_PPC_NATIVEINST_PPC_HPP

--- a/src/hotspot/cpu/ppc/registerMap_ppc.hpp
+++ b/src/hotspot/cpu/ppc/registerMap_ppc.hpp
@@ -36,7 +36,7 @@
   address pd_location(VMReg reg) const { return NULL; }
 
   address pd_location(VMReg base_reg, int slot_idx) const {
-    return location(base_reg->next(slot_idx));
+    return location(base_reg->next(slot_idx), (intptr_t*)NULL);
   }
 
   // no PD state to clear or copy:

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -4667,9 +4667,9 @@ class StubGenerator: public StubCodeGenerator {
 };
 
 #define UCM_TABLE_MAX_ENTRIES 8
-void StubGenerator_generate(CodeBuffer* code, bool all) {
+void StubGenerator_generate(CodeBuffer* code, int phase) {
   if (UnsafeCopyMemory::_table == NULL) {
     UnsafeCopyMemory::create_table(UCM_TABLE_MAX_ENTRIES);
   }
-  StubGenerator g(code, all);
+  StubGenerator g(code, phase);
 }

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -476,6 +476,11 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
   return entry;
 }
 
+address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  Unimplemented();
+  return NULL;
+}
+
 // Interpreter intrinsic for WeakReference.get().
 // 1. Don't push a full blown frame and go on dispatching, but fetch the value
 //    into R8 and return quickly

--- a/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
@@ -1181,3 +1181,7 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
   fatal("vectorizedMismatch intrinsic is not implemented on this platform");
 }
+
+void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
+  fatal("Continuation.doYield intrinsic is not implemented on this platform");
+}

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_S390_CONTINUATION_S390_INLINE_HPP
+#define CPU_S390_CONTINUATION_S390_INLINE_HPP
+
+#include "oops/instanceStackChunkKlass.inline.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
+
+// TODO: Implement
+const int ContinuationHelper::frame_metadata = 0;
+const int ContinuationHelper::align_wiggle = 0;
+
+#ifdef ASSERT
+bool Frame::assert_frame_laid_out(frame f) {
+  Unimplemented();
+  return false;
+}
+#endif
+
+inline intptr_t** Frame::callee_link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+static inline intptr_t* real_fp(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
+static inline intptr_t** link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address* Interpreted::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline address* Frame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address Frame::real_pc(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void Frame::patch_pc(const frame& f, address pc) {
+  Unimplemented();
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind, typename RegisterMapT>
+inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+template<typename RegisterMapT>
+inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::push_pd(const frame& f) {
+  Unimplemented();
+}
+
+// creates the yield stub frame faster than JavaThread::last_frame
+inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+  Unimplemented();
+  return frame();
+}
+
+frame ContinuationEntry::to_frame() {
+  Unimplemented();
+  return frame();
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind>
+inline frame Freeze<ConfigT>::sender(const frame& f) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+template <typename FKind, bool bottom>
+inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline frame Thaw<ConfigT>::new_entry_frame() {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind, bool bottom>
+inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
+  Unimplemented();
+  return NULL;
+}
+
+#endif // CPU_S390_CONTINUATION_S390_INLINE_HPP

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -461,11 +461,12 @@
  private:
 
   inline void find_codeblob_and_set_pc_and_deopt_state(address pc);
+  const ImmutableOopMap* get_oop_map() const;
 
- // Constructors
+// Constructors
 
  public:
-  inline frame(intptr_t* sp);
+//  inline frame(intptr_t* sp);
   // To be used, if sp was not extended to match callee's calling convention.
   inline frame(intptr_t* sp, address pc);
   inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp);
@@ -486,8 +487,10 @@
   address* sender_pc_addr(void) const;
 
  public:
+  template <bool relative = false>
+  inline intptr_t* interpreter_frame_last_sp() const;
 
-  // Additional interface for interpreter frames:
+// Additional interface for interpreter frames:
   static int interpreter_frame_interpreterstate_size_in_bytes();
   static int interpreter_frame_monitor_size_in_bytes();
 

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -119,7 +119,7 @@ inline bool frame::is_older(intptr_t* id) const {
   return this->id() > id;
 }
 
-inline int frame::frame_size(RegisterMap* map) const {
+inline int frame::frame_size() const {
   // Stack grows towards smaller addresses on z/Linux: sender is at a higher address.
   return sender_sp() - sp();
 }
@@ -168,14 +168,10 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
 }
 
 // Bottom(base) of the expression stack (highest address).
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   return (intptr_t*)interpreter_frame_monitor_end() - 1;
 }
-
-inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
-  return &interpreter_frame_tos_address()[offset];
-}
-
 
 // monitor elements
 
@@ -206,6 +202,7 @@ inline intptr_t** frame::interpreter_frame_esp_addr() const {
 }
 
 // top of expression stack (lowest address)
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return *interpreter_frame_esp_addr() + 1;
 }
@@ -223,10 +220,6 @@ inline oop * frame::interpreter_frame_temp_oop_addr() const {
 // Beginning element is oldest element. Also begin is one past last monitor.
 inline BasicObjectLock * frame::interpreter_frame_monitor_begin() const {
   return (BasicObjectLock*)ijava_state();
-}
-
-inline BasicObjectLock * frame::interpreter_frame_monitor_end() const {
-  return interpreter_frame_monitors();
 }
 
 inline void frame::interpreter_frame_set_monitor_end(BasicObjectLock* monitors) {
@@ -277,15 +270,63 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 }
 
 inline oop frame::saved_oop_result(RegisterMap* map) const {
-  return *((oop*) map->location(Z_R2->as_VMReg()));  // R2 is return register.
+  return *((oop*) map->location(Z_R2->as_VMReg(), (intptr_t*) NULL));  // R2 is return register.
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
-  *((oop*) map->location(Z_R2->as_VMReg())) = obj;  // R2 is return register.
+  *((oop*) map->location(Z_R2->as_VMReg(), (intptr_t*) NULL)) = obj;  // R2 is return register.
 }
 
 inline intptr_t* frame::real_fp() const {
   return fp();
+}
+
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::compiled_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  Unimplemented();
+}
+
+inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool relative>
+inline intptr_t* frame::interpreter_frame_last_sp() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  Unimplemented();
+  return 0;
+}
+
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
+  Unimplemented();
+}
+
+inline void frame::set_unextended_sp(intptr_t* value) {
+  Unimplemented();
+}
+
+inline int frame::offset_unextended_sp() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
 }
 
 #endif // CPU_S390_FRAME_S390_INLINE_HPP

--- a/src/hotspot/cpu/s390/instanceStackChunkKlass_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/instanceStackChunkKlass_s390.inline.hpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_S390_INSTANCESTACKCHUNKKLASS_S390_INLINE_HPP
+#define CPU_S390_INSTANCESTACKCHUNKKLASS_S390_INLINE_HPP
+
+#include "interpreter/oopMapCache.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+int InstanceStackChunkKlass::metadata_words() {
+  Unimplemented();
+  return 0;
+}
+
+int InstanceStackChunkKlass::align_wiggle()   {
+  Unimplemented();
+  return 0;
+}
+
+#ifdef ASSERT
+template <bool mixed>
+inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+  Unimplemented();
+  return true;
+}
+#endif
+
+template <bool mixed>
+inline frame StackChunkFrameStream<mixed>::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+template <bool mixed>
+inline address StackChunkFrameStream<mixed>::get_pc() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+  Unimplemented();
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template <bool mixed>
+template <typename RegisterMapT>
+inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+
+// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+class SmallRegisterMap {
+public:
+  static constexpr SmallRegisterMap* instance = nullptr;
+private:
+  static void assert_is_rfp(VMReg r) PRODUCT_RETURN 
+                                     DEBUG_ONLY({ Unimplemented(); })
+public:
+  // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
+  // Consider enhancing SmallRegisterMap to support those cases
+  const RegisterMap* as_RegisterMap() const { return nullptr; }
+  RegisterMap* as_RegisterMap() { return nullptr; }
+
+  RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
+    Unimplemented();
+    return map;
+  }
+  
+  SmallRegisterMap() {}
+
+  SmallRegisterMap(const RegisterMap* map) {
+    Unimplemented();
+  }
+
+  inline address location(VMReg reg, intptr_t* sp) const {
+    Unimplemented();
+    return NULL;
+  }
+
+  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+
+  JavaThread* thread() const {
+  #ifndef ASSERT
+    guarantee (false, ""); 
+  #endif
+    return nullptr;
+  }
+
+  bool update_map()    const { return false; }
+  bool walk_cont()     const { return false; }
+  bool include_argument_oops() const { return false; }
+  void set_include_argument_oops(bool f)  {}
+  bool in_cont()       const { return false; }
+  stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
+  
+#ifdef ASSERT
+  bool should_skip_missing() const  { return false; }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
+    Unimplemented();
+    return NULL;
+  }
+  void print() const { print_on(tty); }
+  void print_on(outputStream* st) const { st->print_cr("Small register map"); }
+#endif
+};
+
+#endif // CPU_S390_INSTANCESTACKCHUNKKLASS_S390_INLINE_HPP

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -654,4 +654,35 @@ class NativeGeneralJump: public NativeInstruction {
   void verify() PRODUCT_RETURN;
 };
 
+class NativePostCallNop: public NativeInstruction {
+public:
+  bool check() const { Unimplemented(); return false; }
+  int displacement() const { Unimplemented(); return 0; }
+  void patch(jint diff) { Unimplemented(); }
+  void make_deopt() { Unimplemented(); }
+};
+
+inline NativePostCallNop* nativePostCallNop_at(address address) {
+  Unimplemented();
+  return NULL;
+}
+
+class NativeDeoptInstruction: public NativeInstruction {
+public:
+  address instruction_address() const       { Unimplemented(); return NULL; }
+  address next_instruction_address() const  { Unimplemented(); return NULL; }
+
+  void  verify() { Unimplemented(); }
+
+  static bool is_deopt_at(address instr) {
+    Unimplemented();
+    return false;
+  }
+
+  // MT-safe patching
+  static void insert(address code_pos) {
+    Unimplemented();
+  }
+};
+
 #endif // CPU_S390_NATIVEINST_S390_HPP

--- a/src/hotspot/cpu/s390/registerMap_s390.hpp
+++ b/src/hotspot/cpu/s390/registerMap_s390.hpp
@@ -37,7 +37,7 @@
   address pd_location(VMReg reg) const {return NULL;}
 
   address pd_location(VMReg base_reg, int slot_idx) const {
-    return location(base_reg->next(slot_idx));
+    return location(base_reg->next(slot_idx), (intptr_t*) NULL);
   }
 
   // No PD state to clear or copy.

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2449,6 +2449,6 @@ class StubGenerator: public StubCodeGenerator {
 
 };
 
-void StubGenerator_generate(CodeBuffer* code, bool all) {
-  StubGenerator g(code, all);
+void StubGenerator_generate(CodeBuffer* code, int phase) {
+  StubGenerator g(code, phase);
 }

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -482,6 +482,11 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
   return __ addr_at(entry_offset);
 }
 
+address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  Unimplemented();
+  return NULL;
+}
+
 address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   // Inputs:
   //  Z_ARG1 - receiver

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -35,7 +35,7 @@ const int ContinuationHelper::align_wiggle = 1;
 #ifdef ASSERT
 bool Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
-  address pc = *(address*)(sp - SENDER_SP_RET_ADDRESS_OFFSET);
+  address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
   intptr_t* fp = *(intptr_t**)(sp - frame::sender_sp_offset);
   assert (f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
   assert (f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
@@ -407,7 +407,7 @@ intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
   log_develop_trace(jvmcont)("push_interpreter_return_frame initial sp: " INTPTR_FORMAT " final sp: " INTPTR_FORMAT " fp: " INTPTR_FORMAT, p2i(sp), p2i(sp - ContinuationHelper::frame_metadata), p2i(fp));
 
   sp -= ContinuationHelper::frame_metadata;
-  *(address*)(sp - SENDER_SP_RET_ADDRESS_OFFSET) = pc;
+  *(address*)(sp - frame::sender_sp_ret_address_offset()) = pc;
   *(intptr_t**)(sp - frame::sender_sp_offset) = fp;
   return sp;
 }

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -389,6 +389,10 @@ inline bool frame::is_interpreted_frame() const {
   return Interpreter::contains(pc());
 }
 
+int frame::sender_sp_ret_address_offset() {
+  return frame::sender_sp_offset - frame::return_addr_offset;
+}
+
 inline const ImmutableOopMap* frame::get_oop_map() const {
   if (_cb == NULL) return NULL;
   if (_cb->oop_maps() != NULL) {

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ZERO_CONTINUATION_ZERO_INLINE_HPP
+#define CPU_ZERO_CONTINUATION_ZERO_INLINE_HPP
+
+#include "oops/instanceStackChunkKlass.inline.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
+
+// TODO: Implement
+const int ContinuationHelper::frame_metadata = 0;
+const int ContinuationHelper::align_wiggle = 0;
+
+#ifdef ASSERT
+bool Frame::assert_frame_laid_out(frame f) {
+  Unimplemented();
+  return false;
+}
+#endif
+
+inline intptr_t** Frame::callee_link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+static inline intptr_t* real_fp(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
+static inline intptr_t** link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address* Interpreted::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline address* Frame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address Frame::real_pc(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void Frame::patch_pc(const frame& f, address pc) {
+  Unimplemented();
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+template <bool relative>
+inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind, typename RegisterMapT>
+inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+template<typename RegisterMapT>
+inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::push_pd(const frame& f) {
+  Unimplemented();
+}
+
+// creates the yield stub frame faster than JavaThread::last_frame
+inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+  Unimplemented();
+  return frame();
+}
+
+frame ContinuationEntry::to_frame() {
+  Unimplemented();
+  return frame();
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind>
+inline frame Freeze<ConfigT>::sender(const frame& f) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+template <typename FKind, bool bottom>
+inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Freeze<ConfigT>::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline frame Thaw<ConfigT>::new_entry_frame() {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+template<typename FKind, bool bottom>
+inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+intptr_t* Thaw<ConfigT>::push_interpreter_return_frame(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
+template <typename ConfigT>
+void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
+  Unimplemented();
+}
+
+template <typename ConfigT>
+inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
+  Unimplemented();
+  return NULL;
+}
+
+#endif // CPU_ZERO_CONTINUATION_ZERO_INLINE_HPP

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -98,7 +98,12 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return get_interpreterState()->monitor_base();
 }
 
-BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+// Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
+template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+
+template <bool relative>
+inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_interpreterState()->stack_base();
 }
 
@@ -181,15 +186,12 @@ BasicType frame::interpreter_frame_result(oop* oop_result,
   return type;
 }
 
-int frame::frame_size(RegisterMap* map) const {
-#ifdef PRODUCT
-  ShouldNotCallThis();
-#endif // PRODUCT
-  return 0; // make javaVFrame::print_value work
-}
+template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
 
+template <bool relative>
 intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
-  int index = (Interpreter::expr_offset_in_bytes(offset) / wordSize);
+  int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
   return &interpreter_frame_tos_address()[index];
 }
 
@@ -380,6 +382,10 @@ void ZeroFrame::identify_vp_word(int       frame_index,
 #ifndef PRODUCT
 
 void frame::describe_pd(FrameValues& values, int frame_no) {
+
+}
+
+void frame::describe_top_pd(FrameValues& values) {
 
 }
 

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -33,7 +33,9 @@
     pc_return_offset = 0
   };
 
-  // Constructor
+ const ImmutableOopMap* get_oop_map() const;
+
+ // Constructor
  public:
   frame(ZeroFrame* zeroframe, intptr_t* sp);
 
@@ -72,5 +74,10 @@
                            int           buflen) const;
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
+
+  inline address* sender_pc_addr() const;
+
+  template <bool relative = false>
+  inline intptr_t* interpreter_frame_last_sp() const;
 
 #endif // CPU_ZERO_FRAME_ZERO_HPP

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -40,6 +40,10 @@ inline frame::frame() {
 
 inline address  frame::sender_pc()           const { ShouldNotCallThis(); return NULL; }
 
+inline frame::frame(intptr_t* sp) {
+  Unimplemented();
+}
+
 inline frame::frame(ZeroFrame* zf, intptr_t* sp) {
   _zeroframe = zf;
   _sp = sp;
@@ -111,6 +115,7 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
   return NULL; // silence compiler warnings
 }
 
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return get_interpreterState()->_stack + 1;
 }
@@ -124,6 +129,7 @@ inline int frame::interpreter_frame_monitor_size() {
   return BasicObjectLock::size();
 }
 
+template <bool relative>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
   return monitor_end - 1;
@@ -161,6 +167,66 @@ inline intptr_t* frame::entry_frame_argument_at(int offset) const {
 
 inline intptr_t* frame::unextended_sp() const {
   return (intptr_t *) -1;
+}
+
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::compiled_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  Unimplemented();
+}
+
+inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool relative>
+inline intptr_t* frame::interpreter_frame_last_sp() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  Unimplemented();
+  return 0;
+}
+
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
+  Unimplemented();
+}
+
+inline void frame::set_unextended_sp(intptr_t* value) {
+  Unimplemented();
+}
+
+inline int frame::offset_unextended_sp() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
+}
+
+inline int frame::frame_size() const {
+#ifdef PRODUCT
+  ShouldNotCallThis();
+#endif // PRODUCT
+  return 0; // make javaVFrame::print_value work
+}
+
+inline address* frame::sender_pc_addr() const {
+  ShouldNotCallThis();
+  return NULL;
 }
 
 #endif // CPU_ZERO_FRAME_ZERO_INLINE_HPP

--- a/src/hotspot/cpu/zero/instanceStackChunkKlass_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/instanceStackChunkKlass_zero.inline.hpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_ZERO_INSTANCESTACKCHUNKKLASS_ZERO_INLINE_HPP
+#define CPU_ZERO_INSTANCESTACKCHUNKKLASS_ZERO_INLINE_HPP
+
+#include "interpreter/oopMapCache.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+int InstanceStackChunkKlass::metadata_words() {
+  Unimplemented();
+  return 0;
+}
+
+int InstanceStackChunkKlass::align_wiggle()   {
+  Unimplemented();
+  return 0;
+}
+
+#ifdef ASSERT
+template <bool mixed>
+inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+  Unimplemented();
+  return true;
+}
+#endif
+
+template <bool mixed>
+inline frame StackChunkFrameStream<mixed>::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+template <bool mixed>
+inline address StackChunkFrameStream<mixed>::get_pc() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <bool mixed>
+inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+  Unimplemented();
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+template <bool mixed>
+inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template <bool mixed>
+template <typename RegisterMapT>
+inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+
+// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+class SmallRegisterMap {
+public:
+  static constexpr SmallRegisterMap* instance = nullptr;
+private:
+  static void assert_is_rfp(VMReg r) PRODUCT_RETURN 
+                                     DEBUG_ONLY({ Unimplemented(); })
+public:
+  // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
+  // Consider enhancing SmallRegisterMap to support those cases
+  const RegisterMap* as_RegisterMap() const { return nullptr; }
+  RegisterMap* as_RegisterMap() { return nullptr; }
+
+  RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
+    Unimplemented();
+    return map;
+  }
+  
+  SmallRegisterMap() {}
+
+  SmallRegisterMap(const RegisterMap* map) {
+    Unimplemented();
+  }
+
+  inline address location(VMReg reg, intptr_t* sp) const {
+    Unimplemented();
+    return NULL;
+  }
+
+  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+
+  JavaThread* thread() const {
+  #ifndef ASSERT
+    guarantee (false, ""); 
+  #endif
+    return nullptr;
+  }
+
+  bool update_map()    const { return false; }
+  bool walk_cont()     const { return false; }
+  bool include_argument_oops() const { return false; }
+  void set_include_argument_oops(bool f)  {}
+  bool in_cont()       const { return false; }
+  stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
+  
+#ifdef ASSERT
+  bool should_skip_missing() const  { return false; }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
+    Unimplemented();
+    return NULL;
+  }
+  void print() const { print_on(tty); }
+  void print_on(outputStream* st) const { st->print_cr("Small register map"); }
+#endif
+};
+
+#endif // CPU_ZERO_INSTANCESTACKCHUNKKLASS_ZERO_INLINE_HPP

--- a/src/hotspot/cpu/zero/nativeInst_zero.hpp
+++ b/src/hotspot/cpu/zero/nativeInst_zero.hpp
@@ -211,4 +211,35 @@ inline NativeGeneralJump* nativeGeneralJump_at(address address) {
   return NULL;
 }
 
+class NativePostCallNop: public NativeInstruction {
+public:
+  bool check() const { Unimplemented(); return false; }
+  int displacement() const { Unimplemented(); return 0; }
+  void patch(jint diff) { Unimplemented(); }
+  void make_deopt() { Unimplemented(); }
+};
+
+inline NativePostCallNop* nativePostCallNop_at(address address) {
+  Unimplemented();
+  return NULL;
+}
+
+class NativeDeoptInstruction: public NativeInstruction {
+public:
+  address instruction_address() const       { Unimplemented(); return NULL; }
+  address next_instruction_address() const  { Unimplemented(); return NULL; }
+
+  void  verify() { Unimplemented(); }
+
+  static bool is_deopt_at(address instr) {
+    Unimplemented();
+    return false;
+  }
+
+  // MT-safe patching
+  static void insert(address code_pos) {
+    Unimplemented();
+  }
+};
+
 #endif // CPU_ZERO_NATIVEINST_ZERO_HPP

--- a/src/hotspot/cpu/zero/registerMap_zero.hpp
+++ b/src/hotspot/cpu/zero/registerMap_zero.hpp
@@ -35,7 +35,7 @@
   address pd_location(VMReg reg) const { return NULL; }
 
   address pd_location(VMReg base_reg, int slot_idx) const {
-    return location(base_reg->next(slot_idx));
+    return location(base_reg->next(slot_idx), (intptr_t*) NULL);
   }
 
   // no PD state to clear or copy:

--- a/src/hotspot/cpu/zero/stubGenerator_zero.cpp
+++ b/src/hotspot/cpu/zero/stubGenerator_zero.cpp
@@ -306,8 +306,8 @@ class StubGenerator: public StubCodeGenerator {
   }
 };
 
-void StubGenerator_generate(CodeBuffer* code, bool all) {
-  StubGenerator g(code, all);
+void StubGenerator_generate(CodeBuffer* code, int phase) {
+  StubGenerator g(code, phase);
 }
 
 EntryFrame *EntryFrame::build(const intptr_t*  parameters,

--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -123,7 +123,7 @@ void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame 
 #ifndef VM_LITTLE_ENDIAN
         VMReg vmReg = omv.reg();
         // Don't do this on SPARC float registers as they can be individually addressed
-        if (!vmReg->is_stack() SPARC_ONLY(&& !vmReg->is_FloatRegister())) {
+        if (!vmReg->is_stack()) {
           // compressed oops in registers only take up 4 bytes of an
           // 8 byte register but they are in the wrong part of the
           // word so adjust loc to point at the right place.

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -46,7 +46,6 @@
 #include "oops/cpCache.inline.hpp"
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/klass.inline.hpp"
-#include "oops/method.hpp"
 #include "oops/method.inline.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/objArrayOop.hpp"
@@ -58,6 +57,7 @@
 #include "runtime/reflection.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/signature.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.inline.hpp"
 #include "runtime/vmThread.hpp"
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -784,7 +784,11 @@ public:
 
   bool do_bit(BitMap::idx_t index) override {
     OopT* p = _chunk->address_for_bit<OopT>(index);
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
     if ((intptr_t*)p < _top && (intptr_t*)p != _chunk->sp_address() - frame::sender_sp_offset) return true; // skip oops that are not seen by the oopmap scan
+#else
+    Unimplemented();
+#endif
 
     log_develop_trace(jvmcont)("debug_verify_stack_chunk bitmap oop p: " INTPTR_FORMAT " index: %lu bit_offset: %lu", p2i(p), index, _chunk->bit_offset());
     _count++;
@@ -804,7 +808,12 @@ public:
       InterpreterOopMap mask;
       frame fr = f.to_frame();
       fr.interpreted_frame_oop_map(&mask);
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
       _top = fr.addr_at(frame::interpreter_frame_initial_sp_offset) - mask.expression_stack_size();
+#else
+      Unimplemented();
+      _top = 0;
+#endif
     } else if (f.is_compiled()) {
       Method* callee = f.cb()->as_compiled_method()->attached_method_before_pc(f.pc());
       if (callee != nullptr) {
@@ -812,7 +821,12 @@ public:
         _top = f.unextended_sp() + outgoing_args_words;
       } else {
         _top = f.unextended_sp();
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
         _next = _top + f.cb()->frame_size() - frame::sender_sp_offset;
+#else
+        Unimplemented();
+        _next = 0;
+#endif
         _exact = false;
       }
     } else {

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -28,7 +28,7 @@
 
 #include "classfile/javaClasses.hpp"
 #include "code/codeBlob.hpp"
-#include "code/codeCache.hpp"
+#include "code/codeCache.inline.hpp"
 #include "code/nativeInst.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -103,7 +103,12 @@ inline bool stackChunkOopDesc::is_in_chunk(void* p) const {
 
 bool stackChunkOopDesc::is_usable_in_chunk(void* p) const {
   assert (is_stackChunk(), "");
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
   HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset;
+#else
+  Unimplemented();
+  HeapWord* start = NULL;
+#endif
   HeapWord* end = start + stack_size();
   return (HeapWord*)p >= start && (HeapWord*)p < end;
 }

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -123,6 +123,11 @@ class frame {
   int frame_index() const { return _frame_index; }
   void set_frame_index( int index ) { _frame_index = index; }
 
+  static int sender_sp_ret_address_offset();
+
+  template <typename RegisterMapT>
+  static void update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr);
+
   CodeBlob* cb() const           { return _cb; }
   inline CodeBlob* get_cb() const;
   // inline void set_cb(CodeBlob* cb);


### PR DESCRIPTION
This WIP provides enough stubs to make Loom cross-compilable to PPC64, S390, ARM32 and Zero. This should be enough to get the sense where the shared code actually platform-specific (referencing stuff from `frame` that is platform-specific), what should be implemented for a platform, and also should be enough to get GHA build checks green.

Note that ARM32 builds would not be clean until #65 is integrated with 32-bit cleanliness fixes.