### PR TITLE
Loom test groups for development/porting use

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -99,16 +99,16 @@ tier1_loom = \
   :tier1_loom_serviceability
 
 tier1_loom_runtime = \
-  runtime/vthread
+  runtime/vthread \
+  runtime/jni/IsVirtualThread
 
 tier1_loom_serviceability = \
   serviceability/jvmti/vthread \
-  serviceability/jvmti/events
+  serviceability/jvmti/events \
+  serviceability/dcmd/thread
 
 hotspot_loom = \
-  :tier1_loom \
-  runtime/jni/IsVirtualThread \
-  serviceability/dcmd/thread
+  :tier1_loom
 
 tier1_common = \
   sanity/BasicVMTest.java \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -96,11 +96,9 @@ jdk_loom = \
     com/sun/management/HotSpotDiagnosticMXBean/ \
     java/lang/Thread \
     java/lang/ThreadGroup \
-    java/lang/Throwable \
     java/lang/ScopeLocal \
     java/lang/management/ThreadMXBean \
-    java/util/concurrent/ExecutorService \
-    java/util/concurrent/Future \
+    java/util/concurrent/ \
     jdk/internal/vm/Continuation \
     jdk/jfr/threading
 


### PR DESCRIPTION
Porting/development work would be much simpler if we had a comprehensive test group with Loom-specific tests. There is `tier1_loom`, but it probably has a separate meaning. We can add some test groups with Loom-specific tests. I basically went and added tests that are added/substantially-modified by Loom, judging by a [recent webrev](https://builds.shipilev.net/patch-openjdk-loom-fibers/).

Sample run:

```
$ time CONF=linux-x86_64-server-fastdebug make test TEST="hotspot_loom jdk_loom"
...
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg:hotspot_loom                63    63     0     0   
   jtreg:test/jdk:jdk_loom                             187   187     0     0   
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-x86_64-server-fastdebug'

real	6m37.938s
user	54m13.043s
sys	2m12.437s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/loom pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/74.diff">https://git.openjdk.java.net/loom/pull/74.diff</a>

</details>
