### PR TITLE
Fix non-supported platforms release builds

### DIFF
--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -3207,7 +3207,12 @@ frame Continuation::continuation_parent_frame(RegisterMap* map) {
 
   map->set_stack_chunk(nullptr);
 
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
   frame sender(cont.entrySP(), cont.entryFP(), cont.entryPC());
+#else
+  frame sender = frame();
+  Unimplemented();
+#endif
 
   // tty->print_cr("continuation_parent_frame");
   // print_vframe(sender, map, nullptr);


### PR DESCRIPTION
It seems when doing #72, I missed a spot that makes release builds fail for non-supported platforms. I am not sure why fastdebug passes, but oh well. The fix is to platform-ifdef the offending block, like we do in other places.

Additional testing:
 - [x] Linux x86_64 Zero release builds now
 - [x] Linux x86_64 Server fastdebug/release pass `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.java.net/loom pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/75.diff">https://git.openjdk.java.net/loom/pull/75.diff</a>

</details>
