### PR TITLE
Remove -XX:ContPerfTest

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7906,21 +7906,18 @@ RuntimeStub* generate_cont_doYield() {
 
     __ post_call_nop(); // this must be exactly after the pc value that is pushed into the frame info, we use this nop for fast CodeBlob lookup
 
-    if (ContPerfTest > 5) {
-      Register thread = get_thread();
-      NOT_LP64(__ push(thread));
-      LP64_ONLY(__ movptr(c_rarg0, thread));
-      __ set_last_Java_frame(rsp, rbp, the_pc);
+    Register thread = get_thread();
+    NOT_LP64(__ push(thread));
+    LP64_ONLY(__ movptr(c_rarg0, thread));
+    __ set_last_Java_frame(rsp, rbp, the_pc);
 
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::freeze), 2);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::freeze), 2);
       
-      __ reset_last_Java_frame(true);
-      NOT_LP64(__ pop(rdi));
-    }
+    __ reset_last_Java_frame(true);
+    NOT_LP64(__ pop(rdi));
 
     Label pinned;
 
-    if (ContPerfTest <= 5) { __ xorq(rax, rax); }
     __ testq(rax, rax);
     __ jcc(Assembler::notZero, pinned);
 
@@ -7983,12 +7980,9 @@ RuntimeStub* generate_cont_doYield() {
     }
 
     __ movl(c_rarg1, (return_barrier ? 1 : 0) + (exception ? 1 : 0));
-    if (ContPerfTest > 105) {
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::prepare_thaw), r15_thread, c_rarg1);
-      __ movptr(rbx, rax); // rax contains the size of the frames to thaw, 0 if overflow or no more frames
-    } else {
-      __ xorq(rbx, rbx);
-    }
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::prepare_thaw), r15_thread, c_rarg1);
+    __ movptr(rbx, rax); // rax contains the size of the frames to thaw, 0 if overflow or no more frames
+
     if (return_barrier) {
       __ pop_d(xmm0); __ pop(rax); // restore return value (no safepoint in the call to thaw, so even an oop return value should be OK)
     }
@@ -8012,9 +8006,7 @@ RuntimeStub* generate_cont_doYield() {
     }
 
     __ movl(c_rarg1, (return_barrier ? 1 : 0) + (exception ? 1 : 0));
-    if (ContPerfTest > 112) {
-      __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::thaw), r15_thread, c_rarg1);
-    }
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, Continuation::thaw), r15_thread, c_rarg1);
     __ movptr(rbx, rax); // rax is the sp of the yielding frame
 
     if (return_barrier) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1729,9 +1729,6 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, UseNewCode3, false, DIAGNOSTIC,                             \
           "Testing Only: Use the new version while testing")                \
                                                                             \
-  product(intx, ContPerfTest, 1000, DIAGNOSTIC,                             \
-          "Testing Only: Use the new version while testing")                \
-                                                                            \
   notproduct(bool, UseDebuggerErgo, false,                                  \
           "Debugging Only: Adjust the VM to be more debugger-friendly. "    \
           "Turns on the other UseDebuggerErgo* flags")                      \


### PR DESCRIPTION
When porting to x86_32, I noticed there is a diagnostic `ContPerfTest` option which effectively takes different paths, depending on diagnostic setting. Is it still useful? For a cleanup/preparation-for-upstreaming, I propose we roll it back.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/loom pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/76.diff">https://git.openjdk.java.net/loom/pull/76.diff</a>

</details>
