### PR TITLE
Drop x86_32 code from x86_64-specific files

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7940,6 +7940,7 @@ RuntimeStub* generate_cont_doYield() {
 
     address start = __ pc();
 
+    __ get_thread(r15_thread);
     __ reset_last_Java_frame(true); // false would be fine, too, I guess
     __ reinit_heapbase();
     


### PR DESCRIPTION
There are instances of x86_32 code in x86_64-specific files. That code would not be ever used and thus would bit rot, as it would never be compiled on x86_32. The porting to x86_32 would make the x86_32-specific versions of the StubGenerator. This simplifies x86_64 StubGenerator a bit.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/loom pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/77.diff">https://git.openjdk.java.net/loom/pull/77.diff</a>

</details>
