### PR TITLE
Harmonize actual and expected signature of Continuation.doYield

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -358,7 +358,6 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
 
 void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
   BasicTypeList signature(0);
-  // signature.append(T_INT);
   CallingConvention* cc = frame_map()->java_calling_convention(&signature, true);
 
   const LIR_Opr result_reg = result_register_for(x->type());

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -512,7 +512,7 @@ class methodHandle;
   do_signature(continuationGetStacks_signature, "(III)V")                                                               \
   do_alias(continuationOnPinned_signature,      int_void_signature)                                                     \
   do_intrinsic(_Continuation_doYield, jdk_internal_vm_Continuation,  doYield_name, continuationDoYield_signature, F_S)  \
-    do_alias(continuationDoYield_signature,     int_int_signature)                                                      \
+    do_alias(continuationDoYield_signature,     void_int_signature)                                                     \
                                                                                                                         \
   /* support for UnsafeConstants */                                                                                     \
   do_class(jdk_internal_misc_UnsafeConstants,      "jdk/internal/misc/UnsafeConstants")                                 \

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7275,8 +7275,6 @@ Node* LibraryCallKit::inline_digestBase_implCompressMB_predicate(int predicate) 
 
 bool LibraryCallKit::inline_continuation_do_yield() {
   address call_addr = StubRoutines::cont_doYield();
-  // Node* arg0 = argument(0); // type int - scopes
-  // Node* arg0 = intcon(0); // type int - from interpreter
   const TypeFunc* tf = OptoRuntime::continuation_doYield_Type();
   Node* call = make_runtime_call(RC_NO_LEAF, tf, call_addr, "doYield", TypeRawPtr::BOTTOM);
   Node* result = _gvn.transform(new ProjNode(call, TypeFunc::Parms));

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -727,15 +727,16 @@ const TypeFunc* OptoRuntime::void_void_Type() {
  }
 
  const TypeFunc* OptoRuntime::continuation_doYield_Type() {
+   // create input type (domain)
    const Type **fields = TypeTuple::fields(0);
-  //  fields[TypeFunc::Parms+0] = TypeInt::INT;
-   const TypeTuple *args = TypeTuple::make(TypeFunc::Parms+0, fields);
+   const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+0, fields);
 
+   // create result type (range)
    fields = TypeTuple::fields(1);
    fields[TypeFunc::Parms+0] = TypeInt::INT;
-   const TypeTuple *result = TypeTuple::make(TypeFunc::Parms+1, fields);
+   const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+1, fields);
 
-   return TypeFunc::make(args, result);
+   return TypeFunc::make(domain, range);
  }
 
  const TypeFunc* OptoRuntime::continuation_jump_Type() {

--- a/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -352,7 +352,7 @@ public class Continuation {
     }
 
     @IntrinsicCandidate
-    private static int doYield(int scopes) { throw new Error("Intrinsic not installed"); };
+    private static int doYield() { throw new Error("Intrinsic not installed"); };
 
     @IntrinsicCandidate
     private native static void enterSpecial(Continuation c, boolean isContinue);
@@ -411,7 +411,7 @@ public class Continuation {
 
         if (scope != this.scope)
             this.yieldInfo = scope;
-        int res = doYield(0);
+        int res = doYield();
         unsafe.storeFence(); // needed to prevent certain transformations by the compiler
         
         if (TRACE) System.out.println(this + " awake on scope " + scope + " child: " + child + " res: " + res + " yieldInfo: " + yieldInfo);


### PR DESCRIPTION
Found this inconsistency when reading the Loom code during x86_32 porting. `Continuation.doYield` has an `int` argument, yet C2's `OptoRuntime::continuation_doYield_Type` does not declare it. I think this is basically asking for trouble in C2, as the optimizations may ask the function type, discover there is an input of type `int`, but no such input is actually present. Runtime stubs seem to be also oblivious there is an argument, and calling conventions probably put it in the register on x86_64 and AArch64. On other arches, that might not be true.

I don't believe it breaks anything now, but let's fix it, while we are at it. It looks to me that `Continuation.doYield` is ever called with `0`, so we might just drop its `int` argument? Not sure if `scopes` is something Java code plans to use.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/loom pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/78.diff">https://git.openjdk.java.net/loom/pull/78.diff</a>

</details>
