### PR TITLE
Ensure compensate when ForkJoinWorkerThread is pinned

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/VTCompensate.java
+++ b/test/jdk/java/lang/Thread/virtual/VTCompensate.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @compile --enable-preview -source ${jdk.version} VTCompensate.java
+ * @run testng/othervm --enable-preview -Djdk.defaultScheduler.parallelism=1 -Djdk.tracePinnedThreads=full VTCompensate
+ * @summary Basic test for ForkJoinPool to compensate when all threads are pinned.
+ */
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.locks.ReentrantLock;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class VTCompensate {
+    @Test
+    public static void test() throws Exception {
+        ThreadFactory tf = Thread.ofVirtual().name("vt", 0).factory();
+        // VT0, VT1, main
+        // 1. main acquire lock
+        // 2. VT0 start, acquire lock and park
+        // 3. VT1 start, acquire lock and pin
+        // 4. main release lock and unpack VT0
+        // 5. dead in VT1 and VT0, no VT can run
+        ReentrantLock lock = new ReentrantLock();
+        Runnable vt0_r = new Runnable() {
+            @Override
+            public void run() {
+                lock.lock();
+                System.out.println("vt0 get lock " + Thread.currentThread());
+                lock.unlock();
+            }
+        };
+        Runnable vt1_r = new Runnable() {
+            @Override
+            public void run() {
+                synchronized (this) {
+                    lock.lock();
+                }
+                System.out.println("vt1 get lock " + Thread.currentThread());
+                lock.unlock();
+            }
+        };
+        Thread vt0 = Thread.ofVirtual().name("vt0").unstarted(vt0_r);
+        Thread vt1 = Thread.ofVirtual().name("vt1").unstarted(vt1_r);
+        lock.lock();
+        System.out.println("main lock");
+        vt0.start();
+        Thread.sleep(1000);
+        vt1.start();
+        // wait vt1 pin and unlock
+        while (true) {
+            if (vt1.getState() == Thread.State.WAITING) {
+                break;
+            }
+        }
+        lock.unlock();
+        System.out.println("main release");
+        vt0.join();
+        assertEquals(vt0.getState(),  Thread.State.TERMINATED);
+        vt1.join();
+        assertEquals(vt1.getState(),  Thread.State.TERMINATED);
+    }
+}


### PR DESCRIPTION
Hello,
We have a test case about Loom, it can pass before;
The test case can be seen on this PR;
 
But it cannot pass after this patch:
```
commit de90a43c7a5f0b28bd0af9271de210475808ca0c
Author: Alan Bateman <alan.bateman@oracle.com>
Date:   Wed Sep 1 09:22:23 2021 +0100
 
    Replace lock/condition objects to simplify pinned park
```
 
Actually, this modify cause the test fail, because getCondition.await() will call tryCompensate() of ForkJoinPool eventually:
```
+    private void parkOnCarrierThread(long nanos) {

-                if (!parkPermit) {
-                    // wait to be signalled or interrupted
-                    getCondition().await();

+            if (!parkPermit) {
+                U.park(false, nanos);
             }
``` 
If ForkJoinWorkerThread are all pinned, how to make vt work correct?

Thanks，

Miao

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/loom pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/80.diff">https://git.openjdk.java.net/loom/pull/80.diff</a>

</details>
