### PR TITLE
8252388: Allocation without ResourceMark in InterpreterOopMap::resource_copy

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -58,7 +58,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   _pc = pc;
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
-  
+
   setup(pc);
 
   _oop_map = NULL;
@@ -143,7 +143,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   _cb = CodeCache::find_blob_fast(pc);
   _oop_map = NULL;
   assert(_cb != NULL, "pc: " INTPTR_FORMAT " sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " fp: " INTPTR_FORMAT, p2i(pc), p2i(sp), p2i(unextended_sp), p2i(fp));
-  
+
   setup(pc);
 }
 
@@ -248,13 +248,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Method* m = interpreter_frame_method();
   int   bci = interpreter_frame_bci();
   m->mask_for(bci, mask); // OopMapCache::compute_one_oop_map(m, bci, mask);
-}
-
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  return   mask->num_oops()
-        + 1 // for the mirror oop
-        + ((intptr_t*)interpreter_frame_monitor_begin() - (intptr_t*)interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 // helper to update a map with callee-saved RBP
@@ -461,7 +454,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     // outside of update_register_map.
     if (stub) { // compiled frames do not use callee-saved registers
       map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-      if (oop_map() != NULL) { 
+      if (oop_map() != NULL) {
         _oop_map->update_register_map(this, map);
       }
     } else {
@@ -476,11 +469,11 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     update_map_with_saved_link(map, saved_fp_addr);
   }
 
-  if (Continuation::is_return_barrier_entry(sender_pc)) {	
-    if (map->walk_cont()) { // about to walk into an h-stack 	
-      return Continuation::top_frame(*this, map);	
+  if (Continuation::is_return_barrier_entry(sender_pc)) {
+    if (map->walk_cont()) { // about to walk into an h-stack
+      return Continuation::top_frame(*this, map);
     } else {
-      Continuation::fix_continuation_bottom_sender(map->thread(), *this, &sender_pc, &sender_sp);	
+      Continuation::fix_continuation_bottom_sender(map->thread(), *this, &sender_pc, &sender_sp);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/instanceStackChunkKlass_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/instanceStackChunkKlass_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,9 +110,9 @@ inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
   // InterpreterOopMap mask;
   // to_frame().interpreted_frame_oop_map(&mask);
   // intptr_t* top = derelativize(frame::interpreter_frame_initial_sp_offset) - mask.expression_stack_size();
-  
+
   intptr_t* top = unextended_sp(); // later subtract argsize if callee is interpreted
-  intptr_t* bottom = derelativize(frame::interpreter_frame_locals_offset) + 1; // the sender's unextended sp: derelativize(frame::interpreter_frame_sender_sp_offset); 
+  intptr_t* bottom = derelativize(frame::interpreter_frame_locals_offset) + 1; // the sender's unextended sp: derelativize(frame::interpreter_frame_sender_sp_offset);
 
   // tty->print_cr(">>>> StackChunkFrameStream<mixed>::interpreter_frame_size bottom: %d top: %d size: %d", _chunk->to_offset(bottom - 1) + 1, _chunk->to_offset(top), (int)(bottom - top));
   return (int)(bottom - top);
@@ -129,6 +129,7 @@ inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const
 template <bool mixed>
 inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
   assert (mixed && is_interpreted(), "");
+  ResourceMark rm;
   InterpreterOopMap mask;
   frame f = to_frame();
   f.interpreted_frame_oop_map(&mask);
@@ -184,7 +185,7 @@ public:
     frame::update_map_with_saved_link(map, (intptr_t**)sp - frame::sender_sp_offset);
     return map;
   }
-  
+
   SmallRegisterMap() {}
 
   SmallRegisterMap(const RegisterMap* map) {
@@ -205,7 +206,7 @@ public:
 
   JavaThread* thread() const {
   #ifndef ASSERT
-    guarantee (false, ""); 
+    guarantee (false, "");
   #endif
     return nullptr;
   }
@@ -216,7 +217,7 @@ public:
   void set_include_argument_oops(bool f)  {}
   bool in_cont()       const { return false; }
   stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
-  
+
 #ifdef ASSERT
   bool should_skip_missing() const  { return false; }
   VMReg find_register_spilled_here(void* p, intptr_t* sp) { return rfp->as_VMReg(); }

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,11 +244,6 @@ inline int frame::compiled_frame_stack_argsize() const {
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
-}
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  Unimplemented();
-  return 0;
 }
 
 template <bool relative>

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -226,11 +226,6 @@ inline int frame::compiled_frame_stack_argsize() const {
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
-}
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  Unimplemented();
-  return 0;
 }
 
 template <bool relative>

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -293,11 +293,6 @@ inline int frame::compiled_frame_stack_argsize() const {
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
-}
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  Unimplemented();
-  return 0;
 }
 
 template <bool relative>

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   _pc = pc;
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc); // not fast because this constructor can be used on native frames
-  
+
   setup(pc);
 
   _oop_map = NULL;
@@ -239,13 +239,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Method* m = interpreter_frame_method();
   int   bci = interpreter_frame_bci();
   m->mask_for(bci, mask); // OopMapCache::compute_one_oop_map(m, bci, mask);
-}
-
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  return   mask->num_oops()
-        + 1 // for the mirror oop
-        + ((intptr_t*)interpreter_frame_monitor_begin() - (intptr_t*)interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 // helper to update a map with callee-saved RBP
@@ -453,7 +446,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     // outside of update_register_map.
     if (stub) { // compiled frames do not use callee-saved registers
       map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-      if (oop_map() != NULL) { 
+      if (oop_map() != NULL) {
         _oop_map->update_register_map(this, map);
       }
     } else {
@@ -470,11 +463,11 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
 
   assert(sender_sp != sp(), "must have changed");
 
-  if (Continuation::is_return_barrier_entry(sender_pc)) {	
-    if (map->walk_cont()) { // about to walk into an h-stack 	
-      return Continuation::top_frame(*this, map);	
+  if (Continuation::is_return_barrier_entry(sender_pc)) {
+    if (map->walk_cont()) { // about to walk into an h-stack
+      return Continuation::top_frame(*this, map);
     } else {
-      Continuation::fix_continuation_bottom_sender(map->thread(), *this, &sender_pc, &sender_sp);	
+      Continuation::fix_continuation_bottom_sender(map->thread(), *this, &sender_pc, &sender_sp);
     }
   }
 

--- a/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,9 +110,9 @@ inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
   // InterpreterOopMap mask;
   // to_frame().interpreted_frame_oop_map(&mask);
   // intptr_t* top = derelativize(frame::interpreter_frame_initial_sp_offset) - mask.expression_stack_size();
-  
+
   intptr_t* top = unextended_sp(); // later subtract argsize if callee is interpreted
-  intptr_t* bottom = derelativize(frame::interpreter_frame_locals_offset) + 1; // the sender's unextended sp: derelativize(frame::interpreter_frame_sender_sp_offset); 
+  intptr_t* bottom = derelativize(frame::interpreter_frame_locals_offset) + 1; // the sender's unextended sp: derelativize(frame::interpreter_frame_sender_sp_offset);
 
   // tty->print_cr(">>>> StackChunkFrameStream<mixed>::interpreter_frame_size bottom: %d top: %d size: %d", _chunk->to_offset(bottom - 1) + 1, _chunk->to_offset(top), (int)(bottom - top));
   return (int)(bottom - top);
@@ -129,6 +129,7 @@ inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const
 template <bool mixed>
 inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
   assert (mixed && is_interpreted(), "");
+  ResourceMark rm;
   InterpreterOopMap mask;
   frame f = to_frame();
   f.interpreted_frame_oop_map(&mask);
@@ -184,7 +185,7 @@ public:
     frame::update_map_with_saved_link(map, (intptr_t**)sp - frame::sender_sp_offset);
     return map;
   }
-  
+
   SmallRegisterMap() {}
 
   SmallRegisterMap(const RegisterMap* map) {
@@ -205,7 +206,7 @@ public:
 
   JavaThread* thread() const {
   #ifndef ASSERT
-    guarantee (false, ""); 
+    guarantee (false, "");
   #endif
     return nullptr;
   }

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -181,11 +181,6 @@ inline int frame::compiled_frame_stack_argsize() const {
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
-}
-
-inline int frame::interpreted_frame_num_oops(InterpreterOopMap* mask) const {
-  Unimplemented();
-  return 0;
 }
 
 template <bool relative>

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -755,7 +755,7 @@ public:
     _count++;
 
     log_develop_trace(jvmcont)("debug_verify_stack_chunk bitmap p: " INTPTR_FORMAT " i: " SIZE_FORMAT, p2i(p), index);
-    
+
     if (!SafepointSynchronize::is_at_safepoint()) {
       oop obj = safe_load(p);
       assert (obj == nullptr || is_good_oop(obj),
@@ -941,7 +941,7 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops, i
   if (closure._cb != nullptr && closure._cb->is_compiled()) {
     assert (chunk->argsize() == (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord,
       "chunk argsize: %d bottom frame argsize: %d", chunk->argsize(), (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord);
-  } 
+  }
 
   assert (closure._num_interpreted_frames == 0 || chunk->has_mixed_frames(), "");
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -671,7 +671,6 @@ public:
     }
 
     if (UseChunkBitmaps) {
-      // ResourceMark rm;
       BuildBitmapOopClosure<compressedOops> oops_closure(_chunk->start_address(), _chunk->bit_offset(), _chunk->bitmap());
       f.iterate_oops(&oops_closure, map);
     }
@@ -727,7 +726,6 @@ void InstanceStackChunkKlass::fix_thawed_frame(stackChunkOop chunk, const frame&
   if (chunk->has_bitmap() && UseCompressedOops) {
     FixCompressedOopClosure oop_closure;
     if (f.is_interpreted_frame()) {
-      ResourceMark rm;
       f.oops_interpreted_do(&oop_closure, nullptr);
     } else {
       OopMapDo<OopClosure, DerelativizeDerivedPointers, SkipNullValue> visitor(&oop_closure, nullptr);
@@ -757,7 +755,7 @@ public:
     _count++;
 
     log_develop_trace(jvmcont)("debug_verify_stack_chunk bitmap p: " INTPTR_FORMAT " i: " SIZE_FORMAT, p2i(p), index);
-
+    
     if (!SafepointSynchronize::is_at_safepoint()) {
       oop obj = safe_load(p);
       assert (obj == nullptr || is_good_oop(obj),
@@ -877,7 +875,6 @@ public:
     //   }
     // }
 
-    ResourceMark rm;
     StackChunkVerifyOopsClosure oops_closure(_chunk, f.sp());
     f.iterate_oops(&oops_closure, map);
     assert (oops_closure.count() == num_oops, "oops: %d oopmap->num_oops(): %d", oops_closure.count(), num_oops);
@@ -944,7 +941,7 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops, i
   if (closure._cb != nullptr && closure._cb->is_compiled()) {
     assert (chunk->argsize() == (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord,
       "chunk argsize: %d bottom frame argsize: %d", chunk->argsize(), (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord);
-  }
+  } 
 
   assert (closure._num_interpreted_frames == 0 || chunk->has_mixed_frames(), "");
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -671,6 +671,7 @@ public:
     }
 
     if (UseChunkBitmaps) {
+      // ResourceMark rm;
       BuildBitmapOopClosure<compressedOops> oops_closure(_chunk->start_address(), _chunk->bit_offset(), _chunk->bitmap());
       f.iterate_oops(&oops_closure, map);
     }
@@ -726,6 +727,7 @@ void InstanceStackChunkKlass::fix_thawed_frame(stackChunkOop chunk, const frame&
   if (chunk->has_bitmap() && UseCompressedOops) {
     FixCompressedOopClosure oop_closure;
     if (f.is_interpreted_frame()) {
+      ResourceMark rm;
       f.oops_interpreted_do(&oop_closure, nullptr);
     } else {
       OopMapDo<OopClosure, DerelativizeDerivedPointers, SkipNullValue> visitor(&oop_closure, nullptr);
@@ -755,7 +757,7 @@ public:
     _count++;
 
     log_develop_trace(jvmcont)("debug_verify_stack_chunk bitmap p: " INTPTR_FORMAT " i: " SIZE_FORMAT, p2i(p), index);
-    
+
     if (!SafepointSynchronize::is_at_safepoint()) {
       oop obj = safe_load(p);
       assert (obj == nullptr || is_good_oop(obj),
@@ -875,6 +877,7 @@ public:
     //   }
     // }
 
+    ResourceMark rm;
     StackChunkVerifyOopsClosure oops_closure(_chunk, f.sp());
     f.iterate_oops(&oops_closure, map);
     assert (oops_closure.count() == num_oops, "oops: %d oopmap->num_oops(): %d", oops_closure.count(), num_oops);
@@ -941,7 +944,7 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops, i
   if (closure._cb != nullptr && closure._cb->is_compiled()) {
     assert (chunk->argsize() == (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord,
       "chunk argsize: %d bottom frame argsize: %d", chunk->argsize(), (closure._cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord);
-  } 
+  }
 
   assert (closure._num_interpreted_frames == 0 || chunk->has_mixed_frames(), "");
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -129,7 +129,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, bool gc
     // }
   }
   DEBUG_ONLY(else _unextended_sp = nullptr;)
-
+  
   if (is_stub()) {
     get_oopmap(pc(), 0);
     DEBUG_ONLY(_has_stub = true);
@@ -142,7 +142,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, const f
   assert (mixed || !chunk->has_mixed_frames(), "");
 
   DEBUG_ONLY(_index = 0;)
-
+  
   _end = chunk->bottom_address();
 
   assert (chunk->is_in_chunk(f.sp()), "");
@@ -178,13 +178,13 @@ inline bool StackChunkFrameStream<mixed>::is_compiled() const {
 }
 
 template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_interpreted() const {
-  return mixed ? (!is_done() && Interpreter::contains(pc())) : false;
+inline bool StackChunkFrameStream<mixed>::is_interpreted() const { 
+  return mixed ? (!is_done() && Interpreter::contains(pc())) : false; 
 }
 
 template <bool mixed>
 inline int StackChunkFrameStream<mixed>::frame_size() const {
-  return is_interpreted() ? interpreter_frame_size()
+  return is_interpreted() ? interpreter_frame_size() 
                           : cb()->frame_size() + stack_argsize();
 }
 
@@ -247,18 +247,18 @@ inline void StackChunkFrameStream<mixed>::get_cb() {
     return;
   }
 
-  assert (pc() != nullptr && dbg_is_safe(pc(), -1),
-  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d",
+  assert (pc() != nullptr && dbg_is_safe(pc(), -1), 
+  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d", 
   _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp());
 
   _cb = CodeCache::find_blob_fast(pc());
 
   // if (_cb == nullptr) { tty->print_cr("OOPS"); os::print_location(tty, (intptr_t)pc()); }
-  assert (_cb != nullptr,
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d",
+  assert (_cb != nullptr, 
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d", 
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), _chunk->is_gc_mode());
-  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0),
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d",
+  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0), 
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d", 
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), is_stub(), is_compiled(), _cb->frame_size(), mixed);
 }
 
@@ -266,7 +266,7 @@ template <bool mixed>
 inline void StackChunkFrameStream<mixed>::get_oopmap() const {
   if (is_interpreted()) return;
   assert (is_compiled(), "");
-  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc()));
+  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc())); 
 }
 
 template <bool mixed>
@@ -416,12 +416,12 @@ template<bool mixed>
 template <class DerivedOopClosureType, class RegisterMapT>
 inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClosureType* closure, const RegisterMapT* map) const {
   if (is_interpreted()) return;
-
+  
   for (OopMapStream oms(oopmap()); !oms.is_done(); oms.next()) {
     OopMapValue omv = oms.current();
     if (omv.type() != OopMapValue::derived_oop_value)
       continue;
-
+    
     intptr_t* derived_loc = (intptr_t*)reg_to_loc(omv.reg(), map);
     intptr_t* base_loc    = (intptr_t*)reg_to_loc(omv.content_reg(), map); // see OopMapDo<OopMapFnT, DerivedOopFnT, ValueFilterT>::walk_derived_pointers1
 
@@ -430,7 +430,7 @@ inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClo
     assert (derived_loc != base_loc, "Base and derived in same location");
     assert (is_in_oops(base_loc, map), "not found: " INTPTR_FORMAT, p2i(base_loc));
     assert (!is_in_oops(derived_loc, map), "found: " INTPTR_FORMAT, p2i(derived_loc));
-
+    
     Devirtualizer::do_derived_oop(closure, (oop*)base_loc, (derived_pointer*)derived_loc);
   }
   OrderAccess::storestore(); // to preserve that we set the offset *before* fixing the base oop
@@ -610,7 +610,7 @@ inline void InstanceStackChunkKlass::iterate_stack(stackChunkOop obj, StackChunk
 
     RegisterMap full_map((JavaThread*)nullptr, true, false, true);
     full_map.set_include_argument_oops(false);
-
+    
     f.next(&full_map);
 
     // log_develop_trace(jvmcont)("stackChunkOopDesc::iterate_stack this: " INTPTR_FORMAT " safepoint yield caller frame: %d", p2i(this), f.index());

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, bool gc
     // }
   }
   DEBUG_ONLY(else _unextended_sp = nullptr;)
-  
+
   if (is_stub()) {
     get_oopmap(pc(), 0);
     DEBUG_ONLY(_has_stub = true);
@@ -142,7 +142,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, const f
   assert (mixed || !chunk->has_mixed_frames(), "");
 
   DEBUG_ONLY(_index = 0;)
-  
+
   _end = chunk->bottom_address();
 
   assert (chunk->is_in_chunk(f.sp()), "");
@@ -178,13 +178,13 @@ inline bool StackChunkFrameStream<mixed>::is_compiled() const {
 }
 
 template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_interpreted() const { 
-  return mixed ? (!is_done() && Interpreter::contains(pc())) : false; 
+inline bool StackChunkFrameStream<mixed>::is_interpreted() const {
+  return mixed ? (!is_done() && Interpreter::contains(pc())) : false;
 }
 
 template <bool mixed>
 inline int StackChunkFrameStream<mixed>::frame_size() const {
-  return is_interpreted() ? interpreter_frame_size() 
+  return is_interpreted() ? interpreter_frame_size()
                           : cb()->frame_size() + stack_argsize();
 }
 
@@ -247,18 +247,18 @@ inline void StackChunkFrameStream<mixed>::get_cb() {
     return;
   }
 
-  assert (pc() != nullptr && dbg_is_safe(pc(), -1), 
-  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d", 
+  assert (pc() != nullptr && dbg_is_safe(pc(), -1),
+  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d",
   _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp());
 
   _cb = CodeCache::find_blob_fast(pc());
 
   // if (_cb == nullptr) { tty->print_cr("OOPS"); os::print_location(tty, (intptr_t)pc()); }
-  assert (_cb != nullptr, 
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d", 
+  assert (_cb != nullptr,
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d",
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), _chunk->is_gc_mode());
-  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0), 
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d", 
+  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0),
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d",
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), is_stub(), is_compiled(), _cb->frame_size(), mixed);
 }
 
@@ -266,7 +266,7 @@ template <bool mixed>
 inline void StackChunkFrameStream<mixed>::get_oopmap() const {
   if (is_interpreted()) return;
   assert (is_compiled(), "");
-  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc())); 
+  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc()));
 }
 
 template <bool mixed>
@@ -416,12 +416,12 @@ template<bool mixed>
 template <class DerivedOopClosureType, class RegisterMapT>
 inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClosureType* closure, const RegisterMapT* map) const {
   if (is_interpreted()) return;
-  
+
   for (OopMapStream oms(oopmap()); !oms.is_done(); oms.next()) {
     OopMapValue omv = oms.current();
     if (omv.type() != OopMapValue::derived_oop_value)
       continue;
-    
+
     intptr_t* derived_loc = (intptr_t*)reg_to_loc(omv.reg(), map);
     intptr_t* base_loc    = (intptr_t*)reg_to_loc(omv.content_reg(), map); // see OopMapDo<OopMapFnT, DerivedOopFnT, ValueFilterT>::walk_derived_pointers1
 
@@ -430,7 +430,7 @@ inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClo
     assert (derived_loc != base_loc, "Base and derived in same location");
     assert (is_in_oops(base_loc, map), "not found: " INTPTR_FORMAT, p2i(base_loc));
     assert (!is_in_oops(derived_loc, map), "found: " INTPTR_FORMAT, p2i(derived_loc));
-    
+
     Devirtualizer::do_derived_oop(closure, (oop*)base_loc, (derived_pointer*)derived_loc);
   }
   OrderAccess::storestore(); // to preserve that we set the offset *before* fixing the base oop
@@ -610,7 +610,7 @@ inline void InstanceStackChunkKlass::iterate_stack(stackChunkOop obj, StackChunk
 
     RegisterMap full_map((JavaThread*)nullptr, true, false, true);
     full_map.set_include_argument_oops(false);
-    
+
     f.next(&full_map);
 
     // log_develop_trace(jvmcont)("stackChunkOopDesc::iterate_stack this: " INTPTR_FORMAT " safepoint yield caller frame: %d", p2i(this), f.index());

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, bool gc
     // }
   }
   DEBUG_ONLY(else _unextended_sp = nullptr;)
-  
+
   if (is_stub()) {
     get_oopmap(pc(), 0);
     DEBUG_ONLY(_has_stub = true);
@@ -142,7 +142,7 @@ StackChunkFrameStream<mixed>::StackChunkFrameStream(stackChunkOop chunk, const f
   assert (mixed || !chunk->has_mixed_frames(), "");
 
   DEBUG_ONLY(_index = 0;)
-  
+
   _end = chunk->bottom_address();
 
   assert (chunk->is_in_chunk(f.sp()), "");
@@ -178,13 +178,13 @@ inline bool StackChunkFrameStream<mixed>::is_compiled() const {
 }
 
 template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_interpreted() const { 
-  return mixed ? (!is_done() && Interpreter::contains(pc())) : false; 
+inline bool StackChunkFrameStream<mixed>::is_interpreted() const {
+  return mixed ? (!is_done() && Interpreter::contains(pc())) : false;
 }
 
 template <bool mixed>
 inline int StackChunkFrameStream<mixed>::frame_size() const {
-  return is_interpreted() ? interpreter_frame_size() 
+  return is_interpreted() ? interpreter_frame_size()
                           : cb()->frame_size() + stack_argsize();
 }
 
@@ -247,18 +247,18 @@ inline void StackChunkFrameStream<mixed>::get_cb() {
     return;
   }
 
-  assert (pc() != nullptr && dbg_is_safe(pc(), -1), 
-  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d", 
+  assert (pc() != nullptr && dbg_is_safe(pc(), -1),
+  "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d",
   _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp());
 
   _cb = CodeCache::find_blob_fast(pc());
 
   // if (_cb == nullptr) { tty->print_cr("OOPS"); os::print_location(tty, (intptr_t)pc()); }
-  assert (_cb != nullptr, 
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d", 
+  assert (_cb != nullptr,
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d gc_flag: %d",
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), _chunk->is_gc_mode());
-  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0), 
-    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d", 
+  assert (is_interpreted() || ((is_stub() || is_compiled()) && _cb->frame_size() > 0),
+    "index: %d sp: " INTPTR_FORMAT " sp offset: %d end offset: %d size: %d chunk sp: %d is_stub: %d is_compiled: %d frame_size: %d mixed: %d",
     _index, p2i(sp()), _chunk->to_offset(sp()), _chunk->to_offset(_chunk->bottom_address()), _chunk->stack_size(), _chunk->sp(), is_stub(), is_compiled(), _cb->frame_size(), mixed);
 }
 
@@ -266,7 +266,7 @@ template <bool mixed>
 inline void StackChunkFrameStream<mixed>::get_oopmap() const {
   if (is_interpreted()) return;
   assert (is_compiled(), "");
-  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc())); 
+  get_oopmap(pc(), CodeCache::find_oopmap_slot_fast(pc()));
 }
 
 template <bool mixed>
@@ -416,12 +416,12 @@ template<bool mixed>
 template <class DerivedOopClosureType, class RegisterMapT>
 inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClosureType* closure, const RegisterMapT* map) const {
   if (is_interpreted()) return;
-  
+
   for (OopMapStream oms(oopmap()); !oms.is_done(); oms.next()) {
     OopMapValue omv = oms.current();
     if (omv.type() != OopMapValue::derived_oop_value)
       continue;
-    
+
     intptr_t* derived_loc = (intptr_t*)reg_to_loc(omv.reg(), map);
     intptr_t* base_loc    = (intptr_t*)reg_to_loc(omv.content_reg(), map); // see OopMapDo<OopMapFnT, DerivedOopFnT, ValueFilterT>::walk_derived_pointers1
 
@@ -430,7 +430,7 @@ inline void StackChunkFrameStream<mixed>::iterate_derived_pointers(DerivedOopClo
     assert (derived_loc != base_loc, "Base and derived in same location");
     assert (is_in_oops(base_loc, map), "not found: " INTPTR_FORMAT, p2i(base_loc));
     assert (!is_in_oops(derived_loc, map), "found: " INTPTR_FORMAT, p2i(derived_loc));
-    
+
     Devirtualizer::do_derived_oop(closure, (oop*)base_loc, (derived_pointer*)derived_loc);
   }
   OrderAccess::storestore(); // to preserve that we set the offset *before* fixing the base oop
@@ -610,7 +610,7 @@ inline void InstanceStackChunkKlass::iterate_stack(stackChunkOop obj, StackChunk
 
     RegisterMap full_map((JavaThread*)nullptr, true, false, true);
     full_map.set_include_argument_oops(false);
-    
+
     f.next(&full_map);
 
     // log_develop_trace(jvmcont)("stackChunkOopDesc::iterate_stack this: " INTPTR_FORMAT " safepoint yield caller frame: %d", p2i(this), f.index());

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -361,7 +361,7 @@ ContMirror::ContMirror(const RegisterMap* map)
 #endif
   {
   assert(_cont != nullptr && oopDesc::is_oop_or_null(_cont), "Invalid cont: " INTPTR_FORMAT, p2i((void*)_cont));
-  assert (_entry == nullptr || _cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT, 
+  assert (_entry == nullptr || _cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
     p2i( (oopDesc*)_cont), p2i((oopDesc*)_entry->cont_oop()), p2i(entrySP()));
   read();
 }
@@ -2194,6 +2194,7 @@ public:
   NOINLINE void recurse_thaw_interpreted_frame(const frame& hf, frame& caller, int num_frames) {
     assert (hf.is_interpreted_frame(), "");
 
+    ResourceMark rm; // oops_interpreted_do require ResourceMark
     const bool bottom = recurse_thaw_java_frame<Interpreted>(caller, num_frames);
 
     DEBUG_ONLY(before_thaw_java_frame(hf, caller, bottom, num_frames);)
@@ -2832,7 +2833,7 @@ bool Continuation::unpin(JavaThread* current) {
   oop cont = ce->cont_oop();
   assert (cont != nullptr, "");
   assert (cont == ContinuationHelper::get_continuation(current), "");
-  
+
   jshort value = jdk_internal_vm_Continuation::critical_section(cont);
   if (value > 0) {
     jdk_internal_vm_Continuation::set_critical_section(cont, value - 1);

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -361,7 +361,7 @@ ContMirror::ContMirror(const RegisterMap* map)
 #endif
   {
   assert(_cont != nullptr && oopDesc::is_oop_or_null(_cont), "Invalid cont: " INTPTR_FORMAT, p2i((void*)_cont));
-  assert (_entry == nullptr || _cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
+  assert (_entry == nullptr || _cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT, 
     p2i( (oopDesc*)_cont), p2i((oopDesc*)_entry->cont_oop()), p2i(entrySP()));
   read();
 }
@@ -2194,7 +2194,6 @@ public:
   NOINLINE void recurse_thaw_interpreted_frame(const frame& hf, frame& caller, int num_frames) {
     assert (hf.is_interpreted_frame(), "");
 
-    ResourceMark rm; // oops_interpreted_do require ResourceMark
     const bool bottom = recurse_thaw_java_frame<Interpreted>(caller, num_frames);
 
     DEBUG_ONLY(before_thaw_java_frame(hf, caller, bottom, num_frames);)
@@ -2833,7 +2832,7 @@ bool Continuation::unpin(JavaThread* current) {
   oop cont = ce->cont_oop();
   assert (cont != nullptr, "");
   assert (cont == ContinuationHelper::get_continuation(current), "");
-
+  
   jshort value = jdk_internal_vm_Continuation::critical_section(cont);
   if (value > 0) {
     jdk_internal_vm_Continuation::set_critical_section(cont, value - 1);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -932,14 +932,6 @@ template void frame::oops_interpreted_do<true> (OopClosure* f, const RegisterMap
 template void frame::oops_interpreted_do<false>(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const;
 
 template <bool relative>
-void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, const InterpreterOopMap& mask) const {
-  Thread *thread = Thread::current();
-  methodHandle m (thread, interpreter_frame_method());
-  jint bci = interpreter_frame_bci();
-  oops_interpreted_do0<relative>(f, map, m, bci, mask);
-}
-
-template <bool relative>
 void frame::oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHandle m, jint bci, const InterpreterOopMap& mask) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   assert(!Universe::heap()->is_in(m()),

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,9 +199,6 @@ class frame {
 
   inline void interpreted_frame_oop_map(InterpreterOopMap* mask) const;
 
-  // the number of oops in the frame
-  inline int interpreted_frame_num_oops(InterpreterOopMap* mask) const;
-
   // returns the sending frame
   frame sender(RegisterMap* map) const;
 
@@ -235,7 +232,7 @@ class frame {
   intptr_t  at(int index) const                  { return *addr_at(index); }
   // in interpreter frames in continuation stacks, internal addresses are relative to fp.
   intptr_t  at_relative(int index) const         { return (intptr_t)(fp() + fp()[index]); }
-  template <bool relative> 
+  template <bool relative>
   intptr_t at(int index) const                   { return relative ? at_relative(index) : at(index); }
 
   // accessors for locals
@@ -364,7 +361,7 @@ class frame {
   //                                 this value is >= BasicObjectLock::size(), and may be rounded up
 
   BasicObjectLock* interpreter_frame_monitor_begin() const;
-  template <bool relative = false> 
+  template <bool relative = false>
   BasicObjectLock* interpreter_frame_monitor_end()   const;
   template <bool relative = false>
   BasicObjectLock* next_monitor_in_interpreter_frame(BasicObjectLock* current) const;

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -438,8 +438,6 @@ class frame {
   void oops_compiled_arguments_do(Symbol* signature, bool has_receiver, bool has_appendix, const RegisterMap* reg_map, OopClosure* f) const;
   template <bool relative = false>
   void oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache = true) const;
-  template <bool relative = false>
-  void oops_interpreted_do(OopClosure* f, const RegisterMap* map, const InterpreterOopMap& mask) const;
 
  private:
   void oops_interpreted_arguments_do(Symbol* signature, bool has_receiver, OopClosure* f) const;

--- a/src/hotspot/share/runtime/frame_helpers.inline.hpp
+++ b/src/hotspot/share/runtime/frame_helpers.inline.hpp
@@ -88,7 +88,6 @@ public:
   template <bool relative>
   static void patch_sender_sp(frame& f, intptr_t* sp);
 
-  static int num_oops(const frame&f, InterpreterOopMap* mask);
   static int size(const frame& f, InterpreterOopMap* mask);
   static int size(const frame& f);
   static inline int expression_stack_size(const frame &f, InterpreterOopMap* mask);
@@ -173,6 +172,7 @@ address Frame::return_pc(const frame& f) {
 #ifdef ASSERT
 intptr_t* Frame::frame_top(const frame &f) {
   if (f.is_interpreted_frame()) {
+    ResourceMark rm;
     InterpreterOopMap mask;
     f.interpreted_frame_oop_map(&mask);
     return Interpreted::frame_top(f, &mask);
@@ -218,11 +218,6 @@ bool Frame::is_deopt_return(address pc, const frame& sender) {
 
 address Interpreted::return_pc(const frame& f) {
   return *return_pc_address(f);
-}
-
-int Interpreted::num_oops(const frame&f, InterpreterOopMap* mask) {
-  // all locks must be nullptr when freezing, but f.oops_do walks them, so we count them
-  return f.interpreted_frame_num_oops(mask);
 }
 
 int Interpreted::size(const frame&f) {


### PR DESCRIPTION
I added a ResourceMark to interpreter_frame_num_oops and kept getting confused with frame::interpreted_frame_num_oops, which I then realized is not used.  So I deleted that one.

I also added a ResourceMark to frame::interpreted_oops_do (the one that's used, and deleted the other) before the InterpreterOopMask definition.  This necessitated using CHeap for FrameValuesOopClosure data because adding to the resource allocated _values field in the oops_interpreted_do ResourceMark got an resource mark nesting assertion.

Also, I apologize for the whitespace changes.  My editor removes white space at the end of lines.  You'll have to remove them anyway.

Ran this test: mach5 --patch-based --extra-src-dirs /scratch/cphillim/hg/jdk-loom -j loom-tier1,loom-tier2 -b linux-x64-debug'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/loom pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/85.diff">https://git.openjdk.java.net/loom/pull/85.diff</a>

</details>
