### PR TITLE
Loom: non-PCH build without C2 fails

### DIFF
--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
  */
 
 #include "precompiled.hpp"
+#include "compiler/compiler_globals.hpp"
 #include "compiler/oopMap.inline.hpp"
 #include "oops/instanceStackChunkKlass.hpp"
-#include "gc/shared/gc_globals.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "oops/stackChunkOop.hpp"
@@ -36,7 +36,6 @@
 #include "jfr/jfrEvents.hpp"
 #include "memory/iterator.inline.hpp"
 #include "memory/oopFactory.hpp"
-#include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/instanceStackChunkKlass.inline.hpp"
 #include "oops/instanceOop.hpp"


### PR DESCRIPTION
Reproduce:

```
./configure --disable-precompiled-headers --with-debug-level=release --with-jvm-features=-compiler2
```

Error message:

```
=== Output from failing command(s) repeated here ===
* For target hotspot_variant-server_libjvm_objs_instanceStackChunkKlass.o:
In file included from ~/jdk_src/src/hotspot/share/oops/instanceStackChunkKlass.cpp:26:
~/jdk_src/src/hotspot/share/compiler/oopMap.inline.hpp: In member function 'void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame*, const RegisterMapT*, const ImmutableOopMap*)':
~/jdk_src/src/hotspot/share/compiler/oopMap.inline.hpp:66:11: error: 'UseJVMCICompiler' was not declared in this scope; did you mean 'UseCompiler'?
   66 |       if (UseJVMCICompiler) {
      |           ^~~~~~~~~~~~~~~~
      |           UseCompiler
```

Note that this failure should exist since commit 9e283a4 [1].

In this patch, we
1) add the missing header, i.e. "compiler/compiler_globals.hpp".
2) remove two redundant headers as they are included in
"compiler/oopMap.inline.hpp" already.

Test:
With this patch, builds under Linux/x86_64, Linux/aarch64 and
macOS/aarch64 succeed.

[1] https://github.com/openjdk/loom/commit/9e283a4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.java.net/loom pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/86.diff">https://git.openjdk.java.net/loom/pull/86.diff</a>

</details>
