### PR TITLE
8278261: runtime/SelectionResolution/* tests failing in loom repo

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2219,10 +2219,9 @@ int ConstantPool::copy_cpool_bytes(int cpool_size,
 // recorded in their constant pool cache. The on_stack-ness of the constant pool controls whether
 // memory for the method is reclaimed.
 bool ConstantPool::on_stack() const {
-  if (_cache == NULL || _pool_holder == NULL) return false; // removed in loading
-
   // See nmethod::is_not_on_continuation_stack for explanation of what this means.
-  bool not_on_vthread_stack = CodeCache::marking_cycle() >= align_up(cache()->marking_cycle(), 2) + 2;
+  bool not_on_vthread_stack = _cache == nullptr ||
+          CodeCache::marking_cycle() >= align_up(cache()->marking_cycle(), 2) + 2;
   return (_flags &_on_stack) != 0 || !not_on_vthread_stack;
 }
 


### PR DESCRIPTION
Simple bug after all.  When doing default method processing, the cpCache pointer in the constant pool is null so the on_stack query returned false.  Tested with tier1 with the wrapper and loom-tier1,loom-tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.java.net/loom pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/88.diff">https://git.openjdk.java.net/loom/pull/88.diff</a>

</details>
