### PR TITLE
Loom: [TESTBUG] HumongousStack.java fails with "-XX:-UseCompressedOops"

### DIFF
--- a/test/jdk/jdk/internal/vm/Continuation/HumongousStack.java
+++ b/test/jdk/jdk/internal/vm/Continuation/HumongousStack.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@
 * @modules java.base/jdk.internal.vm
 *
 * @requires vm.gc.G1
-* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xint HumongousStack 5000
-* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:TieredStopAtLevel=3 -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000
-* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000
+* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xint HumongousStack 5000
+* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:TieredStopAtLevel=3 -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000
+* @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyContinuations -Xms2g -Xmx2g -XX:+UseG1GC -XX:G1HeapRegionSize=1m -Xss10m -Xcomp -XX:-TieredCompilation -XX:CompileOnly=jdk/internal/vm/Continuation,HumongousStack HumongousStack 10000
 */
 
 import jdk.internal.vm.Continuation;


### PR DESCRIPTION
When running with `-XX:-UseCompressedOops`, much more heap memory would
be consumed, leading to `java.lang.OutOfMemoryError: Java heap space`
error.

In this patch, we increase the maximum heap size to 2GB.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.java.net/loom pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/90.diff">https://git.openjdk.java.net/loom/pull/90.diff</a>

</details>
