### PR TITLE
8279653: compiler/codecache/stress/OverloadCompileQueueTest.java failing in loom repo

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 #############################################################################
 
 # Loom specific
-
-compiler/codecache/stress/OverloadCompileQueueTest.java         8279653 generic-all
 
 gc/g1/plab/TestPLABPromotion.java                               8278126 generic-all
 gc/g1/plab/TestPLABResize.java                                  8278126 generic-all

--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,19 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:CompileCommand=exclude,java.lang.Thread::sleep
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.ThreadSleepEvent::*
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.SleepEvent::*
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.Event::*
  *                   -XX:-SegmentedCodeCache
  *                   compiler.codecache.stress.OverloadCompileQueueTest
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
+ *                   -XX:CompileCommand=exclude,java.lang.Thread::sleep
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.ThreadSleepEvent::*
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.SleepEvent::*
+ *                   -XX:CompileCommand=exclude,jdk.internal.event.Event::*
  *                   -XX:+SegmentedCodeCache
  *                   compiler.codecache.stress.OverloadCompileQueueTest
  */


### PR DESCRIPTION
I fixed the test to disable compiling Thread.sleep() and all the methods it seems to call, and this makes the test pass.  I don't know if there's a better way to disable compilation like this that would be less fragile (ie if Thread.sleep() calls something new in the future).  See bug comments for details.  @rickard  do you know?  Thanks!