### PR TITLE
8282468: Loom: Fix build failures for PPC64, S390, ARM32 and Zero

### DIFF
--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -39,13 +39,23 @@ static inline intptr_t** link_address(const frame& f) {
   return NULL;
 }
 
+inline int ContinuationHelper::frame_align_words(int size) {
+  Unimplemented();
+  return 0;
+}
+
+inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
 template<typename FKind, typename RegisterMapT>
-inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
 template<typename RegisterMapT>
-inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
@@ -79,12 +89,6 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 template <typename ConfigT>
 inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
-  Unimplemented();
-  return NULL;
 }
 
 template <typename ConfigT>
@@ -164,12 +168,6 @@ void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
 template <typename ConfigT>
 inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
-  Unimplemented();
-  return NULL;
 }
 
 #endif // CPU_ARM_CONTINUATION_ARM_INLINE_HPP

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,10 +275,10 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
@@ -399,57 +399,6 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
   return frame(sender_sp, unextended_sp, link(), sender_pc());
 }
 
-template <bool stub>
-frame frame::sender_for_compiled_frame(RegisterMap* map) const {
-  assert(map != NULL, "map must be set");
-
-  // frame owned by optimizing compiler
-  assert(_cb->frame_size() >= 0, "must have non-zero frame size");
-  intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  intptr_t* unextended_sp = sender_sp;
-
-  address sender_pc = (address) *(sender_sp - sender_sp_offset + return_addr_offset);
-
-  // This is the saved value of FP which may or may not really be an FP.
-  // It is only an FP if the sender is an interpreter frame (or C1?).
-  intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - sender_sp_offset + link_offset);
-
-  if (map->update_map()) {
-    // Tell GC to use argument oopmaps for some runtime stubs that need it.
-    // For C1, the runtime stub might not have oop maps, so set this flag
-    // outside of update_register_map.
-    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
-      OopMapSet::update_register_map(this, map);
-    }
-
-    // Since the prolog does the save and restore of FP there is no oopmap
-    // for it so we must fill in its location as if there was an oopmap entry
-    // since if our caller was compiled code there could be live jvm state in it.
-    update_map_with_saved_link(map, saved_fp_addr);
-  }
-
-  assert(sender_sp != sp(), "must have changed");
-  return frame(sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
-}
-
-frame frame::sender(RegisterMap* map) const {
-  // Default is we done have to follow them. The sender_for_xxx will
-  // update it accordingly
-  map->set_include_argument_oops(false);
-
-  if (is_entry_frame())       return sender_for_entry_frame(map);
-  if (is_interpreted_frame()) return sender_for_interpreter_frame(map);
-  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
-
-  if (_cb != NULL) {
-    return sender_for_compiled_frame<false>(map);
-  }
-
-  assert(false, "should not be called for a C frame");
-  return frame();
-}
-
 bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   // These are reasonable sanity checks
@@ -548,10 +497,10 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
   return &interpreter_frame_tos_address()[index];

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 
-  template <bool relative = false>
+  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
 #endif // CPU_ARM_FRAME_ARM_HPP

--- a/src/hotspot/cpu/arm/frame_helpers_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_helpers_arm.inline.hpp
@@ -49,7 +49,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +73,7 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/arm/instanceStackChunkKlass_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/instanceStackChunkKlass_arm.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,68 +40,68 @@ int InstanceStackChunkKlass::align_wiggle()   {
 }
 
 #ifdef ASSERT
-template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+template <chunk_frames frame_kind>
+inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <bool mixed>
-inline frame StackChunkFrameStream<mixed>::to_frame() const {
+template <chunk_frames frame_kind>
+inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <bool mixed>
-inline address StackChunkFrameStream<mixed>::get_pc() const {
+template <chunk_frames frame_kind>
+inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+template <chunk_frames frame_kind>
+inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
 }
@@ -116,19 +116,19 @@ inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
 
 template<>
 template<>
-inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <bool mixed>
+template <chunk_frames frame_kind>
 template <typename RegisterMapT>
-inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -39,13 +39,23 @@ static inline intptr_t** link_address(const frame& f) {
   return NULL;
 }
 
+inline int ContinuationHelper::frame_align_words(int size) {
+  Unimplemented();
+  return 0;
+}
+
+inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
 template<typename FKind, typename RegisterMapT>
-inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
 template<typename RegisterMapT>
-inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
@@ -79,12 +89,6 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 template <typename ConfigT>
 inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
-  Unimplemented();
-  return NULL;
 }
 
 template <typename ConfigT>
@@ -164,12 +168,6 @@ void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
 template <typename ConfigT>
 inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
-  Unimplemented();
-  return NULL;
 }
 
 #endif // CPU_PPC_CONTINUATION_PPC_INLINE_HPP

--- a/src/hotspot/cpu/ppc/frame_helpers_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_helpers_ppc.inline.hpp
@@ -49,7 +49,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +73,7 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -219,61 +219,12 @@ frame frame::sender_for_interpreter_frame(RegisterMap *map) const {
   return frame(sender_sp(), sender_pc(), (intptr_t*)get_ijava_state()->sender_sp);
 }
 
-template <bool stub>
-frame frame::sender_for_compiled_frame(RegisterMap *map) const {
-  assert(map != NULL, "map must be set");
-
-  // Frame owned by compiler.
-  address pc = *compiled_sender_pc_addr(_cb);
-  frame caller(compiled_sender_sp(_cb), pc);
-
-  // Now adjust the map.
-
-  // Get the rest.
-  if (map->update_map()) {
-    // Tell GC to use argument oopmaps for some runtime stubs that need it.
-    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
-      OopMapSet::update_register_map(this, map);
-    }
-  }
-
-  return caller;
-}
-
 intptr_t* frame::compiled_sender_sp(CodeBlob* cb) const {
   return sender_sp();
 }
 
 address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
   return sender_pc_addr();
-}
-
-frame frame::sender_raw(RegisterMap* map) const {
-  // Default is we do have to follow them. The sender_for_xxx will
-  // update it accordingly.
-  map->set_include_argument_oops(false);
-
-  if (is_entry_frame())       return sender_for_entry_frame(map);
-  if (is_interpreted_frame()) return sender_for_interpreter_frame(map);
-  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
-
-  if (_cb != NULL) {
-    return sender_for_compiled_frame<false>(map);
-  }
-  // Must be native-compiled frame, i.e. the marshaling code for native
-  // methods that exists in the core system.
-  return frame(sender_sp(), sender_pc());
-}
-
-frame frame::sender(RegisterMap* map) const {
-  frame result = sender_raw(map);
-
-  if (map->process_frames()) {
-    StackWatermarkSet::on_iteration(map->thread(), result);
-  }
-
-  return result;
 }
 
 void frame::patch_pc(Thread* thread, address pc) {
@@ -443,18 +394,18 @@ frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp), _unextended_sp(
 #endif
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_ijava_state()->monitors;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -401,7 +401,7 @@
   inline void interpreter_frame_set_top_frame_sp(intptr_t* top_frame_sp);
   inline void interpreter_frame_set_sender_sp(intptr_t* sender_sp);
 
-  template <bool relative = false>
+  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>
@@ -426,6 +426,6 @@
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 
   // returns the sending frame, without applying any barriers
-  frame sender_raw(RegisterMap* map) const;
+  inline frame sender_raw(RegisterMap* map) const;
 
 #endif // CPU_PPC_FRAME_PPC_HPP

--- a/src/hotspot/cpu/ppc/instanceStackChunkKlass_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/instanceStackChunkKlass_ppc.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,68 +40,68 @@ int InstanceStackChunkKlass::align_wiggle()   {
 }
 
 #ifdef ASSERT
-template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+template <chunk_frames frame_kind>
+inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <bool mixed>
-inline frame StackChunkFrameStream<mixed>::to_frame() const {
+template <chunk_frames frame_kind>
+inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <bool mixed>
-inline address StackChunkFrameStream<mixed>::get_pc() const {
+template <chunk_frames frame_kind>
+inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+template <chunk_frames frame_kind>
+inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
 }
@@ -116,19 +116,19 @@ inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
 
 template<>
 template<>
-inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <bool mixed>
+template <chunk_frames frame_kind>
 template <typename RegisterMapT>
-inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -39,13 +39,23 @@ static inline intptr_t** link_address(const frame& f) {
   return NULL;
 }
 
+inline int ContinuationHelper::frame_align_words(int size) {
+  Unimplemented();
+  return 0;
+}
+
+inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
 template<typename FKind, typename RegisterMapT>
-inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
 template<typename RegisterMapT>
-inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
@@ -79,12 +89,6 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 template <typename ConfigT>
 inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
-  Unimplemented();
-  return NULL;
 }
 
 template <typename ConfigT>
@@ -164,12 +168,6 @@ void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
 template <typename ConfigT>
 inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
-  Unimplemented();
-  return NULL;
 }
 
 #endif // CPU_S390_CONTINUATION_S390_INLINE_HPP

--- a/src/hotspot/cpu/s390/frame_helpers_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_helpers_s390.inline.hpp
@@ -49,7 +49,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +73,7 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -230,54 +230,12 @@ frame frame::sender_for_interpreter_frame(RegisterMap *map) const {
   return frame(sender_sp(), sender_pc(), (intptr_t*)(ijava_state()->sender_sp));
 }
 
-template <bool stub>
-frame frame::sender_for_compiled_frame(RegisterMap *map) const {
-  assert(map != NULL, "map must be set");
-  // Frame owned by compiler.
-
-  address pc = *compiled_sender_pc_addr(_cb);
-  frame caller(compiled_sender_sp(_cb), pc);
-
-  // Now adjust the map.
-
-  // Get the rest.
-  if (map->update_map()) {
-    // Tell GC to use argument oopmaps for some runtime stubs that need it.
-    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
-      OopMapSet::update_register_map(this, map);
-    }
-  }
-
-  return caller;
-}
-
 intptr_t* frame::compiled_sender_sp(CodeBlob* cb) const {
   return sender_sp();
 }
 
 address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
   return sender_pc_addr();
-}
-
-frame frame::sender(RegisterMap* map) const {
-  // Default is we don't have to follow them. The sender_for_xxx will
-  // update it accordingly.
-  map->set_include_argument_oops(false);
-
-  if (is_entry_frame()) {
-    return sender_for_entry_frame(map);
-  }
-  if (is_interpreted_frame()) {
-    return sender_for_interpreter_frame(map);
-  }
-  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
-  if (_cb != NULL) {
-    return sender_for_compiled_frame<false>(map);
-  }
-  // Must be native-compiled frame, i.e. the marshaling code for native
-  // methods that exists in the core system.
-  return frame(sender_sp(), sender_pc());
 }
 
 void frame::patch_pc(Thread* thread, address pc) {
@@ -686,18 +644,18 @@ intptr_t *frame::initial_deoptimization_info() {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return interpreter_frame_monitors();
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -486,7 +486,7 @@
   address* sender_pc_addr(void) const;
 
  public:
-  template <bool relative = false>
+  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -168,7 +168,7 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
 }
 
 // Bottom(base) of the expression stack (highest address).
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   return (intptr_t*)interpreter_frame_monitor_end() - 1;
 }
@@ -202,7 +202,7 @@ inline intptr_t** frame::interpreter_frame_esp_addr() const {
 }
 
 // top of expression stack (lowest address)
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return *interpreter_frame_esp_addr() + 1;
 }
@@ -295,7 +295,7 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
   Unimplemented();
   return NULL;
@@ -304,11 +304,6 @@ inline intptr_t* frame::interpreter_frame_last_sp() const {
 inline int frame::sender_sp_ret_address_offset() {
   Unimplemented();
   return 0;
-}
-
-template <typename RegisterMapT>
-void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
-  Unimplemented();
 }
 
 inline void frame::set_unextended_sp(intptr_t* value) {
@@ -321,6 +316,54 @@ inline int frame::offset_unextended_sp() const {
 }
 
 inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
+}
+
+//------------------------------------------------------------------------------
+// frame::sender
+
+inline frame frame::sender(RegisterMap* map) const {
+  // Default is we don't have to follow them. The sender_for_xxx will
+  // update it accordingly.
+  map->set_include_argument_oops(false);
+
+  if (is_entry_frame()) {
+    return sender_for_entry_frame(map);
+  }
+  if (is_interpreted_frame()) {
+    return sender_for_interpreter_frame(map);
+  }
+  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
+  if (_cb != NULL) return sender_for_compiled_frame(map);
+
+  // Must be native-compiled frame, i.e. the marshaling code for native
+  // methods that exists in the core system.
+  return frame(sender_sp(), sender_pc());
+}
+
+inline frame frame::sender_for_compiled_frame(RegisterMap *map) const {
+  assert(map != NULL, "map must be set");
+  // Frame owned by compiler.
+
+  address pc = *compiled_sender_pc_addr(_cb);
+  frame caller(compiled_sender_sp(_cb), pc);
+
+  // Now adjust the map.
+
+  // Get the rest.
+  if (map->update_map()) {
+    // Tell GC to use argument oopmaps for some runtime stubs that need it.
+    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
+    if (_cb->oop_maps() != NULL) {
+      OopMapSet::update_register_map(this, map);
+    }
+  }
+
+  return caller;
+}
+
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/s390/instanceStackChunkKlass_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/instanceStackChunkKlass_s390.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,68 +40,68 @@ int InstanceStackChunkKlass::align_wiggle()   {
 }
 
 #ifdef ASSERT
-template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+template <chunk_frames frame_kind>
+inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <bool mixed>
-inline frame StackChunkFrameStream<mixed>::to_frame() const {
+template <chunk_frames frame_kind>
+inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <bool mixed>
-inline address StackChunkFrameStream<mixed>::get_pc() const {
+template <chunk_frames frame_kind>
+inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+template <chunk_frames frame_kind>
+inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
 }
@@ -116,19 +116,19 @@ inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
 
 template<>
 template<>
-inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <bool mixed>
+template <chunk_frames frame_kind>
 template <typename RegisterMapT>
-inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -39,13 +39,23 @@ static inline intptr_t** link_address(const frame& f) {
   return NULL;
 }
 
+inline int ContinuationHelper::frame_align_words(int size) {
+  Unimplemented();
+  return 0;
+}
+
+inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
 template<typename FKind, typename RegisterMapT>
-inline void ContinuationHelper::update_register_map(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
 template<typename RegisterMapT>
-inline void ContinuationHelper::update_register_map_with_callee(RegisterMapT* map, const frame& f) {
+inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMapT* map) {
   Unimplemented();
 }
 
@@ -79,12 +89,6 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 template <typename ConfigT>
 inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Freeze<ConfigT>::align_bottom(intptr_t* bottom, int argsize) {
-  Unimplemented();
-  return NULL;
 }
 
 template <typename ConfigT>
@@ -164,12 +168,6 @@ void Thaw<ConfigT>::patch_chunk_pd(intptr_t* sp) {
 template <typename ConfigT>
 inline void Thaw<ConfigT>::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
-}
-
-template <typename ConfigT>
-inline intptr_t* Thaw<ConfigT>::align_chunk(intptr_t* vsp) {
-  Unimplemented();
-  return NULL;
 }
 
 #endif // CPU_ZERO_CONTINUATION_ZERO_INLINE_HPP

--- a/src/hotspot/cpu/zero/frame_helpers_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_helpers_zero.inline.hpp
@@ -49,7 +49,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +73,7 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <bool relative>
+template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2007, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,31 +78,15 @@ frame frame::sender_for_nonentry_frame(RegisterMap *map) const {
   return frame(zeroframe()->next(), sender_sp());
 }
 
-frame frame::sender(RegisterMap* map) const {
-  // Default is not to follow arguments; the various
-  // sender_for_xxx methods update this accordingly.
-  map->set_include_argument_oops(false);
-
-  frame result = zeroframe()->is_entry_frame() ?
-                 sender_for_entry_frame(map) :
-                 sender_for_nonentry_frame(map);
-
-  if (map->process_frames()) {
-    StackWatermarkSet::on_iteration(map->thread(), result);
-  }
-
-  return result;
-}
-
 BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return get_interpreterState()->monitor_base();
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<true>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<false>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
+template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
 
-template <bool relative>
+template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_interpreterState()->stack_base();
 }
@@ -240,10 +224,10 @@ BasicType frame::interpreter_frame_result(oop* oop_result,
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<false>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<true >(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
+template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
 
-template <bool relative>
+template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset) / wordSize);
   return &interpreter_frame_tos_address()[index];

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -77,7 +77,7 @@
 
   inline address* sender_pc_addr() const;
 
-  template <bool relative = false>
+  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/zero/instanceStackChunkKlass_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/instanceStackChunkKlass_zero.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,68 +40,68 @@ int InstanceStackChunkKlass::align_wiggle()   {
 }
 
 #ifdef ASSERT
-template <bool mixed>
-inline bool StackChunkFrameStream<mixed>::is_in_frame(void* p0) const {
+template <chunk_frames frame_kind>
+inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <bool mixed>
-inline frame StackChunkFrameStream<mixed>::to_frame() const {
+template <chunk_frames frame_kind>
+inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <bool mixed>
-inline address StackChunkFrameStream<mixed>::get_pc() const {
+template <chunk_frames frame_kind>
+inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::fp() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::derelativize(int offset) const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline intptr_t* StackChunkFrameStream<mixed>::unextended_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-intptr_t* StackChunkFrameStream<mixed>::next_sp_for_interpreter_frame() const {
+template <chunk_frames frame_kind>
+intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <bool mixed>
-inline void StackChunkFrameStream<mixed>::next_for_interpreter_frame() {
+template <chunk_frames frame_kind>
+inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_size() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_stack_argsize() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <bool mixed>
-inline int StackChunkFrameStream<mixed>::interpreter_frame_num_oops() const {
+template <chunk_frames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
 }
@@ -116,19 +116,19 @@ inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
 
 template<>
 template<>
-inline void StackChunkFrameStream<true>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<false>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <bool mixed>
+template <chunk_frames frame_kind>
 template <typename RegisterMapT>
-inline void StackChunkFrameStream<mixed>::update_reg_map_pd(RegisterMapT* map) {}
+inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 
 // Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
 class SmallRegisterMap {


### PR DESCRIPTION
Updates made in commits [1][2][3][4] are missing for PPC64, S390, ARM32
and Zero, leading to build failures.

Even though we mainly focus on x64 and AArch64 platforms currently, I
think it would be nice if the builds on other platforms are not broken.

Hence, we apply the similar updates from [1][2][3][4] to PPC64, S390,
ARM32 and Zero in this patch.

Testing:

Linux PPC64 cross-compilation
Linux S390 cross-compilation
Linux ARM32 cross-compilation
Linux AArch64 Zero (Hotspot) compilation
Linux x86_64 tier1_loom passes
Linux AArch64 tier1_loom passes

[1] https://github.com/openjdk/loom/commit/4f9b661
[2] https://github.com/openjdk/loom/commit/74b27d0
[3] https://github.com/openjdk/loom/commit/90fb1b9
[4] https://github.com/openjdk/loom/commit/d77311e

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.java.net/loom pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/92.diff">https://git.openjdk.java.net/loom/pull/92.diff</a>

</details>
