### PR TITLE
Fix unloading tests to not have extra full GCs.

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -197,10 +197,6 @@ vmTestbase/nsk/stress/strace/strace002.java                                   82
 vmTestbase/vm/mlvm/indy/func/jdi/breakpointOtherStratum/Test.java            8276713 generic-all
 vmTestbase/vm/mlvm/meth/func/jdi/breakpointOtherStratum/Test.java            8276713 generic-all
 
-vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java 8277989 generic-all
-vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java 8277989 generic-all
-vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java 8277989 generic-all
-
 gtest/GTestWrapper.java                                                       0000000 generic-all
 
 runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java#id0          8272791 generic-all

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,6 +129,7 @@ public class UnloadingTest extends GCTestBase {
 
         System.out.println("ClassAssertion.getCounterOfCheckedAlive() = " + ClassAssertion.getCounterOfCheckedAlive());
         System.out.println("ClassAssertion.getCounterOfCheckedUnloaded() = " + ClassAssertion.getCounterOfCheckedUnloaded());
+        // Passing -XX:-MethodFlushing prevents Full GCs in Loom that subvert the tests.
         checkGCCounters();
         if (System.getProperty("FailTestIfNothingChecked") != null) {
             if (ClassAssertion.getCounterOfCheckedAlive() == 0 || ClassAssertion.getCounterOfCheckedUnloaded() == 0) {

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
+ *      -XX:-MethodFlushing
  *      gc.g1.unloading.UnloadingTest
  *      -redefineClasses true
  *      -inMemoryCompilation true

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
+ *      -XX:-MethodFlushing
  *      gc.g1.unloading.UnloadingTest
  *      -redefineClasses true
  *      -inMemoryCompilation true

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
+ *      -XX:-MethodFlushing
  *      gc.g1.unloading.UnloadingTest
  *      -redefineClasses true
  *      -inMemoryCompilation true


### PR DESCRIPTION
Added -XX:-MethodFlushing to turn off the sweeper, which prevents full GCs that make the test useless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/loom pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/94.diff">https://git.openjdk.java.net/loom/pull/94.diff</a>

</details>
