### PR TITLE
Inject StackChunk fields.

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2457,7 +2457,7 @@ int java_lang_VirtualThread::_state_offset;
   macro(_continuation_offset,  k, "cont",  continuation_signature, false); \
   macro(_state_offset,  k, "state",  int_signature, false)
 
-static jboolean vthread_notify_jvmti_events = JNI_FALSE;
+static bool vthread_notify_jvmti_events = JNI_FALSE;
 
 void java_lang_VirtualThread::compute_offsets() {
   InstanceKlass* k = vmClasses::VirtualThread_klass();
@@ -2486,11 +2486,11 @@ oop java_lang_VirtualThread::continuation(oop vthread) {
   return cont;
 }
 
-jshort java_lang_VirtualThread::state(oop vthread) {
+u2 java_lang_VirtualThread::state(oop vthread) {
   return vthread->short_field_acquire(_state_offset);
 }
 
-JavaThreadStatus java_lang_VirtualThread::map_state_to_thread_status(jint state) {
+JavaThreadStatus java_lang_VirtualThread::map_state_to_thread_status(int state) {
   JavaThreadStatus status = JavaThreadStatus::NEW;
   switch (state) {
     case NEW :
@@ -2528,7 +2528,7 @@ bool java_lang_VirtualThread::notify_jvmti_events() {
   return vthread_notify_jvmti_events == JNI_TRUE;
 }
 
-void java_lang_VirtualThread::set_notify_jvmti_events(jboolean enable) {
+void java_lang_VirtualThread::set_notify_jvmti_events(bool enable) {
   vthread_notify_jvmti_events = enable;
 }
 
@@ -5118,22 +5118,18 @@ int jdk_internal_vm_StackChunk::_cont_offset;
   macro(_parent_offset,    k, vmSymbols::parent_name(),    stackchunk_signature, false); \
   macro(_size_offset,      k, vmSymbols::size_name(),      int_signature,        false); \
   macro(_sp_offset,        k, vmSymbols::sp_name(),        int_signature,        false); \
-  macro(_pc_offset,        k, vmSymbols::pc_name(),        long_signature,       false); \
-  macro(_argsize_offset,   k, vmSymbols::argsize_name(),   int_signature,        false); \
-  macro(_flags_offset,     k, "flags",                     byte_signature,       false); \
-  macro(_gcSP_offset,      k, "gcSP",                      int_signature,        false); \
-  macro(_markCycle_offset, k, "markCycle",                 long_signature,       false); \
-  macro(_maxSize_offset,   k, vmSymbols::maxSize_name(),   int_signature,        false); \
-  macro(_cont_offset,      k, "cont",                      continuation_signature, false);
+  macro(_argsize_offset,   k, vmSymbols::argsize_name(),   int_signature,        false);
 
 void jdk_internal_vm_StackChunk::compute_offsets() {
   InstanceKlass* k = vmClasses::StackChunk_klass();
   STACKCHUNK_FIELDS_DO(FIELD_COMPUTE_OFFSET);
+  STACKCHUNK_INJECTED_FIELDS(INJECTED_FIELD_COMPUTE_OFFSET);
 }
 
 #if INCLUDE_CDS
 void jdk_internal_vm_StackChunk::serialize_offsets(SerializeClosure* f) {
   STACKCHUNK_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
+  STACKCHUNK_INJECTED_FIELDS(INJECTED_FIELD_SERIALIZE_OFFSET);
 }
 #endif
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -631,12 +631,12 @@ class java_lang_VirtualThread : AllStatic {
   static oop vthread_scope();
   static oop carrier_thread(oop vthread);
   static oop continuation(oop vthread);
-  static jshort state(oop vthread);
-  static JavaThreadStatus map_state_to_thread_status(jint state);
+  static u2 state(oop vthread);
+  static JavaThreadStatus map_state_to_thread_status(int state);
   static bool notify_jvmti_events();
-  static void set_notify_jvmti_events(jboolean enable);
+  static void set_notify_jvmti_events(bool enable);
   static void init_static_notify_jvmti_events();
-  static jlong set_jfrTraceId(oop vthread, jlong id);
+  static int64_t set_jfrTraceId(oop vthread, int64_t id);
 };
 
 
@@ -1136,6 +1136,14 @@ class jdk_internal_vm_Continuation: AllStatic {
 };
 
 // Interface to jdk.internal.vm.StackChunk objects
+#define STACKCHUNK_INJECTED_FIELDS(macro)                               \
+  macro(jdk_internal_vm_StackChunk, cont,      continuation_signature, false)   \
+  macro(jdk_internal_vm_StackChunk, flags,     byte_signature, false)   \
+  macro(jdk_internal_vm_StackChunk, pc,        intptr_signature, false) \
+  macro(jdk_internal_vm_StackChunk, gcSP,      int_signature, false)    \
+  macro(jdk_internal_vm_StackChunk, maxSize,   int_signature, false)    \
+  macro(jdk_internal_vm_StackChunk, markCycle, long_signature, false)
+
 class jdk_internal_vm_StackChunk: AllStatic {
   friend class JavaClasses;
  private:
@@ -1149,6 +1157,7 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static int _markCycle_offset;
   static int _maxSize_offset;
   static int _cont_offset;
+
 
   static void compute_offsets();
  public:
@@ -1164,22 +1173,28 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static inline bool is_parent_null(oop ref); // bypasses barriers for a faster test
   template<typename P>
   static inline void set_parent_raw(oop ref, oop value);
-  static inline jint size(oop ref);
-  static inline void set_size(HeapWord* ref, jint value);
-  static inline jint sp(oop ref);
-  static inline void set_sp(oop ref, jint value);
-  static inline jlong pc(oop ref);
-  static inline void set_pc(oop ref, jlong value);
-  static inline jint argsize(oop ref);
-  static inline void set_argsize(oop ref, jint value);
+
+  static inline int size(oop ref);
+  static inline void set_size(HeapWord* ref, int value);
+
+  static inline int sp(oop ref);
+  static inline void set_sp(oop ref, int value);
+  static inline intptr_t pc(oop ref);
+  static inline void set_pc(oop ref, intptr_t value);
+  static inline int argsize(oop ref);
+  static inline void set_argsize(oop ref, int value);
   static inline jbyte flags(oop ref);
   static inline void set_flags(oop ref, jbyte value);
-  static inline jint gc_sp(oop ref);
-  static inline void set_gc_sp(oop ref, jint value);
-  static inline jlong mark_cycle(oop ref);
-  static inline void set_mark_cycle(oop ref, jlong value);
-  static inline jint maxSize(oop ref);
-  static inline void set_maxSize(oop ref, jint value);
+
+  static inline int gc_sp(oop ref);
+  static inline void set_gc_sp(oop ref, int value);
+  static inline int64_t mark_cycle(oop ref);
+  static inline void set_mark_cycle(oop ref, int64_t value);
+
+  static inline int maxSize(oop ref);
+  static inline void set_maxSize(oop ref, int value);
+
+ // cont oop's processing is essential for the chunk's GC protocol
   static inline oop cont(oop ref);
   static inline void set_cont(oop ref, oop value);
   template<typename P>
@@ -2008,7 +2023,8 @@ class InjectedField {
   STACKFRAMEINFO_INJECTED_FIELDS(macro)     \
   MODULE_INJECTED_FIELDS(macro)             \
   THREAD_INJECTED_FIELDS(macro)             \
-  INTERNALERROR_INJECTED_FIELDS(macro)
+  INTERNALERROR_INJECTED_FIELDS(macro)      \
+  STACKCHUNK_INJECTED_FIELDS(macro)
 
 
 // Interface to hard-coded offset checking

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -493,6 +493,9 @@
   template(signers_name,                              "signers_name")                             \
   template(source_file_name,                          "source_file")                              \
   template(loader_data_name,                          "loader_data")                              \
+  template(cont_name,                                 "cont")                                     \
+  template(gcSP_name,                                 "gcSP")                                     \
+  template(markCycle_name,                            "markCycle")                                \
   template(vmdependencies_name,                       "vmdependencies")                           \
   template(last_cleanup_name,                         "last_cleanup")                             \
   template(loader_name,                               "loader")                                   \

--- a/src/java.base/share/classes/jdk/internal/vm/StackChunk.java
+++ b/src/java.base/share/classes/jdk/internal/vm/StackChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,28 +28,13 @@ package jdk.internal.vm;
 public final class StackChunk {
     public static void init() {}
 
-    public static final byte FLAG_HAS_INTERPRETED_FRAMES = 1 << 2;
-
-    private Continuation cont; // must not be accessed by Java code, as this oop's processing is essential for the chunk's GC protocol
     private StackChunk parent;
     private int size; // in words
     private int sp; // in words
     private int argsize; // bottom stack-passed arguments, in words
-    private byte flags;
-    private long pc;
 
-    private int gcSP;
-    private long markCycle;
-
-    private int maxSize; // size when fully thawed on stack
-
-   // the stack itself is appended here by the VM
+    // The stack itself is appended here by the VM
 
     public StackChunk parent() { return parent; }
-    public int size()          { return size; }
-    public int sp()            { return sp; }
-    public int argsize()       { return argsize; }
-    public int maxSize()       { return maxSize; }
     public boolean isEmpty()   { return sp >= (size - argsize); }
-    public boolean isFlag(byte flag) { return (flags & flag) != 0; }
- }
+}


### PR DESCRIPTION
This injects StackChunk fields that aren't being used by Java into VM only.  It also fixes most types to be C++.
tested with loom-tier1 and 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.java.net/loom pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/95.diff">https://git.openjdk.java.net/loom/pull/95.diff</a>

</details>
