### PR TITLE
Better jdb support for vthreads. Improved jdb vthread testing support.

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -366,6 +366,8 @@ class Commands {
         ThreadIterator threadIter = new ThreadIterator(tg);
 
         MessageOutput.println("Thread Group:", tg.name());
+
+        // Iterate over all the threads to figure out the max field widths needed
         int maxIdLength = 0;
         int maxNameLength = 0;
         while (threadIter.hasNext()) {
@@ -376,6 +378,7 @@ class Commands {
                                      thr.name().length());
         }
 
+        // Iterate over all threads in the threadgroup.
         threadIter = new ThreadIterator(tg);
         while (threadIter.hasNext()) {
             ThreadReference thr = threadIter.next();
@@ -463,7 +466,7 @@ class Commands {
 
     void commandThreads(StringTokenizer t) {
         if (!t.hasMoreTokens()) {
-            printThreadGroup(ThreadInfo.group());
+            printThreadGroup(ThreadInfo.group()); // print threads in the current threadgroup
             return;
         }
         String name = t.nextToken();
@@ -471,7 +474,7 @@ class Commands {
         if (tg == null) {
             MessageOutput.println("is not a valid threadgroup name", name);
         } else {
-            printThreadGroup(tg);
+            printThreadGroup(tg); // print threads in specified group (and its subgroups)
         }
     }
 
@@ -515,8 +518,8 @@ class Commands {
 
     void commandRun(StringTokenizer t) {
         /*
-         * The 'run' command makes little sense in a
-         * that doesn't support restarts or multiple VMs. However,
+         * The 'run' command makes little sense in
+         * that it doesn't support restarts or multiple VMs. However,
          * this is an attempt to emulate the behavior of the old
          * JDB as much as possible. For new users and implementations
          * it is much more straightforward to launch immedidately
@@ -568,6 +571,7 @@ class Commands {
         MessageOutput.println("The load command is no longer supported.");
     }
 
+    /* Note: no longer used, but kept around as sample code. */
     private List<ThreadReference> allThreads(ThreadGroupReference group) {
         List<ThreadReference> list = new ArrayList<ThreadReference>();
         list.addAll(group.threads());
@@ -714,6 +718,8 @@ class Commands {
                 MessageOutput.println("killed", thread.toString());
             } catch (InvalidTypeException e) {
                 MessageOutput.println("Invalid exception object");
+            } catch (IllegalThreadStateException its) {
+                MessageOutput.println("Illegal thread state");
             }
         } else {
             MessageOutput.println("Expression must evaluate to an object");

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,8 @@ class Env {
     private static HashMap<String, Value> savedValues = new HashMap<String, Value>();
     private static Method atExitMethod;
 
-    static void init(String connectSpec, boolean openNow, int flags, String extraOptions) {
-        connection = new VMConnection(connectSpec, flags, extraOptions);
+    static void init(String connectSpec, boolean openNow, int flags, boolean trackAllVthreads, String extraOptions) {
+        connection = new VMConnection(connectSpec, flags, trackAllVthreads, extraOptions);
         if (!connection.isLaunch() || openNow) {
             connection.open();
         }

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
@@ -57,8 +57,8 @@ class Env {
     private static HashMap<String, Value> savedValues = new HashMap<String, Value>();
     private static Method atExitMethod;
 
-    static void init(String connectSpec, boolean openNow, int flags, boolean trackAllVthreads, String extraOptions) {
-        connection = new VMConnection(connectSpec, flags, trackAllVthreads, extraOptions);
+    static void init(String connectSpec, boolean openNow, int flags, boolean trackVthreads, String extraOptions) {
+        connection = new VMConnection(connectSpec, flags, trackVthreads, extraOptions);
         if (!connection.isLaunch() || openNow) {
             connection.open();
         }

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -48,12 +48,12 @@ public class EventHandler implements Runnable {
     boolean completed = false;
     String shutdownMessageKey;
     boolean stopOnVMStart;
-    boolean trackAllVthreads;
+    boolean trackVthreads;
 
-    EventHandler(EventNotifier notifier, boolean stopOnVMStart, boolean trackAllVthreads) {
+    EventHandler(EventNotifier notifier, boolean stopOnVMStart, boolean trackVthreads) {
         this.notifier = notifier;
         this.stopOnVMStart = stopOnVMStart;
-        this.trackAllVthreads = trackAllVthreads;
+        this.trackVthreads = trackVthreads;
         this.thread = new Thread(this, "event-handler");
         this.thread.start();
     }
@@ -118,10 +118,10 @@ public class EventHandler implements Runnable {
                 assert eventThread.isVirtual();
             }
             // If we added it, we need to make sure it eventually gets removed. Usually
-            // this happens when the ThreadDeathEvent comes in, but if !trackAllVthreads,
+            // this happens when the ThreadDeathEvent comes in, but if !trackVthreads,
             // then the ThreadDeathReqest was setup to filter out vthreads. So we'll need
             // to create a special ThreadDeathReqest just to detect when this vthread dies.
-            if (added && !trackAllVthreads) {
+            if (added && !trackVthreads) {
                 EventRequestManager erm = Env.vm().eventRequestManager();
                 ThreadDeathRequest tdr = erm.createThreadDeathRequest();
                 tdr.addThreadFilter(eventThread);
@@ -301,7 +301,7 @@ public class EventHandler implements Runnable {
         ThreadReference thread = tde.thread();
         ThreadInfo.removeThread(thread);
 
-        if (!trackAllVthreads && thread.isVirtual()) {
+        if (!trackVthreads && thread.isVirtual()) {
             // Remove the ThreadDeathRequest used for this event since it was created
             // just to remove this one vthread.
             EventRequestManager erm = Env.vm().eventRequestManager();

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -111,8 +111,10 @@ public class EventHandler implements Runnable {
         }
         if (eventThread != null) {
             // This is a vthread we haven't seen before, so add it to our list.
-            assert eventThread.isVirtual();
             boolean added = ThreadInfo.addThread(eventThread);
+            if (added) {
+                assert eventThread.isVirtual();
+            }
             // If we added it, we need to make sure it eventually gets removed. Usually
             // this happens when the ThreadDeathEvent comes in, but if !trackAllVthreads,
             // then the ThreadDeathReqest was setup to filter out vthreads. So we'll need
@@ -122,7 +124,6 @@ public class EventHandler implements Runnable {
                 ThreadDeathRequest tdr = erm.createThreadDeathRequest();
                 tdr.addThreadFilter(eventThread);
                 tdr.enable();
-                //System.out.println("TDR added: " + thread);
             }
         }
 
@@ -303,7 +304,6 @@ public class EventHandler implements Runnable {
             // just to remove this one vthread.
             EventRequestManager erm = Env.vm().eventRequestManager();
             erm.deleteEventRequest(event.request());
-            //System.out.println("TDR removed: " + thread);
         }
         return false;
     }

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -110,9 +110,11 @@ public class EventHandler implements Runnable {
             eventThread = ((LocatableEvent)event).thread();
         }
         if (eventThread != null) {
-            // This is a vthread we haven't seen before, so add it to our list.
+            // This might be a vthread we haven't seen before, so add it to the list.
             boolean added = ThreadInfo.addThread(eventThread);
             if (added) {
+                // If added, it should be a vthread. Platform threads are always added
+                // when the ThreadStart event arrives, so should already be in the list.
                 assert eventThread.isVirtual();
             }
             // If we added it, we need to make sure it eventually gets removed. Usually

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -104,10 +104,10 @@ public class EventHandler implements Runnable {
          * See if the event thread is a vthread that we need to start tracking.
          */
         ThreadReference eventThread = null;
-        if (event instanceof ClassPrepareEvent) {
-            eventThread = ((ClassPrepareEvent)event).thread();
-        } else if (event instanceof LocatableEvent) {
-            eventThread = ((LocatableEvent)event).thread();
+        if (event instanceof ClassPrepareEvent evt) {
+            eventThread = evt.thread();
+        } else if (event instanceof LocatableEvent evt) {
+            eventThread = evt.thread();
         }
         if (eventThread != null) {
             // This might be a vthread we haven't seen before, so add it to the list.

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -74,6 +74,8 @@ public class TTY implements EventNotifier {
 
     private volatile boolean shuttingDown = false;
 
+    private static boolean trackAllVthreads = false;
+
     /**
      * The number of the next source line to target for {@code list}, if any.
      */
@@ -564,7 +566,7 @@ public class TTY implements EventNotifier {
                              * arg 2 is false).
                              */
                             if ((handler == null) && Env.connection().isOpen()) {
-                                handler = new EventHandler(this, false);
+                                handler = new EventHandler(this, false, trackAllVthreads);
                             }
                         } else if (cmd.equals("memory")) {
                             evaluator.commandMemory();
@@ -792,7 +794,7 @@ public class TTY implements EventNotifier {
              * immediately, telling it (through arg 2) to stop on the
              * VM start event.
              */
-            this.handler = new EventHandler(this, true);
+            this.handler = new EventHandler(this, true, trackAllVthreads);
         }
         try {
             BufferedReader in =
@@ -972,6 +974,8 @@ public class TTY implements EventNotifier {
                         return;
                     }
                 }
+            } else if (token.equals("-trackallvthreads")) {
+                trackAllVthreads = true;
             } else if (token.equals("-X")) {
                 usageError("Use java minus X to see");
                 return;
@@ -1163,12 +1167,12 @@ public class TTY implements EventNotifier {
             }
         }
 
-        if (connectSpec.startsWith("com.sun.jdi.CommandLineLaunch:")) {
-            connectSpec += "enumeratevthreads=y,";
+        if (connectSpec.startsWith("com.sun.jdi.CommandLineLaunch:") && trackAllVthreads) {
+            //connectSpec += "enumeratevthreads=y,";
         }
 
         try {
-            Env.init(connectSpec, launchImmediately, traceFlags, javaArgs);
+            Env.init(connectSpec, launchImmediately, traceFlags, trackAllVthreads, javaArgs);
             new TTY();
         } catch(Exception e) {
             MessageOutput.printException("Internal exception:", e);

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -1168,7 +1168,7 @@ public class TTY implements EventNotifier {
         }
 
         if (connectSpec.startsWith("com.sun.jdi.CommandLineLaunch:") && trackAllVthreads) {
-            //connectSpec += "enumeratevthreads=y,";
+            connectSpec += "enumeratevthreads=y,";
         }
 
         try {

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -71,10 +71,9 @@ public class TTY implements EventNotifier {
      * The name of this tool.
      */
     private static final String progname = "jdb";
+    private static boolean trackAllVthreads;
 
-    private volatile boolean shuttingDown = false;
-
-    private static boolean trackAllVthreads = false;
+    private volatile boolean shuttingDown;
 
     /**
      * The number of the next source line to target for {@code list}, if any.
@@ -997,6 +996,8 @@ public class TTY implements EventNotifier {
                    token.startsWith("-ss") || token.startsWith("-oss") ) {
 
                 javaArgs = addArgument(javaArgs, token);
+            } else if (token.startsWith("-R")) {
+                javaArgs = addArgument(javaArgs, token.substring(2));
             } else if (token.equals("-tclassic")) {
                 usageError("Classic VM no longer supported.");
                 return;

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -71,7 +71,7 @@ public class TTY implements EventNotifier {
      * The name of this tool.
      */
     private static final String progname = "jdb";
-    private static boolean trackAllVthreads;
+    private static boolean trackVthreads;
 
     private volatile boolean shuttingDown;
 
@@ -565,7 +565,7 @@ public class TTY implements EventNotifier {
                              * arg 2 is false).
                              */
                             if ((handler == null) && Env.connection().isOpen()) {
-                                handler = new EventHandler(this, false, trackAllVthreads);
+                                handler = new EventHandler(this, false, trackVthreads);
                             }
                         } else if (cmd.equals("memory")) {
                             evaluator.commandMemory();
@@ -793,7 +793,7 @@ public class TTY implements EventNotifier {
              * immediately, telling it (through arg 2) to stop on the
              * VM start event.
              */
-            this.handler = new EventHandler(this, true, trackAllVthreads);
+            this.handler = new EventHandler(this, true, trackVthreads);
         }
         try {
             BufferedReader in =
@@ -973,8 +973,8 @@ public class TTY implements EventNotifier {
                         return;
                     }
                 }
-            } else if (token.equals("-trackallvthreads")) {
-                trackAllVthreads = true;
+            } else if (token.equals("-trackvthreads")) {
+                trackVthreads = true;
             } else if (token.equals("-X")) {
                 usageError("Use java minus X to see");
                 return;
@@ -1168,12 +1168,12 @@ public class TTY implements EventNotifier {
             }
         }
 
-        if (connectSpec.startsWith("com.sun.jdi.CommandLineLaunch:") && trackAllVthreads) {
+        if (connectSpec.startsWith("com.sun.jdi.CommandLineLaunch:") && trackVthreads) {
             connectSpec += "enumeratevthreads=y,";
         }
 
         try {
-            Env.init(connectSpec, launchImmediately, traceFlags, trackAllVthreads, javaArgs);
+            Env.init(connectSpec, launchImmediately, traceFlags, trackVthreads, javaArgs);
             new TTY();
         } catch(Exception e) {
             MessageOutput.printException("Internal exception:", e);

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -476,7 +476,7 @@ public class TTYResources extends java.util.ListResourceBundle {
              "    -connect <connector-name>:<name1>=<value1>,...\n" +
              "                      connect to target VM using named connector with listed argument values\n" +
              "    -dbgtrace [flags] print info for debugging {0}\n" +
-             "    -trackallvthreads attempt to keep track of all virtual threads\n" +
+             "    -trackvthreads    track virtual threads as they are created\n" +
              "    -tclient          run the application in the HotSpot(TM) Client Compiler\n" +
              "    -tserver          run the application in the HotSpot(TM) Server Compiler\n" +
              "\n" +

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,7 @@ public class TTYResources extends java.util.ListResourceBundle {
         {"grouping end character", "}"},
         {"Illegal Argument Exception", "Illegal Argument Exception"},
         {"Illegal connector argument", "Illegal connector argument: {0}"},
+        {"Illegal thread state", "Illegal thread state"},
         {"implementor:", "implementor: {0}"},
         {"implements:", "implements: {0}"},
         {"Initializing progname", "Initializing {0} ..."},
@@ -475,6 +476,7 @@ public class TTYResources extends java.util.ListResourceBundle {
              "    -connect <connector-name>:<name1>=<value1>,...\n" +
              "                      connect to target VM using named connector with listed argument values\n" +
              "    -dbgtrace [flags] print info for debugging {0}\n" +
+             "    -trackallvthreads attempt to keep track of all virtual threads\n" +
              "    -tclient          run the application in the HotSpot(TM) Client Compiler\n" +
              "    -tserver          run the application in the HotSpot(TM) Server Compiler\n" +
              "\n" +

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/ThreadInfo.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/ThreadInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ class ThreadInfo {
     // This is a list of all known ThreadInfo objects. It survives
     // ThreadInfo.invalidateAll, unlike the other static fields below.
     private static List<ThreadInfo> threads = Collections.synchronizedList(new ArrayList<ThreadInfo>());
+    private static List<ThreadInfo> vthreads = Collections.synchronizedList(new ArrayList<ThreadInfo>());
     private static boolean gotInitialThreads = false;
 
     private static ThreadInfo current = null;
@@ -70,7 +71,8 @@ class ThreadInfo {
         }
     }
 
-    static void addThread(ThreadReference thread) {
+    // Returns true if thread is newly added. Returns false if previously added.
+    static boolean addThread(ThreadReference thread) {
         synchronized (threads) {
             initThreads();
             ThreadInfo ti = new ThreadInfo(thread);
@@ -78,8 +80,14 @@ class ThreadInfo {
             // initialization when a particular thread might be added both
             // by a thread start event and by the initial call to threads()
             if (getThreadInfo(thread) == null) {
-                threads.add(ti);
+                if (thread.isVirtual()) {
+                    vthreads.add(ti);
+                } else {
+                    threads.add(ti);
+                }
+                return true;
             }
+            return false;
         }
     }
 
@@ -103,14 +111,28 @@ class ThreadInfo {
             MessageOutput.println("Current thread died. Execution continuing...",
                                   currentThreadName);
         }
-        threads.remove(getThreadInfo(thread));
+        if (thread.isVirtual()) {
+            vthreads.remove(getThreadInfo(thread));
+        } else {
+            threads.remove(getThreadInfo(thread));
+        }
     }
 
     static List<ThreadInfo> threads() {
         synchronized(threads) {
             initThreads();
             // Make a copy to allow iteration without synchronization
-            return new ArrayList<ThreadInfo>(threads);
+            List<ThreadInfo> list = new ArrayList<ThreadInfo>(threads);
+            list.addAll(vthreads); // also include the vthreads list
+            return list;
+        }
+    }
+
+    static List<ThreadInfo> vthreads() {
+        synchronized(threads) {
+            initThreads();
+            // Make a copy to allow iteration without synchronization
+            return new ArrayList<ThreadInfo>(vthreads);
         }
     }
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ class VMConnection {
     private final Connector connector;
     private final Map<String, com.sun.jdi.connect.Connector.Argument> connectorArgs;
     private int traceFlags;
+    private boolean trackAllVthreads;
 
     synchronized void notifyOutputComplete() {
         outputCompleteCount++;
@@ -327,7 +328,7 @@ class VMConnection {
         return (pos + 1 == arr.length);
     }
 
-    VMConnection(String connectSpec, int traceFlags, String extraOptions) {
+    VMConnection(String connectSpec, int traceFlags, boolean trackAllVthreads, String extraOptions) {
         String nameString;
         String argString;
         int index = connectSpec.indexOf(':');
@@ -347,6 +348,7 @@ class VMConnection {
 
         connectorArgs = parseConnectorArgs(connector, argString, extraOptions);
         this.traceFlags = traceFlags;
+        this.trackAllVthreads = trackAllVthreads;
     }
 
     public void setTraceFlags(int flags) {
@@ -466,8 +468,12 @@ class VMConnection {
             (new StringTokenizer("uncaught java.lang.Throwable"));
 
         ThreadStartRequest tsr = erm.createThreadStartRequest();
-        tsr.enable();
         ThreadDeathRequest tdr = erm.createThreadDeathRequest();
+        if (!trackAllVthreads) {
+            tsr.addPlatformThreadsOnlyFilter();
+            tdr.addPlatformThreadsOnlyFilter();
+        }
+        tsr.enable();
         tdr.enable();
     }
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -53,7 +53,7 @@ class VMConnection {
     private final Connector connector;
     private final Map<String, com.sun.jdi.connect.Connector.Argument> connectorArgs;
     private int traceFlags;
-    private boolean trackAllVthreads;
+    private boolean trackVthreads;
 
     synchronized void notifyOutputComplete() {
         outputCompleteCount++;
@@ -328,7 +328,7 @@ class VMConnection {
         return (pos + 1 == arr.length);
     }
 
-    VMConnection(String connectSpec, int traceFlags, boolean trackAllVthreads, String extraOptions) {
+    VMConnection(String connectSpec, int traceFlags, boolean trackVthreads, String extraOptions) {
         String nameString;
         String argString;
         int index = connectSpec.indexOf(':');
@@ -348,7 +348,7 @@ class VMConnection {
 
         connectorArgs = parseConnectorArgs(connector, argString, extraOptions);
         this.traceFlags = traceFlags;
-        this.trackAllVthreads = trackAllVthreads;
+        this.trackVthreads = trackVthreads;
     }
 
     public void setTraceFlags(int flags) {
@@ -469,7 +469,7 @@ class VMConnection {
 
         ThreadStartRequest tsr = erm.createThreadStartRequest();
         ThreadDeathRequest tdr = erm.createThreadDeathRequest();
-        if (!trackAllVthreads) {
+        if (!trackVthreads) {
             tsr.addPlatformThreadsOnlyFilter();
             tdr.addPlatformThreadsOnlyFilter();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -131,8 +131,10 @@ public class kill001 extends JdbTest {
 
         // Continue each of the threads that received the "kill" exception. Not needed
         // for the vthread case since they are not actually killed.
-        if (!vthreadMode) for (int i = 0; i < numThreads; i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+        if (!vthreadMode) {
+            for (int i = 0; i < numThreads; i++) {
+                reply = jdb.receiveReplyFor(JdbCommand.cont);
+            }
         }
 
         // make sure the debugger is at a breakpoint

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,12 +50,13 @@
  * @run main/othervm
  *      nsk.jdb.kill.kill001.kill001
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=5
+ *      -waittime=1 -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
+ *      -jdb.option="-trackallvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 
@@ -98,11 +99,14 @@ public class kill001 extends JdbTest {
         Vector v;
         String found;
         String[] threads;
+        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
 
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        // At this point we are at the breakpoint triggered by the breakHere() call done
+        // after creating all the threads. Get the list of debuggee threads.
+        threads = jdb.getThreadIdsByName(MYTHREAD);
 
         if (threads.length != numThreads) {
             log.complain("jdb should report " + numThreads + " instance of " + DEBUGGEE_THREAD);
@@ -110,13 +114,23 @@ public class kill001 extends JdbTest {
             success = false;
         }
 
+        // Kill each debuggee thread. This will cause each thread to stop in the debugger,
+        // indicating that an exception was thrown.
         for (int i = 0; i < threads.length; i++) {
+            // kill (ThreadReference.stop) is not supproted for vthreads, so we expect an error.
+            String msg = (vthreadMode ? "Illegal thread state" : "killed");
             reply = jdb.receiveReplyForWithMessageWait(JdbCommand.kill + threads[i] + " " +
                                                        DEBUGGEE_EXCEPTIONS + "[" + i + "]",
-                                                       "killed");
+                                                       msg);
         }
 
-        for (int i = 0; i <= numThreads; i++) {
+        // Continue the main thread, which is still at the breakpoint. This will resume
+        // all the debuggee threads, allowing the kill to take place.
+        reply = jdb.receiveReplyFor(JdbCommand.cont);
+
+        // Continue each of the threads that received the "kill" exception. Not needed
+        // for the vthread case since they are not actually killed.
+        if (!vthreadMode) for (int i = 0; i < numThreads; i++) {
             reply = jdb.receiveReplyFor(JdbCommand.cont);
         }
 
@@ -132,9 +146,14 @@ public class kill001 extends JdbTest {
         grep = new Paragrep(reply);
         found = grep.findFirst(DEBUGGEE_RESULT + " =" );
         if (found.length() > 0) {
-            if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
-               log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
-               success = false;
+            if (vthreadMode) {
+                if (found.indexOf(DEBUGGEE_RESULT + " = " + numThreads) < 0) {
+                    log.complain("Some " + MYTHREAD + "s were killed. " + found + " remaining");
+                    success = false;
+                }
+            } else if (found.indexOf(DEBUGGEE_RESULT + " = 0") < 0) {
+                log.complain("Not all " + MYTHREAD + "s were killed. " + found + " remaining");
+                success = false;
             }
         } else {
             log.complain("Value for " + DEBUGGEE_RESULT + " is not found.");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -57,7 +57,7 @@
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
- *      -jdb.option="-trackallvthreads"
+ *      -jdb.option="-trackvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -50,7 +50,8 @@
  * @run main/othervm
  *      nsk.jdb.kill.kill001.kill001
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=1 -verbose
+ *      -waittime=1 
+ *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -50,7 +50,7 @@
  * @run main/othervm
  *      nsk.jdb.kill.kill001.kill001
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=1 
+ *      -waittime=5
  *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package nsk.jdb.kill.kill001;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
+import nsk.share.jdi.JDIThreadFactory;
 
 import java.io.*;
 import java.util.*;
@@ -39,13 +40,14 @@ public class kill001a {
 
     static void breakHere () {}
 
-    static final String MYTHREAD         = "MyThread";
+    static final String MYTHREAD         = nsk.jdb.kill.kill001.kill001.MYTHREAD;
     static final int numThreads          = 5;   // number of threads. one lock per thread.
     static Object lock                   = new Object();
     static Object waitnotify             = new Object();
     public static volatile int notKilled = 0;
     static final String message          = "kill001a's Exception";
     static int waitTime;
+    static boolean vthreadMode           = "Virtual".equals(System.getProperty("main.wrapper"));
 
     static JdbArgumentHandler argumentHandler;
     static Log log;
@@ -69,7 +71,8 @@ public class kill001a {
         Thread holder [] = new Thread[numThreads];
 
         for (i = 0; i < numThreads ; i++) {
-            holder[i] = new MyThread(MYTHREAD + "-" + i);
+            String name = MYTHREAD + "-" + i;
+            holder[i] = JDIThreadFactory.newThread(new MyThread(name), name);
         }
 
         // lock monitor to prevent threads from finishing after they started
@@ -88,12 +91,18 @@ public class kill001a {
             breakHere();  // a break to get thread ids and then to kill MyThreads.
         }
 
-        // wait during watTime until all MyThreads will be killed
+        // wait during waitTime until all MyThreads will be killed
         long oldTime = System.currentTimeMillis();
         while ((System.currentTimeMillis() - oldTime) <= kill001a.waitTime) {
             boolean waited = false;
             for (i = 0; i < numThreads ; i++) {
-                if (holder[i].isAlive()) {
+                if (vthreadMode) {
+                    // vthreads will exit on their own without being killed, so just wait for them to exit.
+                    try {
+                        holder[i].join();
+                    } catch (InterruptedException e) {
+                    }
+                } else if (holder[i].isAlive()) {
                     waited = true;
                     try {
                         synchronized(waitnotify) {
@@ -104,7 +113,7 @@ public class kill001a {
                     }
                 }
             }
-            if (!waited) {
+            if (!waited || vthreadMode) {
                 break;
             }
         }
@@ -112,7 +121,7 @@ public class kill001a {
         log.display("notKilled == " + notKilled);
 
         for (i = 0; i < numThreads ; i++) {
-            if (holder[i].isAlive()) {
+            if (holder[i].isAlive() && !vthreadMode) {
                 log.display("Debuggee FAILED");
                 return kill001.FAILED;
             }
@@ -149,9 +158,11 @@ class MyThread extends Thread {
         // prevent thread from early finish
         synchronized (kill001a.lock) {}
 
-        // sleep during waitTime to give debugger a chance to kill debugee's thread
+        // Sleep during waitTime to give debugger a chance to kill debugee's thread.
+        // Note vthreads need a short sleep because they will never receive the kill,
+        // and therefore sleep the full time, resulting in a test timeout if too long.
         try {
-            Thread.currentThread().sleep(kill001a.waitTime);
+            Thread.currentThread().sleep(kill001a.vthreadMode ? 1000 : kill001a.waitTime);
         } catch (InterruptedException e) {
             kill001a.log.display(ThreadInterrupted);
             e.printStackTrace(kill001a.log.getOutStream());

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -50,7 +50,7 @@
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
- *      -jdb.option="-trackallvthreads"
+ *      -jdb.option="-trackvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -43,7 +43,8 @@
  * @run main/othervm
  *      nsk.jdb.threads.threads002.threads002
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=5 -verbose
+ *      -waittime=5
+ *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,12 +43,13 @@
  * @run main/othervm
  *      nsk.jdb.threads.threads002.threads002
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=5
+ *      -waittime=5 -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
+ *      -jdb.option="-trackallvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002a.java
@@ -102,7 +102,7 @@ class Lock {
     }
 }
 
-class MyThread extends Thread {
+class MyThread implements Runnable {
 
     Lock lock;
     MyThread (Lock l) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -34,7 +34,7 @@
  *  It also tests that vthreads where no event is received are not tracked.
  *  The debugee starts 5 'MyThreads'. The odd numbered threads call a
  *  method that has been setup as a breakpoint. The others do not. All
- *  5 are then suspended on a lock that the main thread posseses. The 
+ *  5 are then suspended on a lock that the main thread posseses. The
  *  'threads' command is issued at this point. The test passes if
  *  only 'MyThreads-1' and 'MyThreads-3' are reported.
  *

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -44,7 +44,8 @@
  * @run main/othervm
  *      nsk.jdb.threads.threads003.threads003
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=1 -verbose
+ *      -waittime=1
+ *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic
  *      -jdb=${test.jdk}/bin/jdb

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -113,7 +113,7 @@ public class threads003 extends JdbTest {
             failure("Unexpected number of " + THREAD_NAME + " was listed: " + threads.length +
                     "\n\texpected value: " + KNOWN_THREADS);
         }
-        
+
         // Now make sure the correct threads were reported.
         for (int i = 0; i < threads.length; i++) {
             // Switch to the thread. The reply should be the new prompt with the thread's name.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -44,7 +44,7 @@
  * @run main/othervm
  *      nsk.jdb.threads.threads003.threads003
  *      -arch=${os.family}-${os.simpleArch}
- *      -waittime=1
+ *      -waittime=5
  *      -verbose
  *      -debugee.vmkind=java
  *      -transport.address=dynamic

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ *
+ * @summary converted from VM Testbase nsk/jdb/threads/threads003.
+ * VM Testbase keywords: [jpda, jdb]
+ * VM Testbase readme:
+ * DECSRIPTION
+ *  This is a test for jdb 'threads' command in conjunction with jdb's
+ *  ability to start tracking a vthread when the first event arrives on it.
+ *  It also tests that vthreads where no event is received are not tracked.
+ *  The debugee starts 5 'MyThreads'. The odd numbered threads call a
+ *  method that has been setup as a breakpoint. The others do not. All
+ *  5 are then suspended on a lock that the main thread posseses. The 
+ *  'threads' command is issued at this point. The test passes if
+ *  only 'MyThreads-1' and 'MyThreads-3' are reported.
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @build nsk.jdb.threads.threads003.threads003a
+ * @run main/othervm
+ *      nsk.jdb.threads.threads003.threads003
+ *      -arch=${os.family}-${os.simpleArch}
+ *      -waittime=1 -verbose
+ *      -debugee.vmkind=java
+ *      -transport.address=dynamic
+ *      -jdb=${test.jdk}/bin/jdb
+ *      -java.options="${test.vm.opts} ${test.java.opts}"
+ *      -workdir=.
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
+ */
+
+package nsk.jdb.threads.threads003;
+
+import nsk.share.*;
+import nsk.share.jdb.*;
+
+import java.io.*;
+import java.util.*;
+
+public class threads003 extends JdbTest {
+
+    public static void main (String argv[]) {
+        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
+    }
+
+    public static int run(String argv[], PrintStream out) {
+        debuggeeClass =  DEBUGGEE_CLASS;
+        firstBreak = FIRST_BREAK;
+        lastBreak = LAST_BREAK;
+        return new threads003().runTest(argv, out);
+    }
+
+    static final String PACKAGE_NAME     = "nsk.jdb.threads.threads003";
+    static final String TEST_CLASS       = PACKAGE_NAME + ".threads003";
+    static final String DEBUGGEE_CLASS   = TEST_CLASS + "a";
+    static final String FIRST_BREAK      = DEBUGGEE_CLASS + ".main";
+    static final String LAST_BREAK       = DEBUGGEE_CLASS + ".breakpoint";
+    static final String THREAD_NAME      = "MyThread";
+    static final int    NUM_THREADS      = 5;
+    static final int    KNOWN_THREADS    = NUM_THREADS / 2; // only odd nubmered threads will be known threads
+
+    protected void runCases() {
+        String[] reply;
+        Paragrep grep;
+        int count;
+        Vector v;
+        String[] threads;
+        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+
+        if (!vthreadMode) {
+            // This test is only meant to be run in vthread mode.
+            log.display("Test not run in vthread mode. Exiting early.");
+            jdb.contToExit(1);
+            return;
+        }
+
+        jdb.setBreakpointInMethod(LAST_BREAK);
+        jdb.receiveReplyFor(JdbCommand.cont); // This is to get the test going
+        jdb.receiveReplyFor(JdbCommand.cont); // This is to continue after MYTHREAD-1 breakpoint
+        jdb.receiveReplyFor(JdbCommand.cont); // This is to continue after MYTHREAD-3 breakpoint
+
+        // At this point we are at the breakpoint done,after creating all the threads.
+        // Get the list of debuggee threads that jdb knows about
+        threads = jdb.getThreadIdsByName(THREAD_NAME);
+
+        // There were NUM_THREADS threads created, but only KNOWN_THREADS hit the breakpoint,
+        // so these should be the only threads found.
+        if (threads.length != KNOWN_THREADS) {
+            failure("Unexpected number of " + THREAD_NAME + " was listed: " + threads.length +
+                    "\n\texpected value: " + KNOWN_THREADS);
+        }
+        
+        // Now make sure the correct threads were reported.
+        for (int i = 0; i < threads.length; i++) {
+            // Switch to the thread. The reply should be the new prompt with the thread's name.
+            reply = jdb.receiveReplyFor(JdbCommand.thread + " " + threads[i]);
+            String prompt = THREAD_NAME + "-" + (i * 2 + 1) + "[1] ";
+            if (!reply[0].equals(prompt)) {
+                failure("Expect to find prompt \"" + prompt + "\" but found \"" + reply[0] + "\"");
+            }
+        }
+
+        jdb.contToExit(1);
+    }
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003a.java
@@ -103,7 +103,7 @@ class Lock {
     }
 }
 
-class MyThread extends Thread {
+class MyThread implements Runnable {
 
     Lock lock;
     boolean doBreakpoint;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003a.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package nsk.jdb.threads.threads002;
+package nsk.jdb.threads.threads003;
 
 import nsk.share.*;
 import nsk.share.jpda.*;
@@ -31,16 +31,16 @@ import nsk.share.jdi.JDIThreadFactory;
 import java.io.*;
 
 /* This is debuggee aplication */
-public class threads002a {
+public class threads003a {
     public static void main(String args[]) {
-        threads002a _threads002a = new threads002a();
-        System.exit(threads002.JCK_STATUS_BASE + _threads002a.runIt(args, System.out));
+        threads003a _threads003a = new threads003a();
+        System.exit(threads003.JCK_STATUS_BASE + _threads003a.runIt(args, System.out));
     }
 
-    static void lastBreak () {}
+    static void breakpoint () {}
 
-    static final String THREAD_NAME = threads002.THREAD_NAME;
-    static int numThreads           = 5;   // number of threads
+    static final String THREAD_NAME = nsk.jdb.threads.threads003.threads003.THREAD_NAME;
+    static int numThreads           = nsk.jdb.threads.threads003.threads003.NUM_THREADS;
     static Object waitnotify        = new Object();
 
     public int runIt(String args[], PrintStream out) {
@@ -53,8 +53,9 @@ public class threads002a {
         try {
             lock.setLock();
             for (int i = 0; i < numThreads ; i++) {
+                boolean doBreakpoint = i % 2 == 1;  // breakpoint on odd threads only
                 String name = THREAD_NAME + "-" + i;
-                holder[i] = JDIThreadFactory.newThread(new MyThread(lock), name);
+                holder[i] = JDIThreadFactory.newThread(new MyThread(lock, doBreakpoint), name);
                 synchronized (waitnotify) {
                     holder[i].start();
                     waitnotify.wait();
@@ -63,10 +64,10 @@ public class threads002a {
         } catch (Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in main thread: " +
                 e.getMessage());
-            System.exit(threads002.FAILED);
+            System.exit(threads003.FAILED);
         }
 
-        lastBreak();   // When jdb stops here, there should be 5 running MyThreads.
+        breakpoint();   // When jdb stops here, there should be 5 running MyThreads.
         lock.releaseLock();
 
         for (int i = 0; i < numThreads ; i++) {
@@ -80,7 +81,7 @@ public class threads002a {
         }
 
         log.display("Debuggee PASSED");
-        return threads002.PASSED;
+        return threads003.PASSED;
     }
 
 }
@@ -105,20 +106,25 @@ class Lock {
 class MyThread extends Thread {
 
     Lock lock;
-    MyThread (Lock l) {
+    boolean doBreakpoint;
+    MyThread (Lock l, boolean doBreakpoint) {
         this.lock = l;
+        this.doBreakpoint = doBreakpoint;
     }
 
     public void run() {
-        synchronized (threads002a.waitnotify) {
-            threads002a.waitnotify.notifyAll();
+        if (doBreakpoint) {
+            threads003a.breakpoint();
+        }
+        synchronized (threads003a.waitnotify) {
+            threads003a.waitnotify.notifyAll();
         }
         try {
             lock.setLock();
         } catch(Exception e) {
             System.err.println("TEST ERROR: Caught unexpected Exception while waiting in MyThread: " +
                 e.getMessage());
-            System.exit(threads002.FAILED);
+            System.exit(threads003.FAILED);
         }
         lock.releaseLock();
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
+ *      -jdb.option="-trackallvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 
@@ -101,10 +102,10 @@ public class trace001 extends JdbTest {
         jdb.setBreakpointInMethod(LAST_BREAK);
         reply = jdb.receiveReplyFor(JdbCommand.cont);
 
-        threads = jdb.getThreadIds(DEBUGGEE_THREAD);
+        threads = jdb.getThreadIdsByName(MYTHREAD);
 
         if (threads.length != 2) {
-            log.complain("jdb should report 2 instance of " + DEBUGGEE_THREAD);
+            log.complain("jdb should report 2 instance named " + MYTHREAD + "-<n>");
             log.complain("Found: " + threads.length);
             success = false;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -56,7 +56,7 @@
  *      -jdb=${test.jdk}/bin/jdb
  *      -java.options="${test.vm.opts} ${test.java.opts}"
  *      -workdir=.
- *      -jdb.option="-trackallvthreads"
+ *      -jdb.option="-trackvthreads"
  *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,11 @@ package nsk.jdb.trace.trace001;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdb.*;
+import nsk.share.jdi.JDIThreadFactory;
 
 import java.io.*;
 
-/* This is debuggee aplication */
+/* This is the debuggee application */
 public class trace001a {
     public static void main(String args[]) {
        trace001a _trace001a = new trace001a();
@@ -38,7 +39,7 @@ public class trace001a {
 
     static void lastBreak () {}
 
-    static final String MYTHREAD  = "MyThread";
+    static final String MYTHREAD  = trace001.MYTHREAD;
     static final int numThreads   = 2;   // number of threads.
 
     static Object waitnotify = new Object();
@@ -54,7 +55,8 @@ public class trace001a {
 
         for (i = 0; i < numThreads ; i++) {
             locks[i]  = new Object();
-            holder[i] = new MyThread(locks[i],MYTHREAD + "-" + i);
+            String name = MYTHREAD + "-" + i;
+            holder[i] = JDIThreadFactory.newThread(new MyThread(locks[i], name), name);
         }
 
         synchronized (waitnotify) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Jdb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -803,17 +803,9 @@ public class Jdb extends LocalProcess implements Finalizable {
     }
 
     /**
-     * Returns as string array all id's for a given <i>threadName</i>.
+     * Returns as string array all id's for a given thread name of <i>threadName</i>.
      */
-    public String[] getThreadIds(String threadName) {
-
-        if (!threadName.startsWith("(")) {
-            threadName = "(" + threadName;
-        }
-        if (!threadName.endsWith(")")) {
-            threadName = threadName + ")";
-        }
-
+    public String[] getThreadIdsByName(String threadName) {
         Vector<String> v = new Vector<String>();
         String[] reply = receiveReplyFor(JdbCommand.threads);
         Paragrep grep = new Paragrep(reply);
@@ -821,9 +813,43 @@ public class Jdb extends LocalProcess implements Finalizable {
         String[] found = grep.findStrings(threadName);
         for (int i = 0; i < found.length; i++) {
             String string = found[i];
-            int j = string.indexOf(threadName);
+            // Check for "(java.lang.Thread)" or "(java.lang.VirtualThread)"
+            String searchString = "Thread)";
+            int j = string.indexOf(searchString);
             if (j >= 0) {
-               j += threadName.length();
+               j += searchString.length(); // The threadID is right after the thread type
+               String threadId = string.substring(j, string.indexOf(" ", j));
+               v.add(threadId);
+            }
+        }
+
+        String[] result = new String[v.size()];
+        v.toArray(result);
+        return result;
+    }
+
+    /**
+     * Returns as string array all id's for a given class type of <i>threadType</i>.
+     */
+    public String[] getThreadIds(String threadType) {
+
+        if (!threadType.startsWith("(")) {
+            threadType = "(" + threadType;
+        }
+        if (!threadType.endsWith(")")) {
+            threadType = threadType + ")";
+        }
+
+        Vector<String> v = new Vector<String>();
+        String[] reply = receiveReplyFor(JdbCommand.threads);
+        Paragrep grep = new Paragrep(reply);
+
+        String[] found = grep.findStrings(threadType);
+        for (int i = 0; i < found.length; i++) {
+            String string = found[i];
+            int j = string.indexOf(threadType);
+            if (j >= 0) {
+               j += threadType.length();
                String threadId = string.substring(j, string.indexOf(" ", j));
                v.add(threadId);
             }


### PR DESCRIPTION
This PR contains a set of some what disparate but related set of changes to JDB, JDI, and nsk jdb tests and test support (Jdb.java).

jdb: Made the “kill” command support `ThreadReference.stop()` throwing `IllegalThreadStateException` for vthreads, because this is how `ThreadReference.stop()` is now spec’d. This change is in `Commands.java`. The rest of the changes are just cleanup. One of the changes in the `kill001` test is to test for this (see below)

jdb: Use `PlatformThreadOnlyFilters` to prevent `ThreadStart/Death` event for vthreads. Instead detect vthreads when events are received on them. The goal here is to prevent jdb from getting a flood of `ThreadStart/Death` events, and getting bogged down with them. With the `PlatformThreadOnlyFilters` in place, this means jdb is not notified when a vthread dies, even one that it learned about later when an event came in on it. For these each of these “learned” vthreads a separate `ThreadDeathRequest` is needed that uses the thread itself as a `ThreadFilter`. This way jdb can tell when these vthreads die. This part is handled in `EventHandler.java`. `VMConnection.java` is where `PlatformThreadOnlyFilters` are added.

jdb: Add `-trackallvthreads` option. This prevents the use of the `PlatformThreadsOnlyFilters` described above, and instead relies on jdb getting the initial set of vthreads from the debug agent via `VM.allThreads()` (by turning on the `enumeratevthreads` option), and by getting a `ThreadStart/Death` event for every vthread created/destroyed after connecting. This is basially how jdb used to work by default before any changes in this PR. There are 3 tests that rely on this behaviour and need this flag. They are `kill001`, `threads002`, and `trace001` (see below). Many more would rely on it if they were converted to use vthreads as these tests were. The bulk of the changes for this support comes from having to pass `trackAllVthreads` through all sorts of constuctors/inits. I wish there were a better way, but I couldn’t find a place to store this value as a static so it is easy to access. If you see a better way, let me know.

jdb: Track vthreads separately. jdb keeps track of every thread by creating a `ThreadInfo` for each and storing it in a `List<ThreadInfo>` called `threads`. I decided to store vthreads in a separate list. The reason is the list is needed by the `threads` command. It doesn’t use the `threads` list, but instead walks the `ThreadGroup` hierarchy and prints out the threads within each `ThreadGroup`. This doesn’t capture vthreads since they are not returned by `ThreadGroupReference.threads()`, even for the `VirtualThreads` group. So after the `threads` command has done its usual `ThreadGroup` traversal, it now also dumps all the vthreads. This is pretty much all hidden in `ThreadIterator.next()`, which automically transitions to getting threads from the vthread list after traversing all the `ThreadGroups`.

`nsk/share/jdb/Jdb.java`: Added support for `getThreadIdsByName()`: There are many jdb tests that use `Jdb.getThreadIds(<classname>)` to get all threads in the `threads` output that are an instance of `<classname>`. The problem is that after converting a test to support a vthread mode for all debuggee threads, the name of the class in the output will always be `java.lang.VirtualThread` (or `java.lang.Thread` when not in vthread mode), and not the test specific class name, which is usually something like `MyThread`.  Making `getThreadIds()` search for `java.lang.VirtualThreads` usually ends up including threads not wanted (ones that are not `MyThread`) such as the main test thread. So `getThreadIdsByName()` was added to allow searching by the thread name (actually just the prefix of the name) rather than its class. As an example, the `threads` command output used to contain a line such as:

`   (nsk.jdb.kill.kill001.MyThread)693            Thread-0            waiting in a monitor`

Now it contains:

`   (java.lang.Thread)693                         MyThread-0          waiting in a monitor`

So instead of searching for “(MyThread)” and grabbing the threadId that comes right after it, `getThreadIdsByName()` first finds all the lines of output that contain “nsk.jdb.kill.kill001.MyThread”, and then for those lines only gets the threadID that is right after “(java.lang.Thread)” or “(java.lang.VirtualThread)”.

jdb `kill001` test: Convert to support all debuggee threads being vthreads by using `JDIThreadFactory`. Enable new jdb `-trackallvthreads` option. Use new `getThreadIdsByName()` support instead of `getThreadIds()`. Allow/expect the `kill` command to fail with "Illegal thread state” when in vthread mode.

jdb `threads002` test: Convert to support all debuggee threads being vthreads by using `JDIThreadFactory`. Enable new jdb `-trackallvthreads` option. I forget why I decided to convert this test. Seems it was useful for testing something I was working on for this PR, but I can’t recall. Maybe it was so I could clone it for the new `threads003` test below.

jdb `trace001` test: Convert to support all debuggee threads being vthreads by using `JDIThreadFactory`. Enable new jdb `-trackallvthreads` option. This is a test I had converted long ago when I first experimented with the `getThreadIdsByName()` support, so I included it with this PR.

jdb `threads003` test: This is a new thread test that tests jdb’s ability to learn about a thread when an event arrives on it. It creates 5 threads, two of which receive a breakpoint. It looks at the `threads` output and checks that only those two vthreads are present. I also used this test to help confirm that the `ThreadDeath` events are only received for these two vthreads. This was done manually by looking for the “TDR removed” output generated by `EventHandler.threadDeathEvent()`. I didn’t put this into the test itself since that println is just for debugging and is now commented out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.java.net/loom pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/97.diff">https://git.openjdk.java.net/loom/pull/97.diff</a>

</details>
