### PR TITLE
Make addressing mode a property of the C++ frame type

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,13 +120,20 @@ inline frame FreezeBase::sender(const frame& f) {
     : frame(sender_sp, sender_sp, *link_addr, sender_pc);
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+static inline void relativize_one(intptr_t* const vfp, intptr_t* const hfp, int offset) {
+  assert (*(hfp + offset) == *(vfp + offset), "");
+  intptr_t* addr = hfp + offset;
+  intptr_t value = *(intptr_t**)addr - vfp;
+  *addr = value;
+}
+
+inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, frame& hf) {
   intptr_t* vfp = f.fp();
   intptr_t* hfp = hf.fp();
   assert (hfp == hf.unextended_sp() + (f.fp() - f.unextended_sp()), "");
-  assert ((f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_last_sp_offset) != 0)
+  assert ((f.at(frame::interpreter_frame_last_sp_offset) != 0)
     || (f.unextended_sp() == f.sp()), "");
-  assert (f.fp() > (intptr_t*)f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_initial_sp_offset), "");
+  assert (f.fp() > (intptr_t*)f.at(frame::interpreter_frame_initial_sp_offset), "");
 
   // on AARCH64, we may insert padding between the locals and the rest of the frame
   // (see TemplateInterpreterGenerator::generate_normal_entry, and AbstractInterpreter::layout_activation)
@@ -137,13 +144,13 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
   *hf.addr_at(frame::interpreter_frame_last_sp_offset) = hf.unextended_sp() - hf.fp();
   *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + f.interpreter_frame_method()->max_locals() - 1;
 
-  relativize(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
+  relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
 
   assert ((hf.fp() - hf.unextended_sp()) == (f.fp() - f.unextended_sp()), "");
-  assert (hf.unextended_sp() == (intptr_t*)hf.at<frame::addressing::RELATIVE>(frame::interpreter_frame_last_sp_offset), "");
-  assert (hf.unextended_sp() <= (intptr_t*)hf.at<frame::addressing::RELATIVE>(frame::interpreter_frame_initial_sp_offset), "");
-  assert (hf.fp()            >  (intptr_t*)hf.at<frame::addressing::RELATIVE>(frame::interpreter_frame_initial_sp_offset), "");
-  assert (hf.fp()            <= (intptr_t*)hf.at<frame::addressing::RELATIVE>(frame::interpreter_frame_locals_offset), "");
+  assert (hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
+  assert (hf.unextended_sp() <= (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert (hf.fp()            >  (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert (hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
 }
 
 template <typename ConfigT>
@@ -164,12 +171,12 @@ template<typename FKind>
 frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
   assert (FKind::is_instance(f), "");
   assert (!caller.is_interpreted_frame()
-    || caller.unextended_sp() == (intptr_t*)caller.at<frame::addressing::RELATIVE>(frame::interpreter_frame_last_sp_offset), "");
+    || caller.unextended_sp() == (intptr_t*)caller.at(frame::interpreter_frame_last_sp_offset), "");
 
   intptr_t *sp, *fp; // sp is really our unextended_sp
   if (FKind::interpreted) {
-    assert ((intptr_t*)f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_last_sp_offset) == nullptr
-      || f.unextended_sp() == (intptr_t*)f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_last_sp_offset), "");
+    assert ((intptr_t*)f.at(frame::interpreter_frame_last_sp_offset) == nullptr
+      || f.unextended_sp() == (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset), "");
     int locals = f.interpreter_frame_method()->max_locals();
     bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
     fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? Interpreted::stack_argsize(f) : 0);
@@ -215,11 +222,16 @@ inline void Freeze<ConfigT>::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
 }
 
 ////////
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+static inline void derelativize_one(intptr_t* const fp, int offset) {
+  intptr_t* addr = fp + offset;
+  *addr = (intptr_t)(fp + *addr);
+}
+
+inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, frame& f) {
   intptr_t* vfp = f.fp();
 
-  derelativize(vfp, frame::interpreter_frame_last_sp_offset);
-  derelativize(vfp, frame::interpreter_frame_initial_sp_offset);
+  derelativize_one(vfp, frame::interpreter_frame_last_sp_offset);
+  derelativize_one(vfp, frame::interpreter_frame_initial_sp_offset);
 }
 
 inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
@@ -238,7 +250,7 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
 
   if (FKind::interpreted) {
     intptr_t* hsp = hf.unextended_sp();
-    const int fsize = Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) - hf.unextended_sp();
+    const int fsize = Interpreted::frame_bottom(hf) - hf.unextended_sp();
     const int locals = hf.interpreter_frame_method()->max_locals();
     intptr_t* vsp = caller.unextended_sp() - fsize;
     intptr_t* fp = vsp + (hf.fp() - hsp);

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -324,12 +324,8 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return (BasicObjectLock*) addr_at(interpreter_frame_monitor_block_bottom_offset);
 }
 
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 BasicObjectLock* frame::interpreter_frame_monitor_end() const {
-  BasicObjectLock* result = (BasicObjectLock*) at<pointers>(interpreter_frame_monitor_block_top_offset);
+  BasicObjectLock* result = (BasicObjectLock*) at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
   assert(sp() <= (intptr_t*) result, "monitor end should be above the stack pointer");
   assert((intptr_t*) result < fp(),  "monitor end should be strictly below the frame pointer");
@@ -561,13 +557,9 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
-  return &interpreter_frame_tos_address<pointers>()[index];
+  return &interpreter_frame_tos_address()[index];
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -169,7 +169,6 @@
   inline address  sender_pc_maybe_signed() const;
 
   // expression stack tos if we are nested in a java call
-  template <addressing pointers = addressing::ABSOLUTE>
   intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -45,6 +45,7 @@ inline frame::frame() {
   _cb = NULL;
   _deopt_state = unknown;
   _sp_is_trusted = false;
+  _pointers = addressing::ABSOLUTE;
 }
 
 static int spin;
@@ -59,6 +60,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   _pc = pc;
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
+  _pointers = addressing::ABSOLUTE;
 
   setup(pc);
 
@@ -100,6 +102,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   _cb = cb;
   _oop_map = NULL;
   assert(_cb != NULL, "pc: " INTPTR_FORMAT, p2i(pc));
+  _pointers = addressing::ABSOLUTE;
 
   setup(pc);
 }
@@ -113,11 +116,12 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   _cb = cb;
   _oop_map = oop_map;
   assert(_cb != NULL, "pc: " INTPTR_FORMAT, p2i(pc));
+  _pointers = addressing::ABSOLUTE;
 
   setup(pc);
 }
 
-inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map, bool dummy) {
+inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map, bool relative) {
   _sp = sp;
   _unextended_sp = unextended_sp;
   _fp = fp;
@@ -126,6 +130,8 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   _oop_map = oop_map;
   _deopt_state = not_deoptimized;
   _sp_is_trusted = false;
+  _pointers = relative ? addressing::RELATIVE : addressing::ABSOLUTE;
+  assert(relative || !is_interpreted_frame(), "these interpreter frames are heap frames");
 #ifdef ASSERT
   // The following assertion has been disabled because it would sometime trap for Continuation.run, which is not *in* a continuation
   // and therefore does not clear the _cont_fastpath flag, but this is benign even in fast mode (see Freeze::setup_jump)
@@ -146,6 +152,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   _cb = CodeCache::find_blob_fast(pc);
   _oop_map = NULL;
   assert(_cb != NULL, "pc: " INTPTR_FORMAT " sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " fp: " INTPTR_FORMAT, p2i(pc), p2i(sp), p2i(unextended_sp), p2i(fp));
+  _pointers = addressing::ABSOLUTE;
 
   setup(pc);
 }
@@ -182,6 +189,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
     _deopt_state = not_deoptimized;
   }
   _sp_is_trusted = false;
+  _pointers = addressing::ABSOLUTE;
 }
 
 // Accessors
@@ -266,9 +274,8 @@ inline intptr_t** frame::interpreter_frame_locals_addr() const {
   return (intptr_t**)addr_at(interpreter_frame_locals_offset);
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
-  return (intptr_t*)at<pointers>(interpreter_frame_last_sp_offset);
+  return (intptr_t*)at(interpreter_frame_last_sp_offset);
 }
 
 inline intptr_t* frame::interpreter_frame_bcp_addr() const {
@@ -299,16 +306,15 @@ inline oop* frame::interpreter_frame_mirror_addr() const {
 }
 
 // top of expression stack
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
-  intptr_t* last_sp = interpreter_frame_last_sp<pointers>();
+  intptr_t* last_sp = interpreter_frame_last_sp();
   if (last_sp == NULL) {
     return sp();
   } else {
     // sp() may have been extended or shrunk by an adapter.  At least
     // check that we don't fall behind the legal region.
     // For top deoptimized frame last_sp == interpreter_frame_monitor_end.
-    assert(last_sp <= (intptr_t*) interpreter_frame_monitor_end<pointers>(), "bad tos");
+    assert(last_sp <= (intptr_t*) interpreter_frame_monitor_end(), "bad tos");
     return last_sp;
   }
 }
@@ -325,9 +331,8 @@ inline int frame::interpreter_frame_monitor_size() {
 // expression stack
 // (the max_stack arguments are used by the GC; see class FrameClosure)
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
-  intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end<pointers>();
+  intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
   return monitor_end-1;
 }
 

--- a/src/hotspot/cpu/aarch64/frame_helpers_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_helpers_aarch64.inline.hpp
@@ -49,11 +49,10 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return (address*)(f.fp() + frame::return_addr_offset);
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   assert (f.is_interpreted_frame(), "");
   intptr_t* la = f.addr_at(frame::interpreter_frame_sender_sp_offset);
-  *la = pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
+  *la = _pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
 }
 
 // inline address* Frame::pc_address(const frame& f) {
@@ -84,9 +83,8 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   // assert (res == f.unextended_sp(), "res: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT, p2i(res), p2i(f.unextended_sp() + 1));
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
-  return (intptr_t*)f.at<pointers>(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
+  return (intptr_t*)f.at(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
 }
 
 inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {

--- a/src/hotspot/cpu/aarch64/frame_helpers_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_helpers_aarch64.inline.hpp
@@ -52,7 +52,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   assert (f.is_interpreted_frame(), "");
   intptr_t* la = f.addr_at(frame::interpreter_frame_sender_sp_offset);
-  *la = _pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
+  *la = f._pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
 }
 
 // inline address* Frame::pc_address(const frame& f) {

--- a/src/hotspot/cpu/aarch64/instanceStackChunkKlass_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/instanceStackChunkKlass_aarch64.inline.hpp
@@ -135,7 +135,7 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
   return  mask.num_oops()
         + 1 // for the mirror oop
         + ((intptr_t*)f.interpreter_frame_monitor_begin()
-            - (intptr_t*)f.interpreter_frame_monitor_end<frame::addressing::RELATIVE>())/BasicObjectLock::size();
+            - (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -275,10 +275,6 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
@@ -497,10 +493,6 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
   return &interpreter_frame_tos_address()[index];

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -123,6 +123,4 @@
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 
-  inline intptr_t* interpreter_frame_last_sp() const;
-
 #endif // CPU_ARM_FRAME_ARM_HPP

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -123,7 +123,6 @@
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 
-  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
 #endif // CPU_ARM_FRAME_ARM_HPP

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -39,6 +39,7 @@ inline frame::frame() {
   _fp = NULL;
   _cb = NULL;
   _deopt_state = unknown;
+  _pointers = addressing::ABSOLUTE;
 }
 
 inline frame::frame(intptr_t* sp) {
@@ -61,6 +62,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
+  _pointers = addressing::ABSOLUTE;
 }
 
 inline frame::frame(intptr_t* sp, intptr_t* fp, address pc) {
@@ -85,6 +87,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   } else {
     _deopt_state = not_deoptimized;
   }
+  _pointers = addressing::ABSOLUTE;
 }
 
 
@@ -105,6 +108,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
+  _pointers = addressing::ABSOLUTE;
 }
 
 
@@ -174,7 +178,6 @@ inline oop* frame::interpreter_frame_mirror_addr() const {
 }
 
 // top of expression stack
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   intptr_t* last_sp = interpreter_frame_last_sp();
   if (last_sp == NULL ) {
@@ -200,7 +203,6 @@ inline int frame::interpreter_frame_monitor_size() {
 // expression stack
 // (the max_stack arguments are used by the GC; see class FrameClosure)
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
   return monitor_end-1;
@@ -246,7 +248,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -248,11 +248,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-inline intptr_t* frame::interpreter_frame_last_sp() const {
-  Unimplemented();
-  return NULL;
-}
-
 inline int frame::sender_sp_ret_address_offset() {
   Unimplemented();
   return 0;

--- a/src/hotspot/cpu/arm/frame_helpers_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_helpers_arm.inline.hpp
@@ -49,7 +49,6 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +72,6 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/ppc/frame_helpers_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_helpers_ppc.inline.hpp
@@ -49,7 +49,6 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +72,6 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -387,25 +387,18 @@ intptr_t *frame::initial_deoptimization_info() {
 
 #ifndef PRODUCT
 // This is a generic constructor which is only used by pns() in debug.cpp.
-frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp), _unextended_sp((intptr_t*)sp) {
+frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp), _unextended_sp((intptr_t*)sp),
+                                             _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // also sets _fp and adjusts _unextended_sp
 }
 
 #endif
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_ijava_state()->monitors;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -387,8 +387,9 @@ intptr_t *frame::initial_deoptimization_info() {
 
 #ifndef PRODUCT
 // This is a generic constructor which is only used by pns() in debug.cpp.
-frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp), _unextended_sp((intptr_t*)sp),
-                                             _pointers(addressing::ABSOLUTE) {
+frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp),
+                                             _pointers(addressing::ABSOLUTE),
+                                             _unextended_sp((intptr_t*)sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // also sets _fp and adjusts _unextended_sp
 }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -401,7 +401,6 @@
   inline void interpreter_frame_set_top_frame_sp(intptr_t* top_frame_sp);
   inline void interpreter_frame_set_sender_sp(intptr_t* sender_sp);
 
-  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -55,19 +55,21 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL),  _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL),
-                        _pointers(addressing::ABSOLUTE) {}
+inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL),  _deopt_state(unknown),
+                        _pointers(addressing::ABSOLUTE),
+                        _unextended_sp(NULL), _fp(NULL) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp) : _sp(sp),  _pointers(addressing::ABSOLUTE), _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->lr); // also sets _fp and adjusts _unextended_sp
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _pointers(addressing::ABSOLUTE), _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp),
-                    _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp),
+                    _pointers(addressing::ABSOLUTE),
+                    _unextended_sp(unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -55,17 +55,19 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL),  _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL) {}
+inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL),  _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL),
+                        _pointers(addressing::ABSOLUTE) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->lr); // also sets _fp and adjusts _unextended_sp
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp) {
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp),
+                    _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }
 
@@ -171,13 +173,11 @@ inline void frame::interpreter_frame_set_esp(intptr_t* esp)                   { 
 inline void frame::interpreter_frame_set_top_frame_sp(intptr_t* top_frame_sp) { get_ijava_state()->top_frame_sp = (intptr_t) top_frame_sp; }
 inline void frame::interpreter_frame_set_sender_sp(intptr_t* sender_sp)       { get_ijava_state()->sender_sp = (intptr_t) sender_sp; }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   return (intptr_t*)interpreter_frame_monitor_end() - 1;
 }
 
 // top of expression stack
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return ((intptr_t*) get_ijava_state()->esp) + Interpreter::stackElementWords;
 }
@@ -228,7 +228,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/s390/frame_helpers_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_helpers_s390.inline.hpp
@@ -49,7 +49,6 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +72,6 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -644,18 +644,10 @@ intptr_t *frame::initial_deoptimization_info() {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return interpreter_frame_monitors();
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -486,7 +486,6 @@
   address* sender_pc_addr(void) const;
 
  public:
-  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -54,24 +54,26 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL) {}
+inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL),
+                        _pointers(addressing::ABSOLUTE) { }
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->return_pc);
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp) {
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp),
+                                                                         _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
 
 // Generic constructor. Used by pns() in debug.cpp only
 #ifndef PRODUCT
 inline frame::frame(void* sp, void* pc, void* unextended_sp) :
-  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _unextended_sp((intptr_t*)unextended_sp) {
+  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _unextended_sp((intptr_t*)unextended_sp), _pointers(addressing::ABSOLUTE) {
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // Also sets _fp and adjusts _unextended_sp.
 }
 #endif
@@ -168,7 +170,6 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
 }
 
 // Bottom(base) of the expression stack (highest address).
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   return (intptr_t*)interpreter_frame_monitor_end() - 1;
 }
@@ -202,7 +203,6 @@ inline intptr_t** frame::interpreter_frame_esp_addr() const {
 }
 
 // top of expression stack (lowest address)
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return *interpreter_frame_esp_addr() + 1;
 }
@@ -295,7 +295,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -54,26 +54,30 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _unextended_sp(NULL), _fp(NULL),
-                        _pointers(addressing::ABSOLUTE) { }
+inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown),
+                        _pointers(addressing::ABSOLUTE),
+                        _unextended_sp(NULL), _fp(NULL) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp) : _sp(sp), _pointers(addressing::ABSOLUTE), _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->return_pc);
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _unextended_sp(sp), _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _pointers(addressing::ABSOLUTE), _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _unextended_sp(unextended_sp),
-                                                                         _pointers(addressing::ABSOLUTE) {
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp),
+                                                                         _pointers(addressing::ABSOLUTE),
+                                                                         _unextended_sp(unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
 
 // Generic constructor. Used by pns() in debug.cpp only
 #ifndef PRODUCT
 inline frame::frame(void* sp, void* pc, void* unextended_sp) :
-  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _unextended_sp((intptr_t*)unextended_sp), _pointers(addressing::ABSOLUTE) {
+  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL),
+   _pointers(addressing::ABSOLUTE),
+  _unextended_sp((intptr_t*)unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // Also sets _fp and adjusts _unextended_sp.
 }
 #endif

--- a/src/hotspot/cpu/x86/frame_helpers_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_helpers_x86.inline.hpp
@@ -49,11 +49,10 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return (address*)(f.fp() + frame::return_addr_offset);
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   assert (f.is_interpreted_frame(), "");
   intptr_t* la = f.addr_at(frame::interpreter_frame_sender_sp_offset);
-  *la = pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
+  *la = f._pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
 }
 
 // inline address* Frame::pc_address(const frame& f) {
@@ -84,9 +83,8 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   // assert (res == f.unextended_sp(), "res: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT, p2i(res), p2i(f.unextended_sp() + 1));
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
-  return (intptr_t*)f.at<pointers>(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
+  return (intptr_t*)f.at(frame::interpreter_frame_locals_offset) + 1; // exclusive, so we add 1 word
 }
 
 inline intptr_t* Interpreted::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -326,12 +326,8 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
   return (BasicObjectLock*) addr_at(interpreter_frame_monitor_block_bottom_offset);
 }
 
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 BasicObjectLock* frame::interpreter_frame_monitor_end() const {
-  BasicObjectLock* result = (BasicObjectLock*) at<pointers>(interpreter_frame_monitor_block_top_offset);
+  BasicObjectLock* result = (BasicObjectLock*) at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
   assert(sp() <= (intptr_t*) result, "monitor end should be above the stack pointer");
   assert((intptr_t*) result < fp(),  "monitor end should be strictly below the frame pointer: result: " INTPTR_FORMAT " fp: " INTPTR_FORMAT, p2i(result), p2i(fp()));
@@ -593,13 +589,9 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
-  return &interpreter_frame_tos_address<pointers>()[index];
+  return &interpreter_frame_tos_address()[index];
 }
 
 #ifndef PRODUCT
@@ -651,6 +643,27 @@ frame::frame(void* sp, void* fp, void* pc) {
 }
 
 #endif
+
+void frame::print_raw() const {
+  tty->print_cr("pc_return " INTPTR_FORMAT, *addr_at(pc_return_offset));
+  tty->print_cr("link " INTPTR_FORMAT, *addr_at(link_offset));
+  tty->print_cr("return_addr " INTPTR_FORMAT, *addr_at(return_addr_offset));
+  tty->print_cr("sender_sp " INTPTR_FORMAT, *addr_at(sender_sp_offset));
+  tty->print_cr("interpreter_frame_result_handler " INTPTR_FORMAT, *addr_at(interpreter_frame_result_handler_offset));
+  tty->print_cr("interpreter_frame_oop_temp " INTPTR_FORMAT, *addr_at(interpreter_frame_oop_temp_offset));
+  tty->print_cr("interpreter_frame_sender_sp " INTPTR_FORMAT, *addr_at(interpreter_frame_sender_sp_offset));
+  tty->print_cr("interpreter_frame_last_sp " INTPTR_FORMAT, *addr_at(interpreter_frame_last_sp_offset));
+  tty->print_cr("interpreter_frame_method " INTPTR_FORMAT, *addr_at(interpreter_frame_method_offset));
+  tty->print_cr("interpreter_frame_mirror " INTPTR_FORMAT, *addr_at(interpreter_frame_mirror_offset));
+  tty->print_cr("interpreter_frame_mdp " INTPTR_FORMAT, *addr_at(interpreter_frame_mdp_offset));
+  tty->print_cr("interpreter_frame_cache " INTPTR_FORMAT, *addr_at(interpreter_frame_cache_offset));
+  tty->print_cr("interpreter_frame_locals " INTPTR_FORMAT, *addr_at(interpreter_frame_locals_offset));
+  tty->print_cr("interpreter_frame_bcp " INTPTR_FORMAT, *addr_at(interpreter_frame_bcp_offset));
+  tty->print_cr("interpreter_frame_initial_sp " INTPTR_FORMAT, *addr_at(interpreter_frame_initial_sp_offset));
+  tty->print_cr("interpreter_frame_monitor_block_top " INTPTR_FORMAT, *addr_at(interpreter_frame_monitor_block_top_offset));
+  tty->print_cr("interpreter_frame_monitor_block_bottom " INTPTR_FORMAT, *addr_at(interpreter_frame_monitor_block_bottom_offset));
+  tty->print_cr("address::%s", _pointers == addressing::RELATIVE ? "relative" : "absolute");
+}
 
 void JavaFrameAnchor::make_walkable(JavaThread* thread) {
   // last frame set?

--- a/src/hotspot/cpu/x86/frame_x86.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.hpp
@@ -142,7 +142,7 @@
 
   frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map);
 
-  frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map, bool dummy); // used for fast frame construction by continuations
+  frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address pc, CodeBlob* cb, const ImmutableOopMap* oop_map, bool relative); // used for fast frame construction by continuations
 
   frame(intptr_t* sp, intptr_t* fp);
 
@@ -159,7 +159,6 @@
   inline address* sender_pc_addr() const;
 
   // expression stack tos if we are nested in a java call
-  template <addressing pointers = addressing::ABSOLUTE>
   intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/instanceStackChunkKlass_x86.inline.hpp
@@ -135,7 +135,7 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
   return  mask.num_oops()
         + 1 // for the mirror oop
         + ((intptr_t*)f.interpreter_frame_monitor_begin()
-            - (intptr_t*)f.interpreter_frame_monitor_end<frame::addressing::RELATIVE>())/BasicObjectLock::size();
+            - (intptr_t*)f.interpreter_frame_monitor_end())/BasicObjectLock::size();
 }
 
 inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {

--- a/src/hotspot/cpu/zero/frame_helpers_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_helpers_zero.inline.hpp
@@ -49,7 +49,6 @@ inline address* Interpreted::return_pc_address(const frame& f) {
   return NULL;
 }
 
-template <frame::addressing pointers>
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
   Unimplemented();
 }
@@ -73,7 +72,6 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   return NULL;
 }
 
-template <frame::addressing pointers>
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
   Unimplemented();
   return NULL;

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -83,10 +83,6 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::ABSOLUTE>() const;
-template BasicObjectLock* frame::interpreter_frame_monitor_end<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_interpreterState()->stack_base();
 }
@@ -224,10 +220,6 @@ BasicType frame::interpreter_frame_result(oop* oop_result,
   return type;
 }
 
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::ABSOLUTE>(jint offset) const;
-template intptr_t* frame::interpreter_frame_tos_at<frame::addressing::RELATIVE>(jint offset) const;
-
-template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset) / wordSize);
   return &interpreter_frame_tos_address()[index];

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -77,7 +77,6 @@
 
   inline address* sender_pc_addr() const;
 
-  template <addressing pointers = addressing::ABSOLUTE>
   inline intptr_t* interpreter_frame_last_sp() const;
 
   template <typename RegisterMapT>

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -36,6 +36,7 @@ inline frame::frame() {
   _pc = NULL;
   _cb = NULL;
   _deopt_state = unknown;
+  _pointers = addressing::ABSOLUTE;
 }
 
 inline address  frame::sender_pc()           const { ShouldNotCallThis(); return NULL; }
@@ -47,6 +48,7 @@ inline frame::frame(intptr_t* sp) {
 inline frame::frame(ZeroFrame* zf, intptr_t* sp) {
   _zeroframe = zf;
   _sp = sp;
+  _pointers = addressing::ABSOLUTE;
   switch (zeroframe()->type()) {
   case ZeroFrame::ENTRY_FRAME:
     _pc = StubRoutines::call_stub_return_pc();
@@ -115,7 +117,6 @@ inline intptr_t* frame::interpreter_frame_mdp_addr() const {
   return NULL; // silence compiler warnings
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_tos_address() const {
   return get_interpreterState()->_stack + 1;
 }
@@ -129,7 +130,6 @@ inline int frame::interpreter_frame_monitor_size() {
   return BasicObjectLock::size();
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_expression_stack() const {
   intptr_t* monitor_end = (intptr_t*) interpreter_frame_monitor_end();
   return monitor_end - 1;
@@ -183,7 +183,6 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
   Unimplemented();
 }
 
-template <frame::addressing pointers>
 inline intptr_t* frame::interpreter_frame_last_sp() const {
   Unimplemented();
   return NULL;

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -791,7 +791,7 @@ public:
     HandleMark hm(Thread::current());
 
     frame fr = f.to_frame();
-    fr.template describe<frame::addressing::RELATIVE>(_values, _frame_no++, get_map(map, f.sp()));
+    fr.describe(_values, _frame_no++, get_map(map, f.sp()));
     return true;
   }
 
@@ -826,7 +826,7 @@ public:
     frame f = fs.to_frame();
     _st->print_cr("-- frame sp: " INTPTR_FORMAT " interpreted: %d size: %d argsize: %d",
       p2i(fs.sp()), fs.is_interpreted(), f.frame_size(), fs.is_interpreted() ? 0 : f.compiled_frame_stack_argsize());
-    f.print_on<frame::addressing::RELATIVE>(_st);
+    f.print_on(_st);
     const ImmutableOopMap* oopmap = fs.oopmap();
     if (oopmap != nullptr) {
       oopmap->print_on(_st);
@@ -878,6 +878,6 @@ template <chunk_frames frames>
 void StackChunkFrameStream<frames>::print_on(outputStream* st) const {
   st->print_cr("chunk: " INTPTR_FORMAT " index: %d sp offset: %d stack size: %d",
     p2i(_chunk), _index, _chunk->to_offset(_sp), _chunk->stack_size());
-  to_frame().template print_on<frame::addressing::RELATIVE>(st);
+  to_frame().print_on(st);
 }
 #endif

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -322,7 +322,7 @@ template <class OopClosureType, class RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::iterate_oops(OopClosureType* closure, const RegisterMapT* map) const {
   if (is_interpreted()) {
     frame f = to_frame();
-    f.oops_interpreted_do<frame::addressing::RELATIVE>(closure, nullptr, true);
+    f.oops_interpreted_do(closure, nullptr, true);
   } else {
     DEBUG_ONLY(int oops = 0;)
     for (OopMapStream oms(oopmap()); !oms.is_done(); oms.next()) {

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -199,11 +199,15 @@ inline address stackChunkOopDesc::interpreter_frame_bcp(const frame& fr) {
 }
 
 inline intptr_t* stackChunkOopDesc::interpreter_frame_expression_stack_at(const frame& fr, int index) const {
-  return derelativize(fr).interpreter_frame_expression_stack_at<frame::addressing::RELATIVE>(index);
+  frame heap_frame = derelativize(fr);
+  assert(heap_frame.is_heap_frame(), "must be");
+  return heap_frame.interpreter_frame_expression_stack_at(index);
 }
 
 inline intptr_t* stackChunkOopDesc::interpreter_frame_local_at(const frame& fr, int index) const {
-  return derelativize(fr).interpreter_frame_local_at<frame::addressing::RELATIVE>(index);
+  frame heap_frame = derelativize(fr);
+  assert(heap_frame.is_heap_frame(), "must be");
+  return heap_frame.interpreter_frame_local_at(index);
 }
 
 template <copy_alignment alignment>

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -200,13 +200,13 @@ inline address stackChunkOopDesc::interpreter_frame_bcp(const frame& fr) {
 
 inline intptr_t* stackChunkOopDesc::interpreter_frame_expression_stack_at(const frame& fr, int index) const {
   frame heap_frame = derelativize(fr);
-  assert(heap_frame.is_heap_frame(), "must be");
+  assert(heap_frame.is_interpreted_heap_frame(), "must be");
   return heap_frame.interpreter_frame_expression_stack_at(index);
 }
 
 inline intptr_t* stackChunkOopDesc::interpreter_frame_local_at(const frame& fr, int index) const {
   frame heap_frame = derelativize(fr);
-  assert(heap_frame.is_heap_frame(), "must be");
+  assert(heap_frame.is_interpreted_heap_frame(), "must be");
   return heap_frame.interpreter_frame_local_at(index);
 }
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1416,7 +1416,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       DEBUG_ONLY(hf.print_value_on(&ls, nullptr);)
-      assert(hf.is_heap_frame(), "should be heap frame");
+      assert(hf.is_interpreted_heap_frame(), "should be");
       DEBUG_ONLY(print_frame_layout(hf, &ls);)
       if (bottom) {
         ls.print_cr("bottom h-frame:");
@@ -1544,7 +1544,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe before (freeze):");
-      assert(caller.is_heap_frame(), "should be heap frame");
+      assert(caller.is_interpreted_heap_frame(), "should be");
       caller.print_on(&ls);
     }
 
@@ -1573,7 +1573,7 @@ public:
       patch_pd<FKind, false>(hf, caller);
     }
     if (FKind::interpreted) {
-      assert(hf.is_heap_frame(), "should be heap frame");
+      assert(hf.is_interpreted_heap_frame(), "should be");
       Interpreted::patch_sender_sp(hf, caller.unextended_sp());
     }
 
@@ -1734,7 +1734,7 @@ public:
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
-      assert(top.is_heap_frame(), "should be heap frame");
+      assert(top.is_interpreted_heap_frame(), "should be");
       top.print_on(&ls);
     }
 
@@ -1757,7 +1757,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe after (freeze):");
-      assert(_cont.last_frame().is_heap_frame(), "should be heap frame");
+      assert(_cont.last_frame().is_interpreted_heap_frame(), "should be");
       _cont.last_frame().print_on(&ls);
     }
 
@@ -2408,7 +2408,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe before (thaw):");
-      assert(hf.is_heap_frame(), "should have created a relative frame");
+      assert(hf.is_interpreted_heap_frame(), "should have created a relative frame");
       hf.print_on(&ls);
     }
 
@@ -2524,7 +2524,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("======== THAWING FRAME: %d", num_frame);
-      assert(hf.is_heap_frame(), "should be heap frame");
+      assert(hf.is_interpreted_heap_frame(), "should be");
       hf.print_on(&ls);
     }
     assert (bottom == _cont.is_entry_frame(caller), "bottom: %d is_entry_frame: %d", bottom, _cont.is_entry_frame(hf));
@@ -2576,7 +2576,7 @@ public:
     intptr_t* const hsp = hf.unextended_sp();
     intptr_t* const frame_bottom = Interpreted::frame_bottom(f);
 
-    assert(hf.is_heap_frame(), "should be heap frame");
+    assert(hf.is_interpreted_heap_frame(), "should be");
     const int fsize = Interpreted::frame_bottom(hf) - hsp;
 
     assert (!bottom || vsp + fsize >= _cont.entrySP() - 2, "");
@@ -2586,8 +2586,8 @@ public:
 
     // on AArch64 we add padding between the locals and the rest of the frame to keep the fp 16-byte-aligned
     const int locals = hf.interpreter_frame_method()->max_locals();
-    assert(hf.is_heap_frame(), "should be heap frame");
-    assert(!f.is_heap_frame(), "should be heap frame");
+    assert(hf.is_interpreted_heap_frame(), "should be");
+    assert(!f.is_interpreted_heap_frame(), "should not be");
 
     copy_from_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom(hf) - locals,
                                           Interpreted::frame_bottom(f) - locals, locals); // copy locals
@@ -2616,7 +2616,7 @@ public:
       // can only fix caller once this frame is thawed (due to callee saved regs)
       InstanceStackChunkKlass::fix_thawed_frame(_cont.tail(), caller, SmallRegisterMap::instance);
     } else if (_cont.tail()->has_bitmap() && locals > 0) {
-      assert(hf.is_heap_frame(), "should be heap frame");
+      assert(hf.is_interpreted_heap_frame(), "should be");
       clear_bitmap_bits(Interpreted::frame_bottom(hf) - locals, locals);
     }
 
@@ -2761,7 +2761,7 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe after (thaw):");
-      assert(_cont.last_frame().is_heap_frame(), "should be heap frame");
+      assert(_cont.last_frame().is_interpreted_heap_frame(), "should be");
       _cont.last_frame().print_on(&ls);
     }
   }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -185,7 +185,6 @@ static bool do_verify_after_thaw(JavaThread* thread, int mode, bool barriers, st
 #endif
 
 #ifndef PRODUCT
-template <frame::addressing pointers>
 static void print_frame_layout(const frame& f, outputStream* st = tty);
 static void print_frames(JavaThread* thread, outputStream* st = tty);
 static jlong java_tid(JavaThread* thread);
@@ -1003,15 +1002,8 @@ void Continuation::debug_print_continuation(oop contOop, outputStream* st) {
 
 class FreezeBase { // avoids the template of the Freeze class
 protected:
-  static inline void relativize_interpreted_frame_metadata(const frame& f, const frame& hf);
+  static inline void relativize_interpreted_frame_metadata(const frame& f, frame& hf);
   template<typename FKind> static inline frame sender(const frame& f);
-
-  static inline void relativize(intptr_t* const vfp, intptr_t* const hfp, int offset) {
-    assert (*(hfp + offset) == *(vfp + offset), "");
-    intptr_t* addr = hfp + offset;
-    intptr_t value = *(intptr_t**)addr - vfp;
-    *addr = value;
-  }
 };
 
 template <typename ConfigT>
@@ -1424,10 +1416,11 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       DEBUG_ONLY(hf.print_value_on(&ls, nullptr);)
-      DEBUG_ONLY(print_frame_layout<frame::addressing::RELATIVE>(hf, &ls);)
+      assert(hf.is_heap_frame(), "should be heap frame");
+      DEBUG_ONLY(print_frame_layout(hf, &ls);)
       if (bottom) {
         ls.print_cr("bottom h-frame:");
-        hf.print_on<frame::addressing::RELATIVE>(&ls);
+        hf.print_on(&ls);
       }
     }
   }
@@ -1551,7 +1544,8 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe before (freeze):");
-      caller.print_on<frame::addressing::RELATIVE>(&ls);
+      assert(caller.is_heap_frame(), "should be heap frame");
+      caller.print_on(&ls);
     }
 
     assert (!empty || Continuation::is_continuation_entry_frame(callee, nullptr), "");
@@ -1579,7 +1573,8 @@ public:
       patch_pd<FKind, false>(hf, caller);
     }
     if (FKind::interpreted) {
-      Interpreted::patch_sender_sp<frame::addressing::RELATIVE>(hf, caller.unextended_sp());
+      assert(hf.is_heap_frame(), "should be heap frame");
+      Interpreted::patch_sender_sp(hf, caller.unextended_sp());
     }
 
 #ifdef ASSERT
@@ -1597,8 +1592,8 @@ public:
   NOINLINE freeze_result recurse_freeze_interpreted_frame(frame& f, frame& caller, int callee_argsize, bool callee_interpreted) {
 #if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
     { // TODO PD
-      assert ((f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
-      intptr_t* real_unextended_sp = (intptr_t*)f.at<frame::addressing::ABSOLUTE>(frame::interpreter_frame_last_sp_offset);
+      assert ((f.at(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
+      intptr_t* real_unextended_sp = (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset);
       if (real_unextended_sp != nullptr) f.set_unextended_sp(real_unextended_sp); // can be null at a safepoint
     }
 #else
@@ -1608,7 +1603,7 @@ public:
     intptr_t* const vsp = Interpreted::frame_top(f, callee_argsize, callee_interpreted);
     const int argsize = Interpreted::stack_argsize(f);
     const int locals = f.interpreter_frame_method()->max_locals();
-    assert (Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f) >= f.fp() + ContinuationHelper::frame_metadata + locals, "");// = on x86
+    assert (Interpreted::frame_bottom(f) >= f.fp() + ContinuationHelper::frame_metadata + locals, "");// = on x86
     const int fsize = f.fp() + ContinuationHelper::frame_metadata + locals - vsp;
 
 #ifdef ASSERT
@@ -1637,11 +1632,11 @@ public:
     frame hf = new_hframe<Interpreted>(f, caller);
 
     intptr_t* hsp = Interpreted::frame_top(hf, callee_argsize, callee_interpreted);
-    assert (Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) == hsp + fsize, "");
+    assert (Interpreted::frame_bottom(hf) == hsp + fsize, "");
 
     // on AArch64 we add padding between the locals and the rest of the frame to keep the fp 16-byte-aligned
-    copy_to_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f) - locals,
-                                             Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) - locals, locals); // copy locals
+    copy_to_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom(f) - locals,
+                                             Interpreted::frame_bottom(hf) - locals, locals); // copy locals
     copy_to_chunk<copy_alignment::WORD_ALIGNED>(vsp, hsp, fsize - locals); // copy rest
     assert (!bottom || !caller.is_interpreted_frame() || (hsp + fsize) == (caller.unextended_sp() + argsize), "");
 
@@ -1739,7 +1734,8 @@ public:
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
-      top.print_on<frame::addressing::RELATIVE>(&ls);
+      assert(top.is_heap_frame(), "should be heap frame");
+      top.print_on(&ls);
     }
 
     set_top_frame_metadata_pd(top);
@@ -1761,7 +1757,8 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe after (freeze):");
-      _cont.last_frame().template print_on<frame::addressing::RELATIVE>(&ls);
+      assert(_cont.last_frame().is_heap_frame(), "should be heap frame");
+      _cont.last_frame().print_on(&ls);
     }
 
     assert(_cont.chunk_invariant(tty), "");
@@ -2178,13 +2175,8 @@ static inline int prepare_thaw0(JavaThread* thread, bool return_barrier) {
 
 class ThawBase { // avoids the template of the Thaw class
 protected:
-  static inline void derelativize_interpreted_frame_metadata(const frame& hf, const frame& f);
+  static inline void derelativize_interpreted_frame_metadata(const frame& hf, frame& f);
   static inline void set_interpreter_frame_bottom(const frame& f, intptr_t* bottom);
-
-  static inline void derelativize(intptr_t* const fp, int offset) {
-    intptr_t* addr = fp + offset;
-    *addr = (intptr_t)(fp + *addr);
-  }
 };
 
 template <typename ConfigT>
@@ -2416,7 +2408,8 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe before (thaw):");
-      hf.print_on<frame::addressing::RELATIVE>(&ls);
+      assert(hf.is_heap_frame(), "should have created a relative frame");
+      hf.print_on(&ls);
     }
 
     frame f;
@@ -2531,7 +2524,8 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("======== THAWING FRAME: %d", num_frame);
-      hf.print_on<frame::addressing::RELATIVE>(&ls);
+      assert(hf.is_heap_frame(), "should be heap frame");
+      hf.print_on(&ls);
     }
     assert (bottom == _cont.is_entry_frame(caller), "bottom: %d is_entry_frame: %d", bottom, _cont.is_entry_frame(hf));
   }
@@ -2554,7 +2548,7 @@ public:
     patch_pd<FKind, bottom>(f, caller); // TODO: reevaluate if and when this is necessary -only bottom & interpreted caller?
 
     if (FKind::interpreted) {
-      Interpreted::patch_sender_sp<frame::addressing::ABSOLUTE>(f, caller.unextended_sp());
+      Interpreted::patch_sender_sp(f, caller.unextended_sp());
     }
 
     assert (!bottom || !_cont.is_empty() || Continuation::is_continuation_entry_frame(f, nullptr), "");
@@ -2577,21 +2571,26 @@ public:
     DEBUG_ONLY(before_thaw_java_frame(hf, caller, bottom, num_frames);)
 
     frame f = new_frame<Interpreted>(hf, caller, bottom);
+
     intptr_t* const vsp = f.sp();
     intptr_t* const hsp = hf.unextended_sp();
-    intptr_t* const frame_bottom = Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f);
+    intptr_t* const frame_bottom = Interpreted::frame_bottom(f);
 
-    const int fsize = Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) - hsp;
+    assert(hf.is_heap_frame(), "should be heap frame");
+    const int fsize = Interpreted::frame_bottom(hf) - hsp;
 
     assert (!bottom || vsp + fsize >= _cont.entrySP() - 2, "");
     assert (!bottom || vsp + fsize <= _cont.entrySP(), "");
 
-    assert (Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f) == vsp + fsize, "");
+    assert (Interpreted::frame_bottom(f) == vsp + fsize, "");
 
     // on AArch64 we add padding between the locals and the rest of the frame to keep the fp 16-byte-aligned
     const int locals = hf.interpreter_frame_method()->max_locals();
-    copy_from_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) - locals,
-                                          Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f) - locals, locals); // copy locals
+    assert(hf.is_heap_frame(), "should be heap frame");
+    assert(!f.is_heap_frame(), "should be heap frame");
+
+    copy_from_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom(hf) - locals,
+                                          Interpreted::frame_bottom(f) - locals, locals); // copy locals
     copy_from_chunk<copy_alignment::WORD_ALIGNED>(hsp, vsp, fsize - locals); // copy rest
 
     set_interpreter_frame_bottom(f, frame_bottom); // the copy overwrites the metadata
@@ -2602,12 +2601,12 @@ public:
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
-      print_frame_layout<frame::addressing::ABSOLUTE>(f, &ls);
+      print_frame_layout(f, &ls);
     }
   #endif
 
     assert(f.is_interpreted_frame_valid(_cont.thread()), "invalid thawed frame");
-    assert(Interpreted::frame_bottom<frame::addressing::ABSOLUTE>(f) <= Frame::frame_top(caller), "");
+    assert(Interpreted::frame_bottom(f) <= Frame::frame_top(caller), "");
 
     CONT_JFR_ONLY(_cont.record_interpreted_frame();)
 
@@ -2617,7 +2616,8 @@ public:
       // can only fix caller once this frame is thawed (due to callee saved regs)
       InstanceStackChunkKlass::fix_thawed_frame(_cont.tail(), caller, SmallRegisterMap::instance);
     } else if (_cont.tail()->has_bitmap() && locals > 0) {
-      clear_bitmap_bits(Interpreted::frame_bottom<frame::addressing::RELATIVE>(hf) - locals, locals);
+      assert(hf.is_heap_frame(), "should be heap frame");
+      clear_bitmap_bits(Interpreted::frame_bottom(hf) - locals, locals);
     }
 
     DEBUG_ONLY(after_thaw_java_frame(f, bottom);)
@@ -2761,7 +2761,8 @@ public:
     if (lt.develop_is_enabled()) {
       LogStream ls(lt);
       ls.print_cr("top hframe after (thaw):");
-      _cont.last_frame().template print_on<frame::addressing::RELATIVE>(&ls);
+      assert(_cont.last_frame().is_heap_frame(), "should be heap frame");
+      _cont.last_frame().print_on(&ls);
     }
   }
 
@@ -3008,16 +3009,17 @@ static jlong java_tid(JavaThread* thread) {
   return java_lang_Thread::thread_id(thread->threadObj());
 }
 
-template <frame::addressing pointers>
 static void print_frame_layout(const frame& f, outputStream* st) {
   ResourceMark rm;
   FrameValues values;
   assert (f.get_cb() != nullptr, "");
-  RegisterMap map(pointers == frame::addressing::RELATIVE ? (JavaThread*)nullptr : JavaThread::current(), true, false, false);
+  RegisterMap map(f._pointers == frame::addressing::RELATIVE ?
+                     (JavaThread*)nullptr :
+                     JavaThread::current(), true, false, false);
   map.set_include_argument_oops(false);
   map.set_skip_missing(true);
   frame::update_map_with_saved_link(&map, Frame::callee_link_address(f));
-  const_cast<frame&>(f).describe<pointers>(values, 0, &map);
+  const_cast<frame&>(f).describe(values, 0, &map);
   values.print_on((JavaThread*)nullptr, st);
 }
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1149,8 +1149,8 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, DerivedOopClosu
   }
 #endif
   if (is_interpreted_frame()) {
-    !map->in_cont() != NULL ? oops_interpreted_do(f, map, use_interpreter_oop_map_cache)
-                            : oops_interpreted_do(f, map, use_interpreter_oop_map_cache);
+    !map->in_cont() ? oops_interpreted_do(f, map, use_interpreter_oop_map_cache)
+                    : oops_interpreted_do(f, map, use_interpreter_oop_map_cache);
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
   } else if (is_optimized_entry_frame()) {

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -441,14 +441,10 @@ void frame::interpreter_frame_set_mdp(address mdp) {
   *interpreter_frame_mdp_addr() = (intptr_t)mdp;
 }
 
-template BasicObjectLock* frame::next_monitor_in_interpreter_frame<frame::addressing::ABSOLUTE>(BasicObjectLock* current) const;
-template BasicObjectLock* frame::next_monitor_in_interpreter_frame<frame::addressing::RELATIVE>(BasicObjectLock* current) const;
-
-template <frame::addressing pointers>
 BasicObjectLock* frame::next_monitor_in_interpreter_frame(BasicObjectLock* current) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
 #ifdef ASSERT
-  interpreter_frame_verify_monitor<pointers>(current);
+  interpreter_frame_verify_monitor(current);
 #endif
   BasicObjectLock* next = (BasicObjectLock*) (((intptr_t*) current) + interpreter_frame_monitor_size());
   return next;
@@ -466,43 +462,31 @@ BasicObjectLock* frame::previous_monitor_in_interpreter_frame(BasicObjectLock* c
 
 // Interpreter locals and expression stack locations.
 
-template intptr_t* frame::interpreter_frame_local_at<frame::addressing::ABSOLUTE>(int index) const;
-template intptr_t* frame::interpreter_frame_local_at<frame::addressing::RELATIVE>(int index) const;
-
-template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_local_at(int index) const {
   const int n = Interpreter::local_offset_in_bytes(index)/wordSize;
-  intptr_t* first = pointers == addressing::RELATIVE
+  intptr_t* first = _pointers == addressing::RELATIVE
                              ? fp() + (intptr_t)*interpreter_frame_locals_addr()
                              : *interpreter_frame_locals_addr();
   return &(first[n]);
 }
 
-template intptr_t* frame::interpreter_frame_expression_stack_at<frame::addressing::ABSOLUTE>(jint index) const;
-template intptr_t* frame::interpreter_frame_expression_stack_at<frame::addressing::RELATIVE>(jint index) const;
-
-template <frame::addressing pointers>
 intptr_t* frame::interpreter_frame_expression_stack_at(jint offset) const {
   const int i = offset * interpreter_frame_expression_stack_direction();
   const int n = i * Interpreter::stackElementWords;
-  return &(interpreter_frame_expression_stack<pointers>()[n]);
+  return &(interpreter_frame_expression_stack()[n]);
 }
 
-template jint frame::interpreter_frame_expression_stack_size<frame::addressing::ABSOLUTE>() const;
-template jint frame::interpreter_frame_expression_stack_size<frame::addressing::RELATIVE>() const;
-
-template <frame::addressing pointers>
 jint frame::interpreter_frame_expression_stack_size() const {
   // Number of elements on the interpreter expression stack
   // Callers should span by stackElementWords
   int element_size = Interpreter::stackElementWords;
   size_t stack_size = 0;
   if (frame::interpreter_frame_expression_stack_direction() < 0) {
-    stack_size = (interpreter_frame_expression_stack<pointers>() -
-                  interpreter_frame_tos_address<pointers>() + 1)/element_size;
+    stack_size = (interpreter_frame_expression_stack() -
+                  interpreter_frame_tos_address() + 1)/element_size;
   } else {
-    stack_size = (interpreter_frame_tos_address<pointers>() -
-                  interpreter_frame_expression_stack<pointers>() + 1)/element_size;
+    stack_size = (interpreter_frame_tos_address() -
+                  interpreter_frame_expression_stack() + 1)/element_size;
   }
   assert (stack_size <= (size_t)max_jint, "stack size too big");
   return (jint)stack_size;
@@ -560,39 +544,33 @@ void frame::print_value_on(outputStream* st, JavaThread *thread) const {
 #endif
 }
 
-
-template void frame::print_on<frame::addressing::ABSOLUTE>(outputStream* st) const;
-template void frame::print_on<frame::addressing::RELATIVE>(outputStream* st) const;
-
-template <frame::addressing pointers>
 void frame::print_on(outputStream* st) const {
   print_value_on(st,NULL);
   if (is_interpreted_frame()) {
-    interpreter_frame_print_on<pointers>(st);
+    interpreter_frame_print_on(st);
   }
 }
 
-template <frame::addressing pointers>
 void frame::interpreter_frame_print_on(outputStream* st) const {
 #ifndef PRODUCT
   assert(is_interpreted_frame(), "Not an interpreted frame");
   jint i;
   for (i = 0; i < interpreter_frame_method()->max_locals(); i++ ) {
-    intptr_t x = *interpreter_frame_local_at<pointers>(i);
+    intptr_t x = *interpreter_frame_local_at(i);
     st->print(" - local  [" INTPTR_FORMAT "]", x);
     st->fill_to(23);
     st->print_cr("; #%d", i);
   }
-  for (i = interpreter_frame_expression_stack_size<pointers>() - 1; i >= 0; --i ) {
-    intptr_t x = *interpreter_frame_expression_stack_at<pointers>(i);
+  for (i = interpreter_frame_expression_stack_size() - 1; i >= 0; --i ) {
+    intptr_t x = *interpreter_frame_expression_stack_at(i);
     st->print(" - stack  [" INTPTR_FORMAT "]", x);
     st->fill_to(23);
     st->print_cr("; #%d", i);
   }
   // locks for synchronization
-  for (BasicObjectLock* current = interpreter_frame_monitor_end<pointers>();
+  for (BasicObjectLock* current = interpreter_frame_monitor_end();
        current < interpreter_frame_monitor_begin();
-       current = next_monitor_in_interpreter_frame<pointers>(current)) {
+       current = next_monitor_in_interpreter_frame(current)) {
     st->print(" - obj    [");
     current->obj()->print_value_on(st);
     st->print_cr("]");
@@ -607,7 +585,7 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
   st->fill_to(23);
   st->print_cr("; @%d", interpreter_frame_bci());
   // locals
-  st->print_cr(" - locals [" INTPTR_FORMAT "]", p2i(interpreter_frame_local_at<pointers>(0)));
+  st->print_cr(" - locals [" INTPTR_FORMAT "]", p2i(interpreter_frame_local_at(0)));
   // method
   st->print(" - method [" INTPTR_FORMAT "]", p2i(interpreter_frame_method()));
   st->fill_to(23);
@@ -759,7 +737,6 @@ void frame::print_on_error(outputStream* st, char* buf, int buflen, bool verbose
   be used. So we save the max_stack value in the FrameClosure object and pass it
   down to the interpreter_frame_expression_stack_at method
 */
-template <frame::addressing pointers>
 class InterpreterFrameClosure : public OffsetClosure {
  private:
   const frame* _fr;
@@ -779,18 +756,18 @@ class InterpreterFrameClosure : public OffsetClosure {
   void offset_do(int offset) {
     oop* addr;
     if (offset < _max_locals) {
-      addr = (oop*) _fr->interpreter_frame_local_at<pointers>(offset);
+      addr = (oop*) _fr->interpreter_frame_local_at(offset);
       assert((intptr_t*)addr >= _fr->sp(), "must be inside the frame");
       _f->do_oop(addr);
     } else {
-      addr = (oop*) _fr->interpreter_frame_expression_stack_at<pointers>((offset - _max_locals));
+      addr = (oop*) _fr->interpreter_frame_expression_stack_at((offset - _max_locals));
       // In case of exceptions, the expression stack is invalid and the esp will be reset to express
       // this condition. Therefore, we call f only if addr is 'inside' the stack (i.e., addr >= esp for Intel).
       bool in_stack;
       if (frame::interpreter_frame_expression_stack_direction() > 0) {
-        in_stack = (intptr_t*)addr <= _fr->interpreter_frame_tos_address<pointers>();
+        in_stack = (intptr_t*)addr <= _fr->interpreter_frame_tos_address();
       } else {
-        in_stack = (intptr_t*)addr >= _fr->interpreter_frame_tos_address<pointers>();
+        in_stack = (intptr_t*)addr >= _fr->interpreter_frame_tos_address();
       }
       if (in_stack) {
         _f->do_oop(addr);
@@ -903,7 +880,6 @@ oop frame::interpreter_callee_receiver(Symbol* signature) {
   return *interpreter_callee_receiver_addr(signature);
 }
 
-template <frame::addressing pointers>
 void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const {
   Thread* current = Thread::current();
   methodHandle m(current, interpreter_frame_method());
@@ -917,15 +893,9 @@ void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool quer
     OopMapCache::compute_one_oop_map(m, bci, &mask);
   }
 
-  oops_interpreted_do0<pointers>(f, map, m, bci, mask);
+  oops_interpreted_do0(f, map, m, bci, mask);
 }
 
-// Initialize explicitly so that these can be used only with definitions.
-// TODO: Rectify as Loom stabilizes...
-template void frame::oops_interpreted_do<frame::addressing::ABSOLUTE>(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const;
-template void frame::oops_interpreted_do<frame::addressing::RELATIVE>(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const;
-
-template <frame::addressing pointers>
 void frame::oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHandle m, jint bci, const InterpreterOopMap& mask) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   assert(!Universe::heap()->is_in(m()),
@@ -937,12 +907,12 @@ void frame::oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHa
 
   // Handle the monitor elements in the activation
   for (
-    BasicObjectLock* current = interpreter_frame_monitor_end<pointers>();
+    BasicObjectLock* current = interpreter_frame_monitor_end();
     current < interpreter_frame_monitor_begin();
-    current = next_monitor_in_interpreter_frame<pointers>(current)
+    current = next_monitor_in_interpreter_frame(current)
   ) {
 #ifdef ASSERT
-    interpreter_frame_verify_monitor<pointers>(current);
+    interpreter_frame_verify_monitor(current);
 #endif
     current->oops_do(f);
   }
@@ -972,7 +942,7 @@ void frame::oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHa
       signature = call.signature();
       has_receiver = call.has_receiver();
       if (map != NULL && map->include_argument_oops() &&
-          interpreter_frame_expression_stack_size<pointers>() > 0) {
+          interpreter_frame_expression_stack_size() > 0) {
         // ResourceMark rm(thread);  // is this right ???
         // we are at a call site & the expression stack is not empty
         // => process callee's arguments
@@ -989,7 +959,7 @@ void frame::oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHa
     }
   }
 
-  InterpreterFrameClosure<pointers> blk(this, max_locals, m->max_stack(), f);
+  InterpreterFrameClosure blk(this, max_locals, m->max_stack(), f);
 
   // process locals & expression stack
   // mask.print();
@@ -1179,8 +1149,8 @@ void frame::oops_do_internal(OopClosure* f, CodeBlobClosure* cf, DerivedOopClosu
   }
 #endif
   if (is_interpreted_frame()) {
-    !map->in_cont() ? oops_interpreted_do<addressing::ABSOLUTE>(f, map, use_interpreter_oop_map_cache)
-                    : oops_interpreted_do<addressing::RELATIVE>(f, map, use_interpreter_oop_map_cache);
+    !map->in_cont() != NULL ? oops_interpreted_do(f, map, use_interpreter_oop_map_cache)
+                            : oops_interpreted_do(f, map, use_interpreter_oop_map_cache);
   } else if (is_entry_frame()) {
     oops_entry_do(f, map);
   } else if (is_optimized_entry_frame()) {
@@ -1258,11 +1228,10 @@ bool frame::verify_return_pc(address x) {
 #endif
 
 #ifdef ASSERT
-template <frame::addressing pointers>
 void frame::interpreter_frame_verify_monitor(BasicObjectLock* value) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   // verify that the value is in the right part of the frame
-  address low_mark  = (address) interpreter_frame_monitor_end<pointers>();
+  address low_mark  = (address) interpreter_frame_monitor_end();
   address high_mark = (address) interpreter_frame_monitor_begin();
   address current   = (address) value;
 
@@ -1360,12 +1329,8 @@ public:
   }
 };
 
-template void frame::describe<frame::addressing::ABSOLUTE>(FrameValues& values, int frame_no, const RegisterMap* reg_map);
-template void frame::describe<frame::addressing::RELATIVE>(FrameValues& values, int frame_no, const RegisterMap* reg_map);
-
 // callers need a ResourceMark because of name_and_sig_as_C_string() usage,
 // RA allocated string is returned to the caller
-template <frame::addressing pointers>
 void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_map) {
   // boundaries: sp and the 'real' frame pointer
   values.describe(-1, sp(), err_msg("sp for #%d", frame_no), 0);
@@ -1403,19 +1368,19 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
     // values.describe(frame_no, (intptr_t*)sender_pc_addr(), Continuation::is_return_barrier_entry(*sender_pc_addr()) ? "return address (return barrier)" : "return address");
 
     if (m->max_locals() > 0) {
-      intptr_t* l0 = interpreter_frame_local_at<pointers>(0);
-      intptr_t* ln = interpreter_frame_local_at<pointers>(m->max_locals() - 1);
+      intptr_t* l0 = interpreter_frame_local_at(0);
+      intptr_t* ln = interpreter_frame_local_at(m->max_locals() - 1);
       values.describe(-1, MAX2(l0, ln), err_msg("locals for #%d", frame_no), 2);
       // Report each local and mark as owned by this frame
       for (int l = 0; l < m->max_locals(); l++) {
-        intptr_t* l0 = interpreter_frame_local_at<pointers>(l);
+        intptr_t* l0 = interpreter_frame_local_at(l);
         values.describe(frame_no, l0, err_msg("local %d", l), 1);
       }
     }
 
-    if (interpreter_frame_monitor_begin() != interpreter_frame_monitor_end<pointers>()) {
+    if (interpreter_frame_monitor_begin() != interpreter_frame_monitor_end()) {
       values.describe(frame_no, (intptr_t*)interpreter_frame_monitor_begin(), "monitors begin");
-      values.describe(frame_no, (intptr_t*)interpreter_frame_monitor_end<pointers>(), "monitors end");
+      values.describe(frame_no, (intptr_t*)interpreter_frame_monitor_end(), "monitors end");
     }
 
     // Compute the actual expression stack size
@@ -1424,8 +1389,8 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
     intptr_t* tos = NULL;
     // Report each stack element and mark as owned by this frame
     for (int e = 0; e < mask.expression_stack_size(); e++) {
-      tos = MAX2(tos, interpreter_frame_expression_stack_at<pointers>(e));
-      values.describe(frame_no, interpreter_frame_expression_stack_at<pointers>(e),
+      tos = MAX2(tos, interpreter_frame_expression_stack_at(e));
+      values.describe(frame_no, interpreter_frame_expression_stack_at(e),
                       err_msg("stack %d", e), 1);
     }
     if (tos != NULL) {

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -188,9 +188,8 @@ class frame {
   bool is_compiled_frame()       const;
   bool is_safepoint_blob_frame() const;
   bool is_deoptimized_frame()    const;
-  bool is_optimized_entry_frame()         const;
-  // only interpreted frames ?  wonder if this is true
-  bool is_heap_frame()           const { return is_interpreted_frame() && _pointers == addressing::RELATIVE; }
+  bool is_optimized_entry_frame()  const;
+  bool is_interpreted_heap_frame() const { return is_interpreted_frame() && _pointers == addressing::RELATIVE; }
 
   // testers
   bool is_first_frame() const; // oldest frame? (has no sender)

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -90,6 +90,8 @@ class frame {
   // Interpreter frames in stack chunks use relative addressing; on the stack they use absolute addressing
   enum class addressing { ABSOLUTE, RELATIVE };
 
+  addressing _pointers;
+
   // Constructors
   frame();
 
@@ -119,16 +121,25 @@ class frame {
   // is deoptimization. It likely no one else should ever use it.
   address raw_pc() const;
 
+  bool has_relative_pointers() const { return _pointers == addressing::RELATIVE; }
+
   void set_pc( address   newpc );
   void set_pc_preserve_deopt( address   newpc );
   void set_pc_preserve_deopt(address newpc, CodeBlob* cb);
 
-  intptr_t* sp() const           { return _sp; }
+  intptr_t* sp() const           {
+    // assert !relative to StackChunk start
+    return _sp;
+  }
   void set_sp( intptr_t* newsp ) { _sp = newsp; }
 
-  int offset_sp() const { return _offset_sp; }
+  int offset_sp() const {
+    // assert relative to StackChunk start
+    return _offset_sp;
+  }
+
   void set_offset_sp( int newsp ) { _offset_sp = newsp; }
-  int frame_index() const { return _frame_index; }
+  int frame_index() const           { return _frame_index; }
   void set_frame_index( int index ) { _frame_index = index; }
 
   static int sender_sp_ret_address_offset();
@@ -178,6 +189,8 @@ class frame {
   bool is_safepoint_blob_frame() const;
   bool is_deoptimized_frame()    const;
   bool is_optimized_entry_frame()         const;
+  // only interpreted frames ?  wonder if this is true
+  bool is_heap_frame()           const { return is_interpreted_frame() && _pointers == addressing::RELATIVE; }
 
   // testers
   bool is_first_frame() const; // oldest frame? (has no sender)
@@ -237,11 +250,13 @@ class frame {
  public:
 
   intptr_t* addr_at(int index) const             { return &fp()[index];    }
-  intptr_t  at(int index) const                  { return *addr_at(index); }
+  intptr_t  at_absolute(int index) const         { return *addr_at(index); }
   // in interpreter frames in continuation stacks, internal addresses are relative to fp.
   intptr_t  at_relative(int index) const         { return (intptr_t)(fp() + fp()[index]); }
-  template <addressing pointers>
-  intptr_t at(int index) const                   { return pointers == addressing::RELATIVE ? at_relative(index) : at(index); }
+
+  intptr_t at(int index) const                   {
+    return _pointers == addressing::RELATIVE ? at_relative(index) : at_absolute(index);
+  }
 
   // accessors for locals
   oop obj_at(int offset) const                   { return *obj_at_addr(offset);  }
@@ -303,7 +318,6 @@ class frame {
   // Locals
 
   // The _at version returns a pointer because the address is used for GC.
-  template <addressing pointers = addressing::ABSOLUTE>
   intptr_t* interpreter_frame_local_at(int index) const;
 
   void interpreter_frame_set_locals(intptr_t* locs);
@@ -338,17 +352,17 @@ class frame {
 
   // expression stack (may go up or down, direction == 1 or -1)
  public:
-  template <addressing pointers = addressing::ABSOLUTE> intptr_t* interpreter_frame_expression_stack() const;
+  intptr_t* interpreter_frame_expression_stack() const;
 
   // The _at version returns a pointer because the address is used for GC.
-  template <addressing pointers = addressing::ABSOLUTE> intptr_t* interpreter_frame_expression_stack_at(jint offset) const;
+  intptr_t* interpreter_frame_expression_stack_at(jint offset) const;
 
   // top of expression stack
-  template <addressing pointers = addressing::ABSOLUTE> intptr_t* interpreter_frame_tos_at(jint offset) const;
-  template <addressing pointers = addressing::ABSOLUTE> intptr_t* interpreter_frame_tos_address() const;
+  intptr_t* interpreter_frame_tos_at(jint offset) const;
+  intptr_t* interpreter_frame_tos_address() const;
 
 
-  template <addressing pointers = addressing::ABSOLUTE> jint  interpreter_frame_expression_stack_size() const;
+  jint  interpreter_frame_expression_stack_size() const;
 
   intptr_t* interpreter_frame_sender_sp() const;
 
@@ -369,14 +383,11 @@ class frame {
   //                                 this value is >= BasicObjectLock::size(), and may be rounded up
 
   BasicObjectLock* interpreter_frame_monitor_begin() const;
-  template <addressing pointers = addressing::ABSOLUTE>
   BasicObjectLock* interpreter_frame_monitor_end()   const;
-  template <addressing pointers = addressing::ABSOLUTE>
   BasicObjectLock* next_monitor_in_interpreter_frame(BasicObjectLock* current) const;
   BasicObjectLock* previous_monitor_in_interpreter_frame(BasicObjectLock* current) const;
   static int interpreter_frame_monitor_size();
 
-  template <addressing pointers = addressing::ABSOLUTE>
   void interpreter_frame_verify_monitor(BasicObjectLock* value) const;
 
   // Return/result value from this interpreter frame
@@ -423,15 +434,13 @@ class frame {
  public:
   void print_value() const { print_value_on(tty,NULL); }
   void print_value_on(outputStream* st, JavaThread *thread) const;
-  template <addressing pointers = addressing::ABSOLUTE>
   void print_on(outputStream* st) const;
-  template <addressing pointers = addressing::ABSOLUTE>
+  void print_raw() const;
   void interpreter_frame_print_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
   static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
 
   // Add annotated descriptions of memory locations belonging to this frame to values
-  template <addressing pointers = addressing::ABSOLUTE>
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=NULL);
 
   // Conversion from a VMReg to physical stack location
@@ -442,12 +451,10 @@ class frame {
 
   // Oops-do's
   void oops_compiled_arguments_do(Symbol* signature, bool has_receiver, bool has_appendix, const RegisterMap* reg_map, OopClosure* f) const;
-  template <addressing pointers = addressing::ABSOLUTE>
   void oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache = true) const;
 
  private:
   void oops_interpreted_arguments_do(Symbol* signature, bool has_receiver, OopClosure* f) const;
-  template <addressing pointers = addressing::ABSOLUTE>
   void oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHandle m, jint bci, const InterpreterOopMap& mask) const;
 
   // Iteration of oops
@@ -518,7 +525,8 @@ class FrameValues {
     return a->location - b->location;
   }
 
-  void print_on(outputStream* out, int min_index, int max_index, intptr_t* v0, intptr_t* v1, frame::addressing pointers = frame::addressing::ABSOLUTE);
+  void print_on(outputStream* out, int min_index, int max_index, intptr_t* v0, intptr_t* v1,
+                frame::addressing pointers = frame::addressing::ABSOLUTE);
 
  public:
   // Used by frame functions to describe locations.

--- a/src/hotspot/share/runtime/frame_helpers.inline.hpp
+++ b/src/hotspot/share/runtime/frame_helpers.inline.hpp
@@ -73,16 +73,12 @@ public:
   static inline intptr_t* frame_top(const frame& f, InterpreterOopMap* mask);
   static inline intptr_t* frame_top(const frame& f);
   static inline intptr_t* frame_top(const frame& f, int callee_argsize, bool callee_interpreted);
-  template <frame::addressing pointers = frame::addressing::ABSOLUTE>
   static inline intptr_t* frame_bottom(const frame& f);
-  template <frame::addressing pointers = frame::addressing::ABSOLUTE>
   static inline intptr_t* sender_unextended_sp(const frame& f);
-  template <frame::addressing pointers = frame::addressing::ABSOLUTE>
   static inline int stack_argsize(const frame& f);
 
   static inline address* return_pc_address(const frame& f);
   static inline address return_pc(const frame& f);
-  template <frame::addressing pointers>
   static void patch_sender_sp(frame& f, intptr_t* sp);
 
   static int size(const frame& f, InterpreterOopMap* mask);
@@ -206,10 +202,9 @@ address Interpreted::return_pc(const frame& f) {
 }
 
 int Interpreted::size(const frame&f) {
-  return Interpreted::frame_bottom<frame::addressing::RELATIVE>(f) - Interpreted::frame_top(f);
+  return Interpreted::frame_bottom(f) - Interpreted::frame_top(f);
 }
 
-template <frame::addressing pointers>
 inline int Interpreted::stack_argsize(const frame& f) {
   return f.interpreter_frame_method()->size_of_parameters();
 }


### PR DESCRIPTION
I added an assert in most of the places where we had <addressing::RELATIVE>.
Passes loom-tier1,loom-tier2,loom-tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.java.net/loom pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/100.diff">https://git.openjdk.java.net/loom/pull/100.diff</a>

</details>
