### PR TITLE
8282209: G1: Use synchronous concurrent marking for the code cache

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1893,6 +1893,7 @@ bool G1CollectedHeap::should_do_concurrent_full_gc(GCCause::Cause cause) {
     case GCCause::_g1_humongous_allocation: return true;
     case GCCause::_g1_periodic_collection:  return G1PeriodicGCInvokesConcurrent;
     case GCCause::_wb_breakpoint:           return true;
+    case GCCause::_codecache_GC_threshold:  return true;
     default:                                return is_user_requested_concurrent_full_gc(cause);
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3445,3 +3445,15 @@ void G1CollectedHeap::fill_with_dummy_object(HeapWord* start, HeapWord* end, boo
   HeapRegion* region = heap_region_containing(start);
   region->fill_with_dummy_object(start, pointer_delta(end, start), zap);
 }
+
+void G1CollectedHeap::start_codecache_marking_cycle_if_inactive() {
+  if (!CodeCache::is_marking_cycle_active()) {
+    // This is the normal case when we do not call collect when a
+    // concurrent mark is ongoing. We then start a new code marking
+    // cycle. If, on the other hand, a concurrent mark is ongoing, we
+    // will be conservative and use the last code marking cycle. Code
+    // caches marked between the two concurrent marks will live a bit
+    // longer than needed.
+    CodeCache::start_marking_cycle();
+  }
+}

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -936,6 +936,7 @@ public:
   GrowableArray<MemoryPool*> memory_pools() override;
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
+  static void start_codecache_marking_cycle_if_inactive();
 
   // Apply the given closure on all cards in the Hot Card Cache, emptying it.
   void iterate_hcc_closure(G1CardTableEntryClosure* cl, uint worker_id);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -814,7 +814,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(); 
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive();
 
   G1PreConcurrentStartTask cl(cause, this);
   G1CollectedHeap::heap()->run_batch_task(&cl);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -814,14 +814,15 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  if (CodeCache::is_marking_cycle_active()) {
-    // It's possible that a preceding initiating young GC decided
-    // that there is no need to do any concurrent marking. In that
-    // case, no remark was ever run. Yet the liveness information
-    // was indeed complete. We finish it here.
-    CodeCache::finish_marking_cycle();
+  if (!CodeCache::is_marking_cycle_active()) {
+    // This is the normal case when we do not call collect when a
+    // concurrent mark is ongoing. We then start a new code marking
+    // cycle. If, on the other hand, a concurrent mark is ongoing, we
+    // will be conservative and use the last code marking cycle. Code
+    // caches marked between the two concurrent marks will live a bit
+    // longer than needed.
+    CodeCache::start_marking_cycle();
   }
-  CodeCache::start_marking_cycle();
 
   G1PreConcurrentStartTask cl(cause, this);
   G1CollectedHeap::heap()->run_batch_task(&cl);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -814,15 +814,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
   assert_at_safepoint_on_vm_thread();
 
-  if (!CodeCache::is_marking_cycle_active()) {
-    // This is the normal case when we do not call collect when a
-    // concurrent mark is ongoing. We then start a new code marking
-    // cycle. If, on the other hand, a concurrent mark is ongoing, we
-    // will be conservative and use the last code marking cycle. Code
-    // caches marked between the two concurrent marks will live a bit
-    // longer than needed.
-    CodeCache::start_marking_cycle();
-  }
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive(); 
 
   G1PreConcurrentStartTask cl(cause, this);
   G1CollectedHeap::heap()->run_batch_task(&cl);

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -188,15 +188,15 @@ void G1FullCollector::prepare_collection() {
 }
 
 void G1FullCollector::collect() {
-  if (CodeCache::is_marking_cycle_active()) {
-    // It's possible that a preceding concurrent cycle is not yet
-    // finished, and has aborted. That marking cycle might have had
-    // incomplete marking information, but we can still finish that
-    // cycle, as we will do a full STW cycle before releasing the
-    // safepoint.
-    CodeCache::finish_marking_cycle();
+  if (!CodeCache::is_marking_cycle_active()) {
+    // This is the normal case when we do not call collect when a
+    // concurrent mark is ongoing. We then start a new code marking
+    // cycle. If, on the other hand, a concurrent mark is ongoing, we
+    // will be conservative and use the last code marking cycle. Code
+    // caches marked between the two concurrent marks will live a bit
+    // longer than needed.
+    CodeCache::start_marking_cycle();
   }
-  CodeCache::start_marking_cycle();
 
   phase1_mark_live_objects();
   verify_after_marking();

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -188,16 +188,7 @@ void G1FullCollector::prepare_collection() {
 }
 
 void G1FullCollector::collect() {
-  if (!CodeCache::is_marking_cycle_active()) {
-    // This is the normal case when we do not call collect when a
-    // concurrent mark is ongoing. We then start a new code marking
-    // cycle. If, on the other hand, a concurrent mark is ongoing, we
-    // will be conservative and use the last code marking cycle. Code
-    // caches marked between the two concurrent marks will live a bit
-    // longer than needed.
-    CodeCache::start_marking_cycle();
-  }
-
+  G1CollectedHeap::start_codecache_marking_cycle_if_inactive();
   phase1_mark_live_objects();
   verify_after_marking();
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1082,9 +1082,9 @@ void G1Policy::decide_on_concurrent_start_pause() {
     } else if (_g1h->is_user_requested_concurrent_full_gc(cause) ||
                (cause == GCCause::_codecache_GC_threshold) ||
                (cause == GCCause::_wb_breakpoint)) {
-      // Initiate a user requested concurrent start or run to a breakpoint.
-      // A concurrent start must be young only GC, so the collector state
-      // must be updated to reflect this.
+      // Initiate a concurrent start.  A concurrent start must be a
+      // young only GC, so the collector state must be updated to
+      // reflect this.
       collector_state()->set_in_young_only_phase(true);
       collector_state()->set_in_young_gc_before_mixed(false);
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1080,6 +1080,7 @@ void G1Policy::decide_on_concurrent_start_pause() {
       initiate_conc_mark();
       log_debug(gc, ergo)("Initiate concurrent cycle (concurrent cycle initiation requested)");
     } else if (_g1h->is_user_requested_concurrent_full_gc(cause) ||
+               (cause == GCCause::_codecache_GC_threshold) ||
                (cause == GCCause::_wb_breakpoint)) {
       // Initiate a user requested concurrent start or run to a breakpoint.
       // A concurrent start must be young only GC, so the collector state

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -367,65 +367,6 @@ MetaWord* CollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* loa
         (loop_count % QueuedAllocationWarningCount == 0)) {
       log_warning(gc, ergo)("satisfy_failed_metadata_allocation() retries %d times,"
                             " size=" SIZE_FORMAT, loop_count, word_size);
-    }
-  } while (true);  // Until a GC is done
-}
-
-void CollectedHeap::collect_for_codecache() {
-  uint loop_count = 0;
-  uint gc_count = 0;
-  uint full_gc_count = 0;
-
-  assert(!Heap_lock->owned_by_self(), "Should not be holding the Heap_lock");
-
-  do {
-    if (GCLocker::is_active_and_needs_gc()) {
-      // If the GCLocker is active, just expand and allocate.
-      // If that does not succeed, wait if this thread is not
-      // in a critical section itself.
-      JavaThread* jthr = JavaThread::current();
-      if (!jthr->in_critical()) {
-        // Wait for JNI critical section to be exited
-        GCLocker::stall_until_clear();
-        // The GC invoked by the last thread leaving the critical
-        // section will be a young collection and a full collection
-        // is (currently) needed for unloading classes so continue
-        // to the next iteration to get a full GC.
-        continue;
-      } else {
-        if (CheckJNICalls) {
-          fatal("Possible deadlock due to allocating while"
-                " in jni critical section");
-        }
-        return;
-      }
-    }
-
-    {  // Need lock to get self consistent gc_count's
-      MutexLocker ml(Heap_lock);
-      gc_count      = Universe::heap()->total_collections();
-      full_gc_count = Universe::heap()->total_full_collections();
-    }
-
-    // Generate a VM operation
-    VM_CollectForCodeCacheAllocation op(gc_count,
-                                        full_gc_count,
-                                        GCCause::_codecache_GC_threshold);
-    VMThread::execute(&op);
-
-    // If GC was locked out, try again. Check before checking success because the
-    // prologue could have succeeded and the GC still have been locked out.
-    if (op.gc_locked()) {
-      continue;
-    }
-
-    if (op.prologue_succeeded()) {
-      return;
-    }
-    loop_count++;
-    if ((QueuedAllocationWarningCount > 0) &&
-        (loop_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, ergo)("collect_for_codecache() retries %d times", loop_count);
     }
   } while (true);  // Until a GC is done
 }

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -372,9 +372,6 @@ class CollectedHeap : public CHeapObj<mtGC> {
                                                        size_t size,
                                                        Metaspace::MetadataType mdtype);
 
-  // Continuation support
-  virtual void collect_for_codecache();
-
   // Return true, if accesses to the object would require barriers.
   // This is used by continuations to copy chunks of a thread stack into StackChunk object or out of a StackChunk
   // object back into the thread stack. These chunks may contain references to objects. It is crucial that

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,30 +259,6 @@ void VM_CollectForMetadataAllocation::doit() {
   }
 
   log_debug(gc)("After Metaspace GC failed to allocate size " SIZE_FORMAT, _size);
-
-  if (GCLocker::is_active_and_needs_gc()) {
-    set_gc_locked();
-  }
-}
-
-VM_CollectForCodeCacheAllocation::VM_CollectForCodeCacheAllocation(uint gc_count_before,
-                                                                   uint full_gc_count_before,
-                                                                   GCCause::Cause gc_cause)
-    : VM_GC_Operation(gc_count_before, gc_cause, full_gc_count_before, true) {
-}
-
-void VM_CollectForCodeCacheAllocation::doit() {
-  SvcGCMarker sgcm(SvcGCMarker::FULL);
-
-  CollectedHeap* heap = Universe::heap();
-  GCCauseSetter gccs(heap, _gc_cause);
-
-  log_debug(gc)("Full GC for CodeCache");
-
-  // Don't clear the soft refs yet.
-  heap->collect_as_vm_thread(GCCause::_codecache_GC_threshold);
-
-  log_debug(gc)("After GC for CodeCache");
 
   if (GCLocker::is_active_and_needs_gc()) {
     set_gc_locked();

--- a/src/hotspot/share/gc/shared/gcVMOperations.hpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,16 +242,6 @@ class VM_CollectForMetadataAllocation: public VM_GC_Operation {
   virtual VMOp_Type type() const { return VMOp_CollectForMetadataAllocation; }
   virtual void doit();
   MetaWord* result() const       { return _result; }
-};
-
-class VM_CollectForCodeCacheAllocation: public VM_GC_Operation {
-public:
-  VM_CollectForCodeCacheAllocation(uint gc_count_before,
-                                   uint full_gc_count_before,
-                                   GCCause::Cause gc_cause);
-
-  virtual VMOp_Type type() const { return VMOp_CollectForCodeCacheAllocation; }
-  virtual void doit();
 };
 
 class SvcGCMarker : public StackObj {

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,11 +169,6 @@ MetaWord* ZCollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* lo
 
 void ZCollectedHeap::collect(GCCause::Cause cause) {
   _driver->collect(cause);
-}
-
-void ZCollectedHeap::collect_for_codecache() {
-  // Start synchronous GC
-  collect(GCCause::_codecache_GC_threshold);
 }
 
 void ZCollectedHeap::collect_as_vm_thread(GCCause::Cause cause) {

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,6 @@ public:
   virtual bool is_maximal_no_gc() const;
   virtual bool is_in(const void* p) const;
   virtual inline bool requires_barriers(oop obj) const;
-
-  // Continuation support
-  virtual void collect_for_codecache();
 
   virtual uint32_t hash_oop(oop obj) const;
 

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -199,7 +199,7 @@ void NMethodSweeper::do_stack_scanning() {
   assert(!CodeCache_lock->owned_by_self(), "just checking");
   if (Continuations::enabled()) {
     // There are continuation stacks in the heap that need to be scanned.
-    Universe::heap()->collect_for_codecache();
+    Universe::heap()->collect(GCCause::_codecache_GC_threshold);
   }
   if (wait_for_stack_scanning()) {
     CodeBlobClosure* code_cl;


### PR DESCRIPTION
This fix removes collect_for_codecache(), and uses collect() directly instead. This has the advantage that the g1 code path can be run concurrently using a concurrent mark instead of a full gc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.java.net/loom pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/102.diff">https://git.openjdk.java.net/loom/pull/102.diff</a>

</details>
