### PR TITLE
Remove space after asserts

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -246,18 +246,18 @@ inline int frame::frame_size() const {
 }
 
 inline int frame::num_oops() const {
-  assert (!is_interpreted_frame(), "interpreted");
-  assert (oop_map() != NULL, "");
+  assert(!is_interpreted_frame(), "interpreted");
+  assert(oop_map() != NULL, "");
   return oop_map()->num_oops() ;
 }
 
 inline int frame::compiled_frame_stack_argsize() const {
-  assert (cb()->is_compiled(), "");
+  assert(cb()->is_compiled(), "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
 }
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
-  assert (mask != NULL, "");
+  assert(mask != NULL, "");
   Method* m = interpreter_frame_method();
   int   bci = interpreter_frame_bci();
   m->mask_for(bci, mask); // OopMapCache::compute_one_oop_map(m, bci, mask);
@@ -433,7 +433,7 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
   intptr_t* l_sender_sp = (!PreserveFramePointer || _sp_is_trusted) ? unextended_sp() + _cb->frame_size()
                                                                     : sender_sp();
-  assert (l_sender_sp == real_fp(), "");
+  assert(l_sender_sp == real_fp(), "");
 
   // the return_address is always the word on the stack
   // For ROP protection, C1/C2 will have signed the sender_pc, but there is no requirement to authenticate it here.
@@ -451,9 +451,9 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
         _oop_map->update_register_map(this, map);
       }
     } else {
-      assert (!_cb->caller_must_gc_arguments(map->thread()), "");
-      assert (!map->include_argument_oops(), "");
-      assert (oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
+      assert(!_cb->caller_must_gc_arguments(map->thread()), "");
+      assert(!map->include_argument_oops(), "");
+      assert(oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
     }
 
     // Since the prolog does the save and restore of EBP there is no oopmap

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -684,7 +684,7 @@ inline NativePostCallNop* nativePostCallNop_at(address address) {
 
 inline NativePostCallNop* nativePostCallNop_unsafe_at(address address) {
   NativePostCallNop* nop = (NativePostCallNop*) address;
-  assert (nop->check(), "");
+  assert(nop->check(), "");
   return nop;
 }
 
@@ -701,7 +701,7 @@ class NativeDeoptInstruction: public NativeInstruction {
   void  verify();
 
   static bool is_deopt_at(address instr) {
-    assert (instr != NULL, "");
+    assert(instr != NULL, "");
     uint32_t value = *(uint32_t *) instr;
     return value == 0xd4ade001;
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6585,7 +6585,7 @@ RuntimeStub* generate_cont_doYield() {
   }
 
   address generate_cont_thaw(bool return_barrier, bool exception) {
-    assert (return_barrier || !exception, "must be");
+    assert(return_barrier || !exception, "must be");
 
     address start = __ pc();
 
@@ -8034,9 +8034,9 @@ DEFAULT_ATOMIC_OP(cmpxchg, 8, _seq_cst)
 
 // on exit, sp points to the ContinuationEntry
 OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots) {
-  assert (ContinuationEntry::size() % VMRegImpl::stack_slot_size == 0, "");
-  assert (in_bytes(ContinuationEntry::cont_offset())  % VMRegImpl::stack_slot_size == 0, "");
-  assert (in_bytes(ContinuationEntry::chunk_offset()) % VMRegImpl::stack_slot_size == 0, "");
+  assert(ContinuationEntry::size() % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::cont_offset())  % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::chunk_offset()) % VMRegImpl::stack_slot_size == 0, "");
 
   stack_slots += (int)ContinuationEntry::size()/wordSize;
   __ sub(sp, sp, (int)ContinuationEntry::size()); // place Continuation metadata

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -35,7 +35,7 @@ const int ContinuationHelper::align_wiggle = 1;
 
 template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
 static inline intptr_t** link_address(const frame& f) {
-  assert (FKind::is_instance(f), "");
+  assert(FKind::is_instance(f), "");
   return FKind::interpreted
             ? (intptr_t**)(f.fp() + frame::link_offset)
             : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - frame::sender_sp_offset);
@@ -104,7 +104,7 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 
 template<typename FKind>
 inline frame FreezeBase::sender(const frame& f) {
-  assert (FKind::is_instance(f), "");
+  assert(FKind::is_instance(f), "");
   if (FKind::interpreted) {
     return frame(f.sender_sp(), f.interpreter_frame_sender_sp(), f.link(), f.sender_pc());
   }
@@ -122,7 +122,7 @@ inline frame FreezeBase::sender(const frame& f) {
 }
 
 static inline void relativize_one(intptr_t* const vfp, intptr_t* const hfp, int offset) {
-  assert (*(hfp + offset) == *(vfp + offset), "");
+  assert(*(hfp + offset) == *(vfp + offset), "");
   intptr_t* addr = hfp + offset;
   intptr_t value = *(intptr_t**)addr - vfp;
   *addr = value;
@@ -131,10 +131,10 @@ static inline void relativize_one(intptr_t* const vfp, intptr_t* const hfp, int 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   intptr_t* vfp = f.fp();
   intptr_t* hfp = hf.fp();
-  assert (hfp == hf.unextended_sp() + (f.fp() - f.unextended_sp()), "");
-  assert ((f.at(frame::interpreter_frame_last_sp_offset) != 0)
+  assert(hfp == hf.unextended_sp() + (f.fp() - f.unextended_sp()), "");
+  assert((f.at(frame::interpreter_frame_last_sp_offset) != 0)
     || (f.unextended_sp() == f.sp()), "");
-  assert (f.fp() > (intptr_t*)f.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert(f.fp() > (intptr_t*)f.at(frame::interpreter_frame_initial_sp_offset), "");
 
   // We compute the locals as below rather than relativize the value in the frame because then we can use the same
   // code on AArch64, which has an added complication (see this method in continuation_aarch64.inline.hpp)
@@ -145,18 +145,18 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 
   relativize_one(vfp, hfp, frame::interpreter_frame_initial_sp_offset); // == block_top == block_bottom
 
-  assert ((hf.fp() - hf.unextended_sp()) == (f.fp() - f.unextended_sp()), "");
-  assert (hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
-  assert (hf.unextended_sp() <= (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
-  assert (hf.fp()            >  (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
-  assert (hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
+  assert((hf.fp() - hf.unextended_sp()) == (f.fp() - f.unextended_sp()), "");
+  assert(hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
+  assert(hf.unextended_sp() <= (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert(hf.fp()            >  (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
+  assert(hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
 }
 
 template <typename ConfigT>
 inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   stackChunkOop chunk = _cont.tail();
-  assert (chunk->is_in_chunk(hf.sp() - 1), "");
-  assert (chunk->is_in_chunk(hf.sp() - frame::sender_sp_offset), "");
+  assert(chunk->is_in_chunk(hf.sp() - 1), "");
+  assert(chunk->is_in_chunk(hf.sp() - frame::sender_sp_offset), "");
 
   *(hf.sp() - 1) = (intptr_t)hf.pc();
 
@@ -168,22 +168,22 @@ inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
 template <typename ConfigT>
 template<typename FKind>
 frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
-  assert (FKind::is_instance(f), "");
-  assert (!caller.is_interpreted_frame()
+  assert(FKind::is_instance(f), "");
+  assert(!caller.is_interpreted_frame()
     || caller.unextended_sp() == (intptr_t*)caller.at(frame::interpreter_frame_last_sp_offset), "");
 
   intptr_t *sp, *fp; // sp is really our unextended_sp
   if (FKind::interpreted) {
-    assert ((intptr_t*)f.at(frame::interpreter_frame_last_sp_offset) == nullptr
+    assert((intptr_t*)f.at(frame::interpreter_frame_last_sp_offset) == nullptr
       || f.unextended_sp() == (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset), "");
     int locals = f.interpreter_frame_method()->max_locals();
     bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
     fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? Interpreted::stack_argsize(f) : 0);
     sp = fp - (f.fp() - f.unextended_sp());
-    assert (sp <= fp && fp <= caller.unextended_sp(), "");
+    assert(sp <= fp && fp <= caller.unextended_sp(), "");
     caller.set_sp(fp + frame::sender_sp_offset);
 
-    assert (_cont.tail()->is_in_chunk(sp), "");
+    assert(_cont.tail()->is_in_chunk(sp), "");
 
     frame hf(sp, sp, fp, f.pc(), nullptr, nullptr, true /* relative */);
     *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + locals - 1;
@@ -198,7 +198,7 @@ frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
     }
     caller.set_sp(sp + fsize);
 
-    assert (_cont.tail()->is_in_chunk(sp), "");
+    assert(_cont.tail()->is_in_chunk(sp), "");
 
     return frame(sp, sp, fp, f.pc(), nullptr, nullptr, false);
   }
@@ -208,7 +208,7 @@ template <typename ConfigT>
 template <typename FKind, bool bottom>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   if (caller.is_interpreted_frame()) {
-    assert (!caller.is_empty(), "");
+    assert(!caller.is_empty(), "");
     patch_callee_link_relative(caller, caller.fp());
   } else {
     patch_callee_link(caller, caller.fp());
@@ -245,7 +245,7 @@ inline frame Thaw<ConfigT>::new_entry_frame() {
 
 template <typename ConfigT>
 template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& caller, bool bottom) {
-  assert (FKind::is_instance(hf), "");
+  assert(FKind::is_instance(hf), "");
 
   if (FKind::interpreted) {
     intptr_t* hsp = hf.unextended_sp();
@@ -254,12 +254,12 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
     intptr_t* vsp = caller.unextended_sp() - fsize;
     intptr_t* fp = vsp + (hf.fp() - hsp);
     DEBUG_ONLY(intptr_t* unextended_sp = fp + *hf.addr_at(frame::interpreter_frame_last_sp_offset);)
-    assert (vsp == unextended_sp, "");
+    assert(vsp == unextended_sp, "");
     caller.set_sp(fp + frame::sender_sp_offset);
     frame f(vsp, vsp, fp, hf.pc());
     // it's set again later in derelativize_interpreted_frame_metadata, but we need to set the locals now so that we'll have the frame's bottom
     intptr_t offset = *hf.addr_at(frame::interpreter_frame_locals_offset);
-    assert ((int)offset == locals + frame::sender_sp_offset - 1, "");
+    assert((int)offset == locals + frame::sender_sp_offset - 1, "");
     *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = fp + offset;
     return f;
   } else {
@@ -271,12 +271,12 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
       fsize += argsize;
       vsp   -= argsize;
       caller.set_sp(caller.sp() - argsize);
-      assert (caller.sp() == vsp + (fsize-argsize), "");
+      assert(caller.sp() == vsp + (fsize-argsize), "");
 
       vsp = align(hf, vsp, caller, bottom);
     }
 
-    assert (hf.cb() != nullptr && hf.oop_map() != nullptr, "");
+    assert(hf.cb() != nullptr && hf.oop_map() != nullptr, "");
     intptr_t* fp = *(intptr_t**)(hf.sp() - frame::sender_sp_offset); // we need to re-read fp because it may be an oop and we might have fixed the frame.
     return frame(vsp, vsp, fp, hf.pc(), hf.cb(), hf.oop_map()); // TODO PERF : this computes deopt state; is it necessary?
   }
@@ -299,7 +299,7 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 template <typename ConfigT>
 template<typename FKind, bool bottom>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
-  assert (!bottom || caller.fp() == _cont.entryFP(), "");
+  assert(!bottom || caller.fp() == _cont.entryFP(), "");
   patch_callee_link(caller, caller.fp());
 }
 

--- a/src/hotspot/cpu/x86/frame_helpers_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_helpers_x86.inline.hpp
@@ -31,8 +31,8 @@ bool Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
   intptr_t* fp = *(intptr_t**)(sp - frame::sender_sp_offset);
-  assert (f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
-  assert (f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
+  assert(f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
+  assert(f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
   return f.raw_pc() == pc && f.fp() == fp;
 }
 #endif
@@ -50,7 +50,7 @@ inline address* Interpreted::return_pc_address(const frame& f) {
 }
 
 void Interpreted::patch_sender_sp(frame& f, intptr_t* sp) {
-  assert (f.is_interpreted_frame(), "");
+  assert(f.is_interpreted_frame(), "");
   intptr_t* la = f.addr_at(frame::interpreter_frame_sender_sp_offset);
   *la = f._pointers == frame::addressing::RELATIVE ? (intptr_t)(sp - f.fp()) : (intptr_t)sp;
 }
@@ -74,13 +74,13 @@ inline intptr_t* Interpreted::frame_top(const frame& f, InterpreterOopMap* mask)
   // interpreter_frame_initial_sp_offset excludes expression stack slots
   int expression_stack_sz = expression_stack_size(f, mask);
   intptr_t* res = *(intptr_t**)f.addr_at(frame::interpreter_frame_initial_sp_offset) - expression_stack_sz;
-  assert (res == (intptr_t*)f.interpreter_frame_monitor_end() - expression_stack_sz, "");
-  assert (res >= f.unextended_sp(),
+  assert(res == (intptr_t*)f.interpreter_frame_monitor_end() - expression_stack_sz, "");
+  assert(res >= f.unextended_sp(),
     "res: " INTPTR_FORMAT " initial_sp: " INTPTR_FORMAT " last_sp: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT " expression_stack_size: %d",
     p2i(res), p2i(f.addr_at(frame::interpreter_frame_initial_sp_offset)), f.at(frame::interpreter_frame_last_sp_offset), p2i(f.unextended_sp()), expression_stack_sz);
   return res;
   // Not true, but using unextended_sp might work
-  // assert (res == f.unextended_sp(), "res: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT, p2i(res), p2i(f.unextended_sp() + 1));
+  // assert(res == f.unextended_sp(), "res: " INTPTR_FORMAT " unextended_sp: " INTPTR_FORMAT, p2i(res), p2i(f.unextended_sp() + 1));
 }
 
 inline intptr_t* Interpreted::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -287,7 +287,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
-  assert (!is_compiled_frame() || !_cb->as_compiled_method()->is_deopt_entry(_pc), "must be");
+  assert(!is_compiled_frame() || !_cb->as_compiled_method()->is_deopt_entry(_pc), "must be");
 
 #ifdef ASSERT
   {

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -233,18 +233,18 @@ inline int frame::frame_size() const {
 }
 
 inline int frame::num_oops() const {
-  assert (!is_interpreted_frame(), "interpreted");
-  assert (oop_map() != NULL, "");
+  assert(!is_interpreted_frame(), "interpreted");
+  assert(oop_map() != NULL, "");
   return oop_map()->num_oops() ;
 }
 
 inline int frame::compiled_frame_stack_argsize() const {
-  assert (cb()->is_compiled(), "");
+  assert(cb()->is_compiled(), "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
 }
 
 inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
-  assert (mask != NULL, "");
+  assert(mask != NULL, "");
   Method* m = interpreter_frame_method();
   int   bci = interpreter_frame_bci();
   m->mask_for(bci, mask); // OopMapCache::compute_one_oop_map(m, bci, mask);
@@ -412,7 +412,7 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // frame owned by optimizing compiler
   assert(_cb->frame_size() >= 0, "must have non-zero frame size");
   intptr_t* sender_sp = unextended_sp() + _cb->frame_size();
-  assert (sender_sp == real_fp(), "");
+  assert(sender_sp == real_fp(), "");
 
   // On Intel the return_address is always the word on the stack
   address sender_pc = (address) *(sender_sp-1);
@@ -432,9 +432,9 @@ inline frame frame::sender_for_compiled_frame(RegisterMap* map) const {
         _oop_map->update_register_map(this, map);
       }
     } else {
-      assert (!_cb->caller_must_gc_arguments(map->thread()), "");
-      assert (!map->include_argument_oops(), "");
-      assert (oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
+      assert(!_cb->caller_must_gc_arguments(map->thread()), "");
+      assert(!map->include_argument_oops(), "");
+      assert(oop_map() == NULL || !oop_map()->has_any(OopMapValue::callee_saved_value), "callee-saved value in compiled frame");
     }
 
     // Since the prolog does the save and restore of EBP there is no oopmap

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1969,7 +1969,7 @@ void MacroAssembler::decrementl(Address dst, int value) {
 }
 
 void MacroAssembler::division_with_shift (Register reg, int shift_value) {
-  assert (shift_value > 0, "illegal shift value");
+  assert(shift_value > 0, "illegal shift value");
   Label _is_positive;
   testl (reg, reg);
   jcc (Assembler::positive, _is_positive);

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -750,7 +750,7 @@ inline NativePostCallNop* nativePostCallNop_at(address address) {
 
 inline NativePostCallNop* nativePostCallNop_unsafe_at(address address) {
   NativePostCallNop* nop = (NativePostCallNop*) address;
-  assert (nop->check(), "");
+  assert(nop->check(), "");
   return nop;
 }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7531,7 +7531,7 @@ RuntimeStub* generate_cont_doYield() {
   }
 
   address generate_cont_thaw(bool return_barrier, bool exception) {
-    assert (return_barrier || !exception, "must be");
+    assert(return_barrier || !exception, "must be");
 
     address start = __ pc();
 
@@ -8283,9 +8283,9 @@ void StubGenerator_generate(CodeBuffer* code, int phase) {
 // on exit, rsp points to the ContinuationEntry
 // kills rax
 OopMap* continuation_enter_setup(MacroAssembler* masm, int& stack_slots) {
-  assert (ContinuationEntry::size() % VMRegImpl::stack_slot_size == 0, "");
-  assert (in_bytes(ContinuationEntry::cont_offset())  % VMRegImpl::stack_slot_size == 0, "");
-  assert (in_bytes(ContinuationEntry::chunk_offset()) % VMRegImpl::stack_slot_size == 0, "");
+  assert(ContinuationEntry::size() % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::cont_offset())  % VMRegImpl::stack_slot_size == 0, "");
+  assert(in_bytes(ContinuationEntry::chunk_offset()) % VMRegImpl::stack_slot_size == 0, "");
 
   stack_slots += (int)ContinuationEntry::size()/wordSize;
   __ subptr(rsp, (int32_t)ContinuationEntry::size()); // place Continuation metadata

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -6329,7 +6329,7 @@ instruct vshiftS(vec dst, vec src, vec shift) %{
         __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
         __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
       } else {
-        assert (vlen == 8, "sanity");
+        assert(vlen == 8, "sanity");
         __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
         __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
       }

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -634,7 +634,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
   // If it is, patch return address to be deopt handler.
   if (!signal_was_handled) {
     address pc = os::Posix::ucontext_get_pc(uc);
-    assert (pc != NULL, "");
+    assert(pc != NULL, "");
     if (NativeDeoptInstruction::is_deopt_at(pc)) {
       CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
       if (cb != NULL && cb->is_compiled()) {
@@ -644,7 +644,7 @@ int JVM_HANDLE_XXX_SIGNAL(int sig, siginfo_t* info,
         address deopt = cm->is_method_handle_return(pc) ?
           cm->deopt_mh_handler_begin() :
           cm->deopt_handler_begin();
-        assert (deopt != NULL, "");
+        assert(deopt != NULL, "");
 
         frame fr = os::fetch_frame_from_context(uc);
         cm->set_original_pc(&fr, pc);

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1153,7 +1153,7 @@ void ciEnv::register_method(ciMethod* target,
       nm->set_has_unsafe_access(has_unsafe_access);
       nm->set_has_wide_vectors(has_wide_vectors);
       nm->set_has_monitors(has_monitors);
-      assert (!method->is_synchronized() || nm->has_monitors(), "");
+      assert(!method->is_synchronized() || nm->has_monitors(), "");
 #if INCLUDE_RTM_OPT
       nm->set_rtm_state(rtm_state);
 #endif

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2787,7 +2787,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
       if (fr.is_first_frame()) break;
 
       if (Continuation::is_continuation_enterSpecial(fr)) {
-        assert (cont == Continuation::get_continuation_entry_for_entry_frame(thread, fr), "");
+        assert(cont == Continuation::get_continuation_entry_for_entry_frame(thread, fr), "");
         if (!show_carrier && cont->is_virtual_thread()) {
           break;
         }
@@ -2815,7 +2815,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
           continue;
         }
         nm = cb->as_compiled_method();
-        assert (nm->method() != NULL, "must be");
+        assert(nm->method() != NULL, "must be");
         if (nm->method()->is_native()) {
           method = nm->method();
           bci = 0;

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -671,7 +671,7 @@ CodeBlob* CodeCache::find_blob_unsafe(void* start) {
 
 CodeBlob* CodeCache::patch_nop(NativePostCallNop* nop, void* pc, int& slot) {
   CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
-  assert (cb != NULL, "must be");
+  assert(cb != NULL, "must be");
 
   if (cb->is_zombie()) {
     // might be called during GC traversal

--- a/src/hotspot/share/code/codeCache.inline.hpp
+++ b/src/hotspot/share/code/codeCache.inline.hpp
@@ -45,12 +45,12 @@ inline CodeBlob* CodeCache::find_blob_and_oopmap(void* pc, int& slot) {
     } else {
       cb = CodeCache::patch_nop(nop, pc, slot);
     }
-    // assert (cb == CodeCache::find_blob(pc), "");
+    // assert(cb == CodeCache::find_blob(pc), "");
   } else {
     cb = CodeCache::find_blob(pc);
     slot = -1;
   }
-  assert (cb != NULL, "must be");
+  assert(cb != NULL, "must be");
   return cb;
 }
 

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -118,7 +118,7 @@ const char* CompiledMethod::state() const {
 
 //-----------------------------------------------------------------------------
 void CompiledMethod::mark_for_deoptimization(bool inc_recompile_counts) {
-  // assert (can_be_deoptimized(), ""); // in some places we check before marking, in others not.
+  // assert(can_be_deoptimized(), ""); // in some places we check before marking, in others not.
   MutexLocker ml(CompiledMethod_lock->owned_by_self() ? NULL : CompiledMethod_lock,
                  Mutex::_no_safepoint_check_flag);
   if (_mark_for_deoptimization_status != deoptimize_done) { // can't go backwards
@@ -372,7 +372,7 @@ void CompiledMethod::preserve_callee_argument_oops(frame fr, const RegisterMap *
   JavaThread* thread = reg_map->thread();
   if (thread->has_last_Java_frame() && fr.sp() == thread->last_Java_sp()) {
     // if (!method()->is_native()) fr.print_on(tty);
-    // assert (method()->is_native(), "");
+    // assert(method()->is_native(), "");
     return;
   }
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1099,8 +1099,8 @@ void nmethod::fix_oop_relocations(address begin, address end, bool initialize_im
 
 
 void nmethod::make_deoptimized() {
-  assert (method() == NULL || can_be_deoptimized(), "");
-  assert (!is_zombie(), "");
+  assert(method() == NULL || can_be_deoptimized(), "");
+  assert(!is_zombie(), "");
 
   CompiledICLocker ml(this);
   assert(CompiledICLocker::is_safe(this), "mt unsafe call");

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -979,7 +979,7 @@ void DerivedPointerTable::update_pointers() {
     *derived_loc = derived_base + offset;
     assert(*derived_loc - derived_base == offset, "sanity check");
 
-    // assert (offset >= 0 && offset <= (intptr_t)(base->size() << LogHeapWordSize), "offset: %ld base->size: %zu relative: %d", offset, base->size() << LogHeapWordSize, *(intptr_t*)derived_loc <= 0);
+    // assert(offset >= 0 && offset <= (intptr_t)(base->size() << LogHeapWordSize), "offset: %ld base->size: %zu relative: %d", offset, base->size() << LogHeapWordSize, *(intptr_t*)derived_loc <= 0);
 
     if (TraceDerivedPointers) {
       tty->print_cr("Updating derived pointer@" INTPTR_FORMAT

--- a/src/hotspot/share/compiler/oopMap.inline.hpp
+++ b/src/hotspot/share/compiler/oopMap.inline.hpp
@@ -52,7 +52,7 @@ template <typename OopFnT, typename DerivedOopFnT, typename ValueFilterT>
 template <typename RegisterMapT>
 void OopMapDo<OopFnT, DerivedOopFnT, ValueFilterT>::iterate_oops_do(const frame *fr, const RegisterMapT *reg_map, const ImmutableOopMap* oopmap) {
   NOT_PRODUCT(if (TraceCodeBlobStacks) OopMapSet::trace_codeblob_maps(fr, reg_map->as_RegisterMap());)
-  assert (fr != NULL, "");
+  assert(fr != NULL, "");
 
   // handle derived pointers first (otherwise base pointer may be
   // changed before derived pointer offset has been collected)

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -270,7 +270,7 @@ inline void G1CollectedHeap::set_humongous_is_live(oop obj) {
 }
 
 inline bool G1CollectedHeap::requires_barriers(stackChunkOop obj) const {
-  assert (obj != NULL, "");
+  assert(obj != NULL, "");
   return !heap_region_containing(obj)->is_young(); // is_in_young does an unnecessary NULL check
 }
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -73,8 +73,8 @@ InstanceStackChunkKlass::InstanceStackChunkKlass(const ClassFileParser& parser)
   // see oopDesc::size_given_klass
    const jint lh = Klass::instance_layout_helper(size_helper(), true);
    set_layout_helper(lh);
-   assert (layout_helper_is_instance(layout_helper()), "");
-   assert (layout_helper_needs_slow_path(layout_helper()), "");
+   assert(layout_helper_is_instance(layout_helper()), "");
+   assert(layout_helper_needs_slow_path(layout_helper()), "");
 }
 
 size_t InstanceStackChunkKlass::oop_size(oop obj) const {
@@ -86,7 +86,7 @@ template <int x> NOINLINE static bool verify_chunk(stackChunkOop c) { return c->
 
 template <InstanceStackChunkKlass::copy_type overlap>
 size_t InstanceStackChunkKlass::copy(oop obj, HeapWord* to_addr, size_t word_size) {
-  assert (obj->is_stackChunk(), "");
+  assert(obj->is_stackChunk(), "");
   stackChunkOop chunk = (stackChunkOop)obj;
 
   HeapWord* from_addr = cast_from_oop<HeapWord*>(obj);
@@ -94,7 +94,7 @@ size_t InstanceStackChunkKlass::copy(oop obj, HeapWord* to_addr, size_t word_siz
                                  : Copy::aligned_conjoint_words(from_addr, to_addr, word_size);
 
   stackChunkOop to_chunk = (stackChunkOop) cast_to_oop(to_addr);
-  assert (!to_chunk->has_bitmap() || to_chunk->is_gc_mode(), "");
+  assert(!to_chunk->has_bitmap() || to_chunk->is_gc_mode(), "");
 
   if (!to_chunk->has_bitmap()) {
     build_bitmap(to_chunk);
@@ -130,10 +130,10 @@ public:
     OrderAccess::loadload();
     oop base = Atomic::load((oop*)base_loc);
     if (base == (oop)nullptr) {
-      assert (*derived_loc == derived_pointer(0), "");
+      assert(*derived_loc == derived_pointer(0), "");
       return;
     }
-    assert (!CompressedOops::is_base(base), "");
+    assert(!CompressedOops::is_base(base), "");
 
 #if INCLUDE_ZGC
     if (UseZGC) {
@@ -175,8 +175,8 @@ public:
     OrderAccess::loadload();
     oop base = Atomic::load(base_loc);
     if (base != (oop)nullptr) {
-      assert (!CompressedOops::is_base(base), "");
-      ZGC_ONLY(assert (ZAddress::is_good(cast_from_oop<uintptr_t>(base)), "");)
+      assert(!CompressedOops::is_base(base), "");
+      ZGC_ONLY(assert(ZAddress::is_good(cast_from_oop<uintptr_t>(base)), "");)
 
       OrderAccess::loadload();
       intptr_t offset = Atomic::load((intptr_t*)derived_loc); // *derived_loc;
@@ -258,7 +258,7 @@ public:
   template <chunk_frames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
     _num_frames++;
-    assert (_closure != nullptr, "");
+    assert(_closure != nullptr, "");
 
     if (_closure->do_metadata()) {
       if (f.is_interpreted()) {
@@ -281,13 +281,13 @@ public:
 };
 
 void InstanceStackChunkKlass::oop_oop_iterate_stack_slow(stackChunkOop chunk, OopIterateClosure* closure, MemRegion mr) {
-  assert (chunk->is_stackChunk(), "");
+  assert(chunk->is_stackChunk(), "");
 
   OopOopIterateStackClosure frame_closure(chunk, closure, mr);
   chunk->iterate_stack(&frame_closure);
 
-  assert (frame_closure._num_frames >= 0, "");
-  assert (frame_closure._num_oops >= 0, "");
+  assert(frame_closure._num_frames >= 0, "");
+  assert(frame_closure._num_oops >= 0, "");
 
   if (closure != nullptr) {
     Continuation::emit_chunk_iterate_event(chunk, frame_closure._num_frames, frame_closure._num_oops);
@@ -349,7 +349,7 @@ void InstanceStackChunkKlass::do_barriers0(stackChunkOop chunk, const StackChunk
     nm->run_nmethod_entry_barrier();
   }
 
-  assert (!f.is_compiled() || f.oopmap()->has_derived_oops() == f.oopmap()->has_any(OopMapValue::derived_oop_value), "");
+  assert(!f.is_compiled() || f.oopmap()->has_derived_oops() == f.oopmap()->has_any(OopMapValue::derived_oop_value), "");
   bool has_derived = f.is_compiled() && f.oopmap()->has_derived_oops();
   if (has_derived) {
     relativize_derived_pointers(f, map);
@@ -443,9 +443,9 @@ static bool is_good_oop(oop o) { return    dbg_is_safe(o, -1)
 
 class FixCompressedOopClosure : public OopClosure {
   void do_oop(oop* p) override {
-    assert (UseCompressedOops, "");
+    assert(UseCompressedOops, "");
     oop obj = CompressedOops::decode(*(narrowOop*)p);
-    assert (obj == nullptr || is_good_oop(obj), "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT, p2i(p), p2i((oopDesc*)obj));
+    assert(obj == nullptr || is_good_oop(obj), "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT, p2i(p), p2i((oopDesc*)obj));
     *p = obj;
   }
 
@@ -465,7 +465,7 @@ public:
     : _stack_start(stack_start), _bit_offset(bit_offset), _bm(bm) {}
 
   virtual void do_oop(oop* p) override {
-    assert (p >= (oop*)_stack_start, "");
+    assert(p >= (oop*)_stack_start, "");
     if (oops == oop_kind::NARROW) {
       // Convert all oops to narrow before marking bit
       oop obj = *p;
@@ -475,15 +475,15 @@ public:
       do_oop((narrowOop*)p);
     } else {
       BitMap::idx_t index = _bit_offset + (p - (oop*)_stack_start);
-      assert (!_bm.at(index), "");
+      assert(!_bm.at(index), "");
       _bm.set_bit(index);
     }
   }
 
   virtual void do_oop(narrowOop* p) override {
-    assert (p >= (narrowOop*)_stack_start, "");
+    assert(p >= (narrowOop*)_stack_start, "");
     BitMap::idx_t index = _bit_offset + (p - (narrowOop*)_stack_start);
-    assert (!_bm.at(index), "");
+    assert(!_bm.at(index), "");
     _bm.set_bit(index);
   }
 };
@@ -513,7 +513,7 @@ public:
 };
 
 void InstanceStackChunkKlass::build_bitmap(stackChunkOop chunk) {
-  assert (!chunk->has_bitmap(), "");
+  assert(!chunk->has_bitmap(), "");
   if (UseChunkBitmaps) {
     chunk->set_has_bitmap(true);
     BitMapView bm = chunk->bitmap();
@@ -570,7 +570,7 @@ public:
 
     if (!SafepointSynchronize::is_at_safepoint()) {
       oop obj = safe_load(p);
-      assert (obj == nullptr || is_good_oop(obj),
+      assert(obj == nullptr || is_good_oop(obj),
               "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT " index: " SIZE_FORMAT " bit_offset: " SIZE_FORMAT,
               p2i(p), p2i((oopDesc*)obj), index, _chunk->bit_offset());
     }
@@ -596,10 +596,10 @@ public:
     if (SafepointSynchronize::is_at_safepoint()) return;
 
     oop obj = safe_load(p);
-    assert (obj == nullptr || is_good_oop(obj), "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT, p2i(p), p2i((oopDesc*)obj));
+    assert(obj == nullptr || is_good_oop(obj), "p: " INTPTR_FORMAT " obj: " INTPTR_FORMAT, p2i(p), p2i((oopDesc*)obj));
     if (_chunk->has_bitmap()) {
       BitMap::idx_t index = (p - (T*)_chunk->start_address()) + _chunk->bit_offset();
-      assert (_chunk->bitmap().at(index), "Bit not set at index " SIZE_FORMAT " corresponding to " INTPTR_FORMAT, index, p2i(p));
+      assert(_chunk->bitmap().at(index), "Bit not set at index " SIZE_FORMAT " corresponding to " INTPTR_FORMAT, index, p2i(p));
     }
   }
 
@@ -624,16 +624,16 @@ public:
                   : Atomic::load((oop*)base_loc);
     if (base != nullptr) {
       ZGC_ONLY(if (UseZGC && !ZAddress::is_good(cast_from_oop<uintptr_t>(base))) return;)
-      assert (!CompressedOops::is_base(base), "");
-      assert (oopDesc::is_oop(base), "");
-      ZGC_ONLY(assert (!UseZGC || ZAddress::is_good(cast_from_oop<uintptr_t>(base)), "");)
+      assert(!CompressedOops::is_base(base), "");
+      assert(oopDesc::is_oop(base), "");
+      ZGC_ONLY(assert(!UseZGC || ZAddress::is_good(cast_from_oop<uintptr_t>(base)), "");)
       OrderAccess::loadload();
       intptr_t offset = Atomic::load((intptr_t*)derived_loc);
       offset = offset <= 0
                   ? -offset
                   : offset - cast_from_oop<intptr_t>(base);
     } else {
-      assert (*derived_loc == derived_pointer(0), "");
+      assert(*derived_loc == derived_pointer(0), "");
     }
   }
 };
@@ -663,7 +663,7 @@ public:
 
     int fsize = f.frame_size() - ((f.is_interpreted() == _callee_interpreted) ? _argsize : 0);
     int num_oops = f.num_oops();
-    assert (num_oops >= 0, "");
+    assert(num_oops >= 0, "");
 
     _argsize   = f.stack_argsize();
     _size     += fsize;
@@ -678,12 +678,12 @@ public:
       LogStream ls(lt);
       f.print_on(&ls);
     }
-    assert (f.pc() != nullptr,
+    assert(f.pc() != nullptr,
       "young: %d num_frames: %d sp: " INTPTR_FORMAT " start: " INTPTR_FORMAT " end: " INTPTR_FORMAT,
       !_chunk->requires_barriers(), _num_frames, p2i(f.sp()), p2i(_chunk->start_address()), p2i(_chunk->bottom_address()));
 
     if (_num_frames == 0) {
-      assert (f.pc() == _chunk->pc(), "");
+      assert(f.pc() == _chunk->pc(), "");
     }
 
     if (_num_frames > 0 && !_callee_interpreted && f.is_interpreted()) {
@@ -693,7 +693,7 @@ public:
 
     StackChunkVerifyOopsClosure oops_closure(_chunk, f.unextended_sp());
     f.iterate_oops(&oops_closure, map);
-    assert (oops_closure.count() == num_oops, "oops: %d oopmap->num_oops(): %d", oops_closure.count(), num_oops);
+    assert(oops_closure.count() == num_oops, "oops: %d oopmap->num_oops(): %d", oops_closure.count(), num_oops);
 
     StackChunkVerifyDerivedPointersClosure derived_oops_closure(_chunk, f.unextended_sp());
     f.iterate_derived_pointers(&derived_oops_closure, map);
@@ -709,23 +709,23 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops,
                                      int* out_frames, int* out_interpreted_frames) {
   DEBUG_ONLY(if (!VerifyContinuations) return true;)
 
-  assert (oopDesc::is_oop(obj), "");
-  assert (obj->is_stackChunk(), "");
+  assert(oopDesc::is_oop(obj), "");
+  assert(obj->is_stackChunk(), "");
 
   stackChunkOop chunk = (stackChunkOop)obj;
 
-  assert (chunk->is_stackChunk(), "");
-  assert (chunk->stack_size() >= 0, "");
-  assert (chunk->argsize() >= 0, "");
-  assert (!chunk->has_bitmap() || chunk->is_gc_mode(), "");
+  assert(chunk->is_stackChunk(), "");
+  assert(chunk->stack_size() >= 0, "");
+  assert(chunk->argsize() >= 0, "");
+  assert(!chunk->has_bitmap() || chunk->is_gc_mode(), "");
 
   if (chunk->is_empty()) {
-    assert (chunk->argsize() == 0, "");
-    assert (chunk->max_size() == 0, "");
+    assert(chunk->argsize() == 0, "");
+    assert(chunk->max_size() == 0, "");
   }
 
   if (!SafepointSynchronize::is_at_safepoint()) {
-    assert (oopDesc::is_oop_or_null(chunk->parent()), "");
+    assert(oopDesc::is_oop_or_null(chunk->parent()), "");
   }
 
   bool check_deopt = false;
@@ -743,8 +743,8 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops,
   // if argsize == 0 and the chunk isn't mixed, the chunk contains the metadata (pc, fp -- frame::sender_sp_offset)
   // for the top frame (below sp), and *not* for the bottom frame
   int size = chunk->stack_size() - chunk->argsize() - chunk->sp();
-  assert (size >= 0, "");
-  assert ((size == 0) == chunk->is_empty(), "");
+  assert(size >= 0, "");
+  assert((size == 0) == chunk->is_empty(), "");
 
   const StackChunkFrameStream<chunk_frames::MIXED> first(chunk);
   const bool has_safepoint_stub_frame = first.is_stub();
@@ -754,26 +754,26 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops,
     has_safepoint_stub_frame ? first.frame_size() : 0);
   chunk->iterate_stack(&closure);
 
-  assert (!chunk->is_empty() || closure._cb == nullptr, "");
+  assert(!chunk->is_empty() || closure._cb == nullptr, "");
   if (closure._cb != nullptr && closure._cb->is_compiled()) {
-    assert (chunk->argsize() ==
+    assert(chunk->argsize() ==
       (closure._cb->as_compiled_method()->method()->num_stack_arg_slots()*VMRegImpl::stack_slot_size) >>LogBytesPerWord,
       "chunk argsize: %d bottom frame argsize: %d", chunk->argsize(),
       (closure._cb->as_compiled_method()->method()->num_stack_arg_slots()*VMRegImpl::stack_slot_size) >>LogBytesPerWord);
   }
 
-  assert (closure._num_interpreted_frames == 0 || chunk->has_mixed_frames(), "");
+  assert(closure._num_interpreted_frames == 0 || chunk->has_mixed_frames(), "");
 
   if (!concurrent) {
-    assert (closure._size <= size + chunk->argsize() + metadata_words(),
+    assert(closure._size <= size + chunk->argsize() + metadata_words(),
       "size: %d argsize: %d closure.size: %d end sp: " PTR_FORMAT " start sp: %d chunk size: %d",
       size, chunk->argsize(), closure._size, closure._sp - chunk->start_address(), chunk->sp(), chunk->stack_size());
-    assert (chunk->argsize() == closure._argsize,
+    assert(chunk->argsize() == closure._argsize,
       "chunk->argsize(): %d closure.argsize: %d closure.callee_interpreted: %d",
       chunk->argsize(), closure._argsize, closure._callee_interpreted);
 
     int max_size = closure._size + closure._num_i2c * align_wiggle();
-    assert (chunk->max_size() == max_size,
+    assert(chunk->max_size() == max_size,
       "max_size(): %d max_size: %d argsize: %d num_i2c: %d",
       chunk->max_size(), max_size, closure._argsize, closure._num_i2c);
 
@@ -782,11 +782,11 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops,
     if (out_frames != nullptr) *out_frames += closure._num_frames;
     if (out_interpreted_frames != nullptr) *out_interpreted_frames += closure._num_interpreted_frames;
   } else {
-    assert (out_size == nullptr && out_oops == nullptr && out_frames == nullptr && out_interpreted_frames == nullptr, "");
+    assert(out_size == nullptr && out_oops == nullptr && out_frames == nullptr && out_interpreted_frames == nullptr, "");
   }
 
   if (chunk->has_bitmap()) {
-    assert (chunk->bitmap().size() == chunk->bit_offset() + (size_t)(chunk->stack_size() << (UseCompressedOops ? 1 : 0)),
+    assert(chunk->bitmap().size() == chunk->bit_offset() + (size_t)(chunk->stack_size() << (UseCompressedOops ? 1 : 0)),
       "bitmap().size(): %zu bit_offset: %zu stack_size: %d",
       chunk->bitmap().size(), chunk->bit_offset(), chunk->stack_size());
     int oop_count;
@@ -803,7 +803,7 @@ bool InstanceStackChunkKlass::verify(oop obj, size_t* out_size, int* out_oops,
         chunk->bit_index_for((oop*)chunk->end_address()));
       oop_count = bitmap_closure._count;
     }
-    assert (oop_count == closure._num_oops,
+    assert(oop_count == closure._num_oops,
       "bitmap_closure._count: %d closure._num_oops: %d", oop_count, closure._num_oops);
   }
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -299,7 +299,7 @@ public:
 
   void handle_deopted() const;
 
-  inline int to_offset(stackChunkOop chunk) const { assert (!is_done(), ""); return _sp - chunk->start_address(); }
+  inline int to_offset(stackChunkOop chunk) const { assert(!is_done(), ""); return _sp - chunk->start_address(); }
 
   inline frame to_frame() const;
 

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -39,7 +39,7 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
 #endif
 
 frame stackChunkOopDesc::top_frame(RegisterMap* map) {
-  assert (!is_empty(), "");
+  assert(!is_empty(), "");
   StackChunkFrameStream<chunk_frames::MIXED> fs(this);
 
   map->set_stack_chunk(this);
@@ -49,19 +49,19 @@ frame stackChunkOopDesc::top_frame(RegisterMap* map) {
   frame f = fs.to_frame();
   // if (!maybe_fix_async_walk(f, map)) return frame();
 
-  assert (to_offset(f.sp()) == sp(), "f.offset_sp(): %d sp(): %d async: %d", f.offset_sp(), sp(), map->is_async());
+  assert(to_offset(f.sp()) == sp(), "f.offset_sp(): %d sp(): %d async: %d", f.offset_sp(), sp(), map->is_async());
   relativize_frame(f);
   f.set_frame_index(0);
   return f;
 }
 
 frame stackChunkOopDesc::sender(const frame& f, RegisterMap* map) {
-  assert (map->in_cont(), "");
-  assert (!map->include_argument_oops(), "");
-  assert (!f.is_empty(), "");
-  assert (map->stack_chunk() == this, "");
-  assert (this != nullptr, "");
-  assert (!is_empty(), "");
+  assert(map->in_cont(), "");
+  assert(!map->include_argument_oops(), "");
+  assert(!f.is_empty(), "");
+  assert(map->stack_chunk() == this, "");
+  assert(this != nullptr, "");
+  assert(!is_empty(), "");
 
   int index = f.frame_index();
   StackChunkFrameStream<chunk_frames::MIXED> fs(this, derelativize(f));
@@ -69,7 +69,7 @@ frame stackChunkOopDesc::sender(const frame& f, RegisterMap* map) {
 
   if (!fs.is_done()) {
     frame sender = fs.to_frame();
-    assert (is_usable_in_chunk(sender.unextended_sp()), "");
+    assert(is_usable_in_chunk(sender.unextended_sp()), "");
     relativize_frame(sender);
 
     sender.set_frame_index(index+1);
@@ -77,7 +77,7 @@ frame stackChunkOopDesc::sender(const frame& f, RegisterMap* map) {
   }
 
   if (parent() != (oop)nullptr) {
-    assert (!parent()->is_empty(), "");
+    assert(!parent()->is_empty(), "");
     return parent()->top_frame(map);
   }
 
@@ -89,7 +89,7 @@ frame stackChunkOopDesc::sender(const frame& f, RegisterMap* map) {
 //     return true;
 
 //   // Can happen during async stack walks, where the continuation is in the midst of a freeze/thaw
-//   assert (map->is_async(), "");
+//   assert(map->is_async(), "");
 //   address pc0 = pc();
 
 //   // we write sp first, then pc; here we read in the opposite order, so if sp is right, so is pc.
@@ -98,7 +98,7 @@ frame stackChunkOopDesc::sender(const frame& f, RegisterMap* map) {
 //     f.set_pc(pc0);
 //     return true;
 //   }
-//   assert (false, "");
+//   assert(false, "");
 //   log_debug(jvmcont)("failed to fix frame during async stackwalk");
 //   return false;
 // }
@@ -112,8 +112,8 @@ static int num_java_frames(CompiledMethod* cm, address pc) {
 }
 
 static int num_java_frames(const StackChunkFrameStream<chunk_frames::MIXED>& f) {
-  assert (f.is_interpreted()
-          || (f.cb() != nullptr && f.cb()->is_compiled() && f.cb()->as_compiled_method()->is_java_method()), "");
+  assert(f.is_interpreted()
+         || (f.cb() != nullptr && f.cb()->is_compiled() && f.cb()->as_compiled_method()->is_java_method()), "");
   return f.is_interpreted() ? 1 : num_java_frames(f.cb()->as_compiled_method(), f.orig_pc());
 }
 

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -80,19 +80,19 @@ inline intptr_t* stackChunkOopDesc::from_offset(int offset) const {
 }
 
 inline bool stackChunkOopDesc::is_empty() const {
-  assert (is_stackChunk(), "");
+  assert(is_stackChunk(), "");
   return sp() >= stack_size() - argsize();
 }
 
 inline bool stackChunkOopDesc::is_in_chunk(void* p) const {
-  assert (is_stackChunk(), "");
+  assert(is_stackChunk(), "");
   HeapWord* start = (HeapWord*)start_address();
   HeapWord* end = start + stack_size();
   return (HeapWord*)p >= start && (HeapWord*)p < end;
 }
 
 bool stackChunkOopDesc::is_usable_in_chunk(void* p) const {
-  assert (is_stackChunk(), "");
+  assert(is_stackChunk(), "");
 #if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
   HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset;
 #else
@@ -126,7 +126,7 @@ inline void stackChunkOopDesc::set_has_mixed_frames(bool value)    { set_flag(FL
 inline bool stackChunkOopDesc::is_gc_mode() const                  { return is_flag(FLAG_GC_MODE); }
 inline void stackChunkOopDesc::set_gc_mode(bool value)             { set_flag(FLAG_GC_MODE, value); }
 inline bool stackChunkOopDesc::has_bitmap() const                  { return is_flag(FLAG_HAS_BITMAP); }
-inline void stackChunkOopDesc::set_has_bitmap(bool value)          { set_flag(FLAG_HAS_BITMAP, value); assert (!value || UseChunkBitmaps, ""); }
+inline void stackChunkOopDesc::set_has_bitmap(bool value)          { set_flag(FLAG_HAS_BITMAP, value); assert(!value || UseChunkBitmaps, ""); }
 inline bool stackChunkOopDesc::has_thaw_slowpath_condition() const { return flags() != 0; }
 
 inline intptr_t* stackChunkOopDesc::relative_base() const {
@@ -138,7 +138,7 @@ inline intptr_t* stackChunkOopDesc::derelativize_address(int offset) const {
   intptr_t* base = relative_base();
   intptr_t* p = base - offset;
   // tty->print_cr(">>> derelativize_address: %d -> %p (base: %p)", offset, p, base);
-  assert (start_address() <= p && p <= base, "");
+  assert(start_address() <= p && p <= base, "");
   return p;
 }
 
@@ -146,8 +146,8 @@ inline int stackChunkOopDesc::relativize_address(intptr_t* p) const {
   intptr_t* base = relative_base();
   intptr_t offset = base - p;
   // tty->print_cr(">>> relativize_address: %p -> %ld (base: %p)", p, offset, base);
-  assert (start_address() <= p && p <= base, "");
-  assert (0 <= offset && offset <= std::numeric_limits<int>::max(), "");
+  assert(start_address() <= p && p <= base, "");
+  assert(0 <= offset && offset <= std::numeric_limits<int>::max(), "");
   return offset;
 }
 
@@ -167,18 +167,18 @@ inline frame stackChunkOopDesc::relativize(frame fr)   const { relativize_frame(
 inline frame stackChunkOopDesc::derelativize(frame fr) const { derelativize_frame(fr); return fr; }
 
 inline int stackChunkOopDesc::relativize_usp_offset(const frame& fr, const int usp_offset_in_bytes) const {
-  assert (fr.is_compiled_frame() || fr.cb()->is_safepoint_stub(), "");
-  assert (is_in_chunk(fr.unextended_sp()), "");
+  assert(fr.is_compiled_frame() || fr.cb()->is_safepoint_stub(), "");
+  assert(is_in_chunk(fr.unextended_sp()), "");
 
   intptr_t* base = fr.real_fp(); // equal to the caller's sp
   intptr_t* loc = (intptr_t*)((address)fr.unextended_sp() + usp_offset_in_bytes);
-  assert (base > loc, "");
+  assert(base > loc, "");
   return (int)(base - loc);
 }
 
 inline address stackChunkOopDesc::reg_to_location(const frame& fr, const RegisterMap* map, VMReg reg) const {
-  assert (fr.is_compiled_frame(), "");
-  assert (map != nullptr && map->stack_chunk() == as_oop(), "");
+  assert(fr.is_compiled_frame(), "");
+  assert(map != nullptr && map->stack_chunk() == as_oop(), "");
 
   // the offsets are saved in the map after going through relativize_usp_offset, so they are sp - loc, in words
   intptr_t offset = (intptr_t)map->location(reg, nullptr); // see usp_offset_to_index for the chunk case
@@ -187,7 +187,7 @@ inline address stackChunkOopDesc::reg_to_location(const frame& fr, const Registe
 }
 
 inline address stackChunkOopDesc::usp_offset_to_location(const frame& fr, const int usp_offset_in_bytes) const {
-  assert (fr.is_compiled_frame(), "");
+  assert(fr.is_compiled_frame(), "");
   return (address)derelativize_address(fr.offset_unextended_sp()) + usp_offset_in_bytes;
 }
 
@@ -219,8 +219,8 @@ inline void stackChunkOopDesc::copy_from_stack_to_chunk(intptr_t* from, intptr_t
     p2i(to), to - start_address(), relative_base() - to, p2i(to + size), to + size - start_address(),
     relative_base() - (to + size), size, size << LogBytesPerWord);
 
-  assert (to >= start_address(), "");
-  assert (to + size <= end_address(), "");
+  assert(to >= start_address(), "");
+  assert(to + size <= end_address(), "");
 
   InstanceStackChunkKlass::copy_from_stack_to_chunk<alignment>(from, to, size);
 }
@@ -233,19 +233,19 @@ inline void stackChunkOopDesc::copy_from_chunk_to_stack(intptr_t* from, intptr_t
   log_develop_trace(jvmcont)("Copying to v: " INTPTR_FORMAT " - " INTPTR_FORMAT " (%d words, %d bytes)", p2i(to),
     p2i(to + size), size, size << LogBytesPerWord);
 
-  assert (from >= start_address(), "");
-  assert (from + size <= end_address(), "");
+  assert(from >= start_address(), "");
+  assert(from + size <= end_address(), "");
 
   InstanceStackChunkKlass::copy_from_chunk_to_stack<alignment>(from, to, size);
 }
 
 inline BitMapView stackChunkOopDesc::bitmap() const {
-  assert (has_bitmap(), "");
+  assert(has_bitmap(), "");
   size_t size_in_bits = InstanceStackChunkKlass::bitmap_size(stack_size()) << LogBitsPerWord;
 #ifdef ASSERT
   BitMapView bm((BitMap::bm_word_t*)InstanceStackChunkKlass::start_of_bitmap(as_oop()), size_in_bits);
-  assert (bm.size() == size_in_bits, "bm.size(): %zu size_in_bits: %zu", bm.size(), size_in_bits);
-  assert (bm.size_in_words() == (size_t)InstanceStackChunkKlass::bitmap_size(stack_size()), "");
+  assert(bm.size() == size_in_bits, "bm.size(): %zu size_in_bits: %zu", bm.size(), size_in_bits);
+  assert(bm.size_in_words() == (size_t)InstanceStackChunkKlass::bitmap_size(stack_size()), "");
   bm.verify_range(bit_index_for(start_address()), bit_index_for(end_address()));
 #endif
   return BitMapView((BitMap::bm_word_t*)InstanceStackChunkKlass::start_of_bitmap(as_oop()), size_in_bits);

--- a/src/hotspot/share/opto/buildOopMap.cpp
+++ b/src/hotspot/share/opto/buildOopMap.cpp
@@ -397,7 +397,7 @@ OopMap *OopFlow::build_oop_map( Node *n, int max_reg, PhaseRegAlloc *regalloc, i
       num_oops++;
     }
   }
-  assert (num_oops == omap->num_oops(), "num_oops: %d omap->num_oops(): %d", num_oops, omap->num_oops());
+  assert(num_oops == omap->num_oops(), "num_oops: %d omap->num_oops(): %d", num_oops, omap->num_oops());
 #endif
 
   return omap;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6199,7 +6199,7 @@ Node* LibraryCallKit::load_field_from_object(Node* fromObj, const char* fieldNam
                                               ciSymbol::make(fieldTypeString),
                                               is_static);
 
-  assert (field != NULL, "undefined field %s %s %s", fieldTypeString, fromKls->name()->as_utf8(), fieldName);
+  assert(field != NULL, "undefined field %s %s %s", fieldTypeString, fromKls->name()->as_utf8(), fieldName);
   if (field == NULL) return (Node *) NULL;
 
   if (is_static) {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3096,7 +3096,7 @@ JVM_END
 
 JVM_ENTRY(jobject, JVM_CurrentThread(JNIEnv* env, jclass threadClass))
   oop theThread = thread->vthread();
-  assert (theThread != (oop)NULL, "no current thread!");
+  assert(theThread != (oop)NULL, "no current thread!");
   return JNIHandles::make_local(THREAD, theThread);
 JVM_END
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -622,7 +622,7 @@ JavaThread* JvmtiEnvBase::is_virtual_thread_mounted(oop vthread) {
   JavaThread* java_thread = java_lang_Thread::thread(carrier_thread);
   oop cont = java_lang_VirtualThread::continuation(vthread);
   assert(cont != NULL, "virtual thread continuation must not be NULL");
-  assert (Continuation::continuation_scope(cont) == java_lang_VirtualThread::vthread_scope(), "must be");
+  assert(Continuation::continuation_scope(cont) == java_lang_VirtualThread::vthread_scope(), "must be");
   return Continuation::is_continuation_mounted(java_thread, cont) ? java_thread : NULL;
 }
 
@@ -632,7 +632,7 @@ JvmtiEnvBase::check_and_skip_hidden_frames(bool is_in_VTMT, javaVFrame* jvf) {
   if (!is_in_VTMT && (jvf == NULL || !jvf->method()->jvmti_mount_transition())) {
     return jvf; // no frames to skip
   }
-  assert (jvf != NULL && jvf->method() != NULL, "");
+  assert(jvf != NULL && jvf->method() != NULL, "");
   // find jvf with a method annotated with @JvmtiMountTransition
   for ( ; jvf != NULL; jvf = jvf->java_sender()) {
     if (jvf->method()->jvmti_mount_transition()) { // cannot actually appear in an unmounted continuation; they're never frozen.

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -1670,7 +1670,7 @@ void JvmtiExport::continuation_yield_cleanup(JavaThread* thread, jint continuati
     return;
   }
 
-  assert (thread == JavaThread::current(), "must be");
+  assert(thread == JavaThread::current(), "must be");
   JvmtiThreadState *state = thread->jvmti_thread_state();
   if (state == NULL) {
     return;

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -48,7 +48,7 @@
 // setup and cleanup actions
 BaseFrameStream::BaseFrameStream(JavaThread* thread, Handle continuation)
   : _thread(thread), _continuation(continuation), _anchor(0L) {
-    assert (thread != NULL, "");
+    assert(thread != NULL, "");
 }
 
 void BaseFrameStream::setup_magic_on_entry(objArrayHandle frames_array) {
@@ -89,7 +89,7 @@ void BaseFrameStream::set_continuation(Handle cont) {
 // static inline Handle continuationScope_of(JavaThread* thread, Handle cont_or_scope) {
 //   if (cont_or_scope.is_null() || cont_or_scope()->is_a(SystemDictionary::ContinuationScope_klass()))
 //     return cont_or_scope;
-//   assert (cont_or_scope()->is_a(SystemDictionary::Continuation_klass()), "must be");
+//   assert(cont_or_scope()->is_a(SystemDictionary::Continuation_klass()), "must be");
 //   return Handle(thread, Continuation::continuation_scope(cont_or_scope()));
 // }
 
@@ -121,7 +121,7 @@ void JavaFrameStream::next() {
 }
 
 void LiveFrameStream::next() {
-  assert (_cont_scope.is_null() || cont() != (oop)NULL, "must be");
+  assert(_cont_scope.is_null() || cont() != (oop)NULL, "must be");
 
   oop cont = this->cont();
   if (cont != (oop)NULL && Continuation::is_continuation_entry_frame(_jvf->fr(), _jvf->register_map())) {
@@ -132,7 +132,7 @@ void LiveFrameStream::next() {
     }
     _cont = _cont->parent();
   }
-  assert (!Continuation::is_scope_bottom(_cont_scope(), _jvf->fr(), _jvf->register_map()), "");
+  assert(!Continuation::is_scope_bottom(_cont_scope(), _jvf->fr(), _jvf->register_map()), "");
 
   _jvf = _jvf->java_sender();
 }
@@ -186,7 +186,7 @@ int StackWalk::fill_in_frames(jlong mode, BaseFrameStream& stream,
 
   int frames_decoded = 0;
   for (; !stream.at_end(); stream.next()) {
-    assert (stream.continuation() == NULL || stream.continuation() == stream.reg_map()->cont(), "");
+    assert(stream.continuation() == NULL || stream.continuation() == stream.reg_map()->cont(), "");
     Method* method = stream.method();
 
     if (method == NULL) continue;
@@ -440,7 +440,7 @@ oop StackWalk::walk(Handle stackStream, jlong mode, int skip_frames, Handle cont
 
   // Setup traversal onto my stack.
   if (live_frame_info(mode)) {
-    assert (use_frames_array(mode), "Bad mode for get live frame");
+    assert(use_frames_array(mode), "Bad mode for get live frame");
     RegisterMap regMap = cont.is_null() ? RegisterMap(jt, true, true, true)
                                         : RegisterMap(cont(), true);
     LiveFrameStream stream(jt, &regMap, cont_scope, cont);

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -275,8 +275,8 @@ public:
 };
 
 oop ContinuationHelper::get_continuation(JavaThread* thread) {
-  assert (thread != nullptr, "");
-  assert (thread->threadObj() != nullptr, "");
+  assert(thread != nullptr, "");
+  assert(thread->threadObj() != nullptr, "");
   return java_lang_Thread::continuation(thread->threadObj());
 }
 
@@ -296,14 +296,14 @@ inline void ContinuationHelper::clear_anchor(JavaThread* thread) {
 
 void ContinuationHelper::set_anchor(JavaThread* thread, intptr_t* sp) {
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
-  assert (pc != nullptr, "");
+  assert(pc != nullptr, "");
 
   JavaFrameAnchor* anchor = thread->frame_anchor();
   anchor->set_last_Java_sp(sp);
   anchor->set_last_Java_pc(pc);
   set_anchor_pd(anchor, sp);
 
-  assert (thread->has_last_Java_frame(), "");
+  assert(thread->has_last_Java_frame(), "");
   assert(thread->last_frame().cb() != nullptr, "");
 }
 
@@ -313,7 +313,7 @@ void ContinuationHelper::set_anchor_to_entry(JavaThread* thread, ContinuationEnt
   anchor->set_last_Java_pc(cont->entry_pc());
   set_anchor_to_entry_pd(anchor, cont);
 
-  assert (thread->has_last_Java_frame(), "");
+  assert(thread->has_last_Java_frame(), "");
   assert(thread->last_frame().cb() != nullptr, "");
 }
 
@@ -381,7 +381,7 @@ public:
   intptr_t* entrySP() const { return _entry->entry_sp(); }
   intptr_t* entryFP() const { return _entry->entry_fp(); }
   address   entryPC() const { return _entry->entry_pc(); }
-  int argsize()       const { assert (_entry->argsize() >= 0, ""); return _entry->argsize(); }
+  int argsize()       const { assert(_entry->argsize() >= 0, ""); return _entry->argsize(); }
   void set_argsize(int value) { _entry->set_argsize(value); }
 
   bool is_empty() const { return last_nonempty_chunk() == nullptr; }
@@ -410,8 +410,8 @@ ContMirror::ContMirror(JavaThread* thread, oop cont)
 #endif
   {
   assert(_cont != nullptr && oopDesc::is_oop_or_null(_cont), "Invalid cont: " INTPTR_FORMAT, p2i((void*)_cont));
-  assert (_cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: "
-          INTPTR_FORMAT, p2i((oopDesc*)_cont), p2i((oopDesc*)_entry->cont_oop()), p2i(entrySP()));
+  assert(_cont == _entry->cont_oop(), "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: "
+         INTPTR_FORMAT, p2i((oopDesc*)_cont), p2i((oopDesc*)_entry->cont_oop()), p2i(entrySP()));
   read();
 }
 
@@ -434,7 +434,7 @@ ContMirror::ContMirror(const RegisterMap* map)
 #endif
   {
   assert(_cont != nullptr && oopDesc::is_oop_or_null(_cont), "Invalid cont: " INTPTR_FORMAT, p2i((void*)_cont));
-  assert (_entry == nullptr || _cont == _entry->cont_oop(),
+  assert(_entry == nullptr || _cont == _entry->cont_oop(),
     "mirror: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
     p2i( (oopDesc*)_cont), p2i((oopDesc*)_entry->cont_oop()), p2i(entrySP()));
   read();
@@ -471,7 +471,7 @@ inline stackChunkOop ContMirror::nonempty_chunk(stackChunkOop chunk) const {
 stackChunkOop ContMirror::find_chunk_by_address(void* p) const {
   for (stackChunkOop chunk = tail(); chunk != nullptr; chunk = chunk->parent()) {
     if (chunk->is_in_chunk(p)) {
-      assert (chunk->is_usable_in_chunk(p), "");
+      assert(chunk->is_usable_in_chunk(p), "");
       return chunk;
     }
   }
@@ -501,11 +501,11 @@ bool ContMirror::chunk_invariant(outputStream* st) {
   if (_tail == (oop)nullptr) {
     return true;
   }
-  assert (_tail->is_stackChunk(), "");
+  assert(_tail->is_stackChunk(), "");
   int i = 1;
   for (stackChunkOop chunk = _tail->parent(); chunk != (oop)nullptr; chunk = chunk->parent()) {
     if (chunk->is_empty()) {
-      assert (chunk != _tail, "");
+      assert(chunk != _tail, "");
       st->print_cr("i: %d", i);
       chunk->print_on(true, st);
       return false;
@@ -532,7 +532,7 @@ static int num_java_frames(ContMirror& cont) {
 // Entry point to freeze. Transitions are handled manually
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* sp))
-  assert (sp == current->frame_anchor()->last_Java_sp(), "");
+  assert(sp == current->frame_anchor()->last_Java_sp(), "");
 
   if (current->raw_cont_fastpath() > current->last_continuation()->entry_sp() || current->raw_cont_fastpath() < sp) {
     current->set_cont_fastpath(nullptr);
@@ -565,10 +565,10 @@ int Continuation::try_force_yield(JavaThread* target, const oop cont) {
     return freeze_pinned_native;
   }
 
-  assert (target->has_last_Java_frame(), "");
-  assert (!Interpreter::contains(target->last_Java_pc()) || !target->cont_fastpath(),
-          "fast_path at codelet %s",
-          Interpreter::codelet_containing(target->last_Java_pc())->description());
+  assert(target->has_last_Java_frame(), "");
+  assert(!Interpreter::contains(target->last_Java_pc()) || !target->cont_fastpath(),
+         "fast_path at codelet %s",
+         Interpreter::codelet_containing(target->last_Java_pc())->description());
 
   const oop scope = jdk_internal_vm_Continuation::scope(cont);
   if (innermost != cont) { // we have nested continuations
@@ -581,7 +581,7 @@ int Continuation::try_force_yield(JavaThread* target, const oop cont) {
     jdk_internal_vm_Continuation::set_yieldInfo(cont, scope);
   }
 
-  assert (target->has_last_Java_frame(), "");
+  assert(target->has_last_Java_frame(), "");
   int res = preempt_freeze(target, target->last_Java_sp());
   log_trace(jvmcont, preempt)("try_force_yield: %s", freeze_result_names[res]);
   if (res == 0) { // success
@@ -611,8 +611,8 @@ JRT_END
 typedef void (*cont_jump_from_sp_t)();
 
 void Continuation::jump_from_safepoint(JavaThread* thread) {
-  assert (thread == JavaThread::current(), "");
-  assert (thread->is_cont_force_yield(), "");
+  assert(thread == JavaThread::current(), "");
+  assert(thread->is_cont_force_yield(), "");
   log_develop_trace(jvmcont)("force_yield_if_preempted: is_cont_force_yield");
   thread->set_cont_preempt(false);
   if (thread->thread_state() == _thread_in_vm) {
@@ -672,7 +672,7 @@ ContinuationEntry* Continuation::get_continuation_entry_for_continuation(JavaThr
 }
 
 ContinuationEntry* Continuation::get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f) {
-  assert (is_continuation_enterSpecial(f), "");
+  assert(is_continuation_enterSpecial(f), "");
   return (ContinuationEntry*)f.unextended_sp();
 }
 
@@ -681,7 +681,7 @@ static bool is_on_stack(JavaThread* thread, const ContinuationEntry* cont) {
     return false;
   }
 
-  assert (thread->is_in_full_stack((address)cont), "");
+  assert(thread->is_in_full_stack((address)cont), "");
   return true;
   // return false if called when transitioning to Java on return from freeze
   // return !thread->has_last_Java_frame() || thread->last_Java_sp() < cont->entry_sp();
@@ -700,7 +700,7 @@ bool Continuation::is_continuation_scope_mounted(JavaThread* thread, oop cont_sc
 // caller is still frozen on the h-stack.
 // The continuation object can be extracted from the thread.
 bool Continuation::is_cont_barrier_frame(const frame& f) {
-  assert (f.is_interpreted_frame() || f.cb() != nullptr, "");
+  assert(f.is_interpreted_frame() || f.cb() != nullptr, "");
   return is_return_barrier_entry(f.is_interpreted_frame() ? Interpreted::return_pc(f) : Compiled::return_pc(f));
 }
 
@@ -733,7 +733,7 @@ bool Continuation::is_frame_in_continuation(const ContinuationEntry* cont, const
 }
 
 ContinuationEntry* Continuation::get_continuation_entry_for_sp(JavaThread* thread, intptr_t* const sp) {
-  assert (thread != nullptr, "");
+  assert(thread != nullptr, "");
   ContinuationEntry* cont = thread->last_continuation();
   while (cont != nullptr && !is_sp_in_continuation(cont, sp)) {
     cont = cont->parent();
@@ -761,7 +761,7 @@ frame Continuation::last_frame(oop continuation, RegisterMap *map) {
 }
 
 frame Continuation::top_frame(const frame& callee, RegisterMap* map) {
-  assert (map != nullptr, "");
+  assert(map != nullptr, "");
   return continuation_top_frame(get_continuation_entry_for_sp(map->thread(), callee.sp())->cont_oop(), map);
 }
 
@@ -777,9 +777,9 @@ javaVFrame* Continuation::last_java_vframe(Handle continuation, RegisterMap *map
 }
 
 frame Continuation::continuation_parent_frame(RegisterMap* map) {
-  assert (map->in_cont(), "");
+  assert(map->in_cont(), "");
   ContMirror cont(map);
-  assert (map->thread() != nullptr || !cont.is_mounted(), "");
+  assert(map->thread() != nullptr || !cont.is_mounted(), "");
 
   log_develop_trace(jvmcont)("continuation_parent_frame");
   if (map->update_map()) {
@@ -846,8 +846,8 @@ bool Continuation::pin(JavaThread* current) {
   }
 
   oop cont = ce->cont_oop();
-  assert (cont != nullptr, "");
-  assert (cont == ContinuationHelper::get_continuation(current), "");
+  assert(cont != nullptr, "");
+  assert(cont == ContinuationHelper::get_continuation(current), "");
 
   jshort value = jdk_internal_vm_Continuation::critical_section(cont);
   if (value < max_jshort) {
@@ -864,8 +864,8 @@ bool Continuation::unpin(JavaThread* current) {
   }
 
   oop cont = ce->cont_oop();
-  assert (cont != nullptr, "");
-  assert (cont == ContinuationHelper::get_continuation(current), "");
+  assert(cont != nullptr, "");
+  assert(cont == ContinuationHelper::get_continuation(current), "");
 
   jshort value = jdk_internal_vm_Continuation::critical_section(cont);
   if (value > 0) {
@@ -880,7 +880,7 @@ bool Continuation::fix_continuation_bottom_sender(JavaThread* thread, const fram
   if (thread != nullptr && is_return_barrier_entry(*sender_pc)) {
     ContinuationEntry* cont = get_continuation_entry_for_sp(thread,
           callee.is_interpreted_frame() ? callee.interpreter_frame_last_sp() : callee.unextended_sp());
-    assert (cont != nullptr, "callee.unextended_sp(): " INTPTR_FORMAT, p2i(callee.unextended_sp()));
+    assert(cont != nullptr, "callee.unextended_sp(): " INTPTR_FORMAT, p2i(callee.unextended_sp()));
 
     log_develop_debug(jvmcont)("fix_continuation_bottom_sender: "
                                   "[" JLONG_FORMAT "] [%d]", java_tid(thread), thread->osthread()->thread_id());
@@ -905,7 +905,7 @@ address Continuation::get_top_return_pc_post_barrier(JavaThread* thread, address
 }
 
 void Continuation::set_cont_fastpath_thread_state(JavaThread* thread) {
-  assert (thread != nullptr, "");
+  assert(thread != nullptr, "");
   bool fast = !thread->is_interp_only_mode();
   thread->set_cont_fastpath_thread_state(fast);
 }
@@ -929,7 +929,7 @@ void Continuation::notify_deopt(JavaThread* thread, intptr_t* sp) {
   } while (cont != nullptr && !is_sp_in_continuation(cont, sp));
 
   if (cont == nullptr) return;
-  assert (is_sp_in_continuation(cont, sp), "");
+  assert(is_sp_in_continuation(cont, sp), "");
   if (sp > prev->parent_cont_fastpath()) {
     prev->set_parent_cont_fastpath(sp);
   }
@@ -963,12 +963,12 @@ void Continuation::emit_chunk_iterate_event(oop chunk, int num_frames, int num_o
 #ifdef ASSERT
 NOINLINE bool Continuation::debug_verify_continuation(oop contOop) {
   DEBUG_ONLY(if (!VerifyContinuations) return true;)
-  assert (contOop != (oop)nullptr, "");
-  assert (oopDesc::is_oop(contOop), "");
+  assert(contOop != (oop)nullptr, "");
+  assert(oopDesc::is_oop(contOop), "");
   ContMirror cont(contOop);
 
-  assert (oopDesc::is_oop_or_null(cont.tail()), "");
-  assert (cont.chunk_invariant(tty), "");
+  assert(oopDesc::is_oop_or_null(cont.tail()), "");
+  assert(cont.chunk_invariant(tty), "");
 
   bool nonempty_chunk = false;
   size_t max_size = 0;
@@ -987,8 +987,8 @@ NOINLINE bool Continuation::debug_verify_continuation(oop contOop) {
   }
 
   const bool is_empty = cont.is_empty();
-  assert (!nonempty_chunk || !is_empty, "");
-  assert (is_empty == (!nonempty_chunk && cont.last_frame().is_empty()), "");
+  assert(!nonempty_chunk || !is_empty, "");
+  assert(is_empty == (!nonempty_chunk && cont.last_frame().is_empty()), "");
 
   return true;
 }
@@ -1043,13 +1043,13 @@ public:
   Freeze(JavaThread* thread, ContMirror& mirror, bool preempt) :
       _thread(thread), _cont(mirror), _barriers(false), _preempt(preempt) {
 
-    assert (thread->last_continuation()->entry_sp() == _cont.entrySP(), "");
+    assert(thread->last_continuation()->entry_sp() == _cont.entrySP(), "");
 
     int argsize = _cont.argsize();
     _bottom_address = _cont.entrySP() - argsize;
     DEBUG_ONLY(_cont.entry()->verify_cookie();)
 
-    assert (!Interpreter::contains(_cont.entryPC()), "");
+    assert(!Interpreter::contains(_cont.entryPC()), "");
 
   #ifdef _LP64
     if (((intptr_t)_bottom_address & 0xf) != 0) {
@@ -1060,7 +1060,7 @@ public:
 
     log_develop_trace(jvmcont)("bottom_address: " INTPTR_FORMAT " entrySP: " INTPTR_FORMAT " argsize: " PTR_FORMAT,
                   p2i(_bottom_address), p2i(_cont.entrySP()), (_cont.entrySP() - _bottom_address) << LogBytesPerWord);
-    assert (_bottom_address != nullptr && _bottom_address <= _cont.entrySP(), "");
+    assert(_bottom_address != nullptr && _bottom_address <= _cont.entrySP(), "");
     DEBUG_ONLY(_last_write = nullptr;)
   }
 
@@ -1078,7 +1078,7 @@ public:
 
   #ifdef ASSERT
     if (_last_write != nullptr) {
-      assert (_last_write == to + size, "Missed a spot: _last_write: " INTPTR_FORMAT " to+size: " INTPTR_FORMAT
+      assert(_last_write == to + size, "Missed a spot: _last_write: " INTPTR_FORMAT " to+size: " INTPTR_FORMAT
           " stack_size: %d _last_write offset: " PTR_FORMAT " to+size: " PTR_FORMAT, p2i(_last_write), p2i(to+size),
           chunk->stack_size(), _last_write-chunk->start_address(), to+size-chunk->start_address());
       _last_write = to;
@@ -1109,7 +1109,7 @@ public:
       e.commit();
     }
     // TODO R REMOVE when deopt change is fixed
-    assert (!_thread->cont_fastpath() || _barriers, "");
+    assert(!_thread->cont_fastpath() || _barriers, "");
     log_develop_trace(jvmcont)("-- RETRYING SLOW --");
     return freeze_slow();
   }
@@ -1127,8 +1127,8 @@ public:
       return false;
     }
 
-    // assert (CodeCache::find_blob(*(address*)(top_sp - SENDER_SP_RET_ADDRESS_OFFSET)) == StubRoutines::cont_doYield_stub(), ""); -- fails on Windows
-    assert (StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
+    // assert(CodeCache::find_blob(*(address*)(top_sp - SENDER_SP_RET_ADDRESS_OFFSET)) == StubRoutines::cont_doYield_stub(), ""); -- fails on Windows
+    assert(StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
     intptr_t* const stack_top     = top_sp + ContinuationHelper::frame_metadata;
     const int       stack_argsize = _cont.argsize();
     intptr_t* const stack_bottom  = _cont.entrySP() - ContinuationHelper::frame_align_words(stack_argsize);
@@ -1139,7 +1139,7 @@ public:
     if (chunk_sp < chunk->stack_size()) {
       size -= stack_argsize;
     }
-    assert (size > 0, "");
+    assert(size > 0, "");
 
     bool available = chunk_sp - ContinuationHelper::frame_metadata >= size;
     log_develop_trace(jvmcont)("is_chunk_available: %d size: %d argsize: %d top: " INTPTR_FORMAT " bottom: " INTPTR_FORMAT,
@@ -1150,10 +1150,10 @@ public:
 
   template <bool chunk_available>
   bool freeze_fast(intptr_t* top_sp) {
-    assert (_thread != nullptr, "");
-    assert (_cont.chunk_invariant(tty), "");
-    assert (!Interpreter::contains(_cont.entryPC()), "");
-    assert (StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
+    assert(_thread != nullptr, "");
+    assert(_cont.chunk_invariant(tty), "");
+    assert(!Interpreter::contains(_cont.entryPC()), "");
+    assert(StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
 
     // properties of the continuation on the stack; all sizes are in words
     intptr_t* const stack_top     = top_sp + ContinuationHelper::frame_metadata;
@@ -1164,7 +1164,7 @@ public:
 
     log_develop_trace(jvmcont)("freeze_fast size: %d argsize: %d top: " INTPTR_FORMAT " bottom: " INTPTR_FORMAT,
       size, stack_argsize, p2i(stack_top), p2i(stack_bottom));
-    assert (size > 0, "");
+    assert(size > 0, "");
 
   #ifdef ASSERT
     bool allocated, empty;
@@ -1179,23 +1179,23 @@ public:
       DEBUG_ONLY(allocated = false;)
       DEBUG_ONLY(orig_chunk_sp = chunk->sp_address();)
 
-      assert (is_chunk_available0, "");
+      assert(is_chunk_available0, "");
 
       sp_before = chunk->sp();
 
       if (sp_before < chunk->stack_size()) { // we are copying into a non-empty chunk
         DEBUG_ONLY(empty = false;)
-        assert (sp_before < (chunk->stack_size() - chunk->argsize()), "");
-        assert (*(address*)(chunk->sp_address() - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");
+        assert(sp_before < (chunk->stack_size() - chunk->argsize()), "");
+        assert(*(address*)(chunk->sp_address() - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");
 
         sp_before += stack_argsize; // we overlap; we'll overwrite the chunk's top frame's callee arguments
-        assert (sp_before <= chunk->stack_size(), "");
+        assert(sp_before <= chunk->stack_size(), "");
 
         chunk->set_max_size(chunk->max_size() + size - stack_argsize);
 
         intptr_t* const bottom_sp = stack_bottom - stack_argsize;
-        assert (bottom_sp == _bottom_address, "");
-        assert (*(address*)(bottom_sp-frame::sender_sp_ret_address_offset()) == StubRoutines::cont_returnBarrier(), "");
+        assert(bottom_sp == _bottom_address, "");
+        assert(*(address*)(bottom_sp-frame::sender_sp_ret_address_offset()) == StubRoutines::cont_returnBarrier(), "");
         patch_chunk_pd(bottom_sp, chunk->sp_address());
         // we don't patch the pc at this time, so as not to make the stack unwalkable
       } else { // the chunk is empty
@@ -1208,9 +1208,9 @@ public:
     } else { // no chunk; allocate
       DEBUG_ONLY(empty = true; allocated = true;)
 
-      assert (_thread->thread_state() == _thread_in_vm, "");
-      assert (!is_chunk_available(top_sp), "");
-      assert (_thread->cont_fastpath(), "");
+      assert(_thread->thread_state() == _thread_in_vm, "");
+      assert(!is_chunk_available(top_sp), "");
+      assert(_thread->cont_fastpath(), "");
 
       chunk = allocate_chunk(size + ContinuationHelper::frame_metadata);
       if (UNLIKELY(chunk == nullptr)) return false; // OOME
@@ -1227,18 +1227,18 @@ public:
       // in a fresh chunk, we freeze *with* the bottom-most frame's stack arguments.
       // They'll then be stored twice: in the chunk and in the parent chunk's top frame
       sp_before = size + ContinuationHelper::frame_metadata;
-      assert (sp_before == chunk->stack_size(), "");
+      assert(sp_before == chunk->stack_size(), "");
 
       DEBUG_ONLY(orig_chunk_sp = chunk->start_address() + sp_before;)
     }
 
-    assert (chunk != nullptr, "");
-    assert (chunk->is_stackChunk(), "");
-    assert (!chunk->has_mixed_frames(), "");
-    assert (!chunk->is_gc_mode(), "");
-    assert (!chunk->has_bitmap(), "");
-    assert (!chunk->requires_barriers(), "");
-    assert (chunk == _cont.tail(), "");
+    assert(chunk != nullptr, "");
+    assert(chunk->is_stackChunk(), "");
+    assert(!chunk->has_mixed_frames(), "");
+    assert(!chunk->is_gc_mode(), "");
+    assert(!chunk->has_bitmap(), "");
+    assert(!chunk->requires_barriers(), "");
+    assert(chunk == _cont.tail(), "");
 
     // We unwind frames after the last safepoint so that the GC will have found the oops in the frames, but before
     // writing into the chunk. This is so that an asynchronous stack walk (not at a safepoint) that suspends us here
@@ -1250,14 +1250,14 @@ public:
 
     log_develop_trace(jvmcont)("freeze_fast start: chunk " INTPTR_FORMAT " size: %d orig sp: %d argsize: %d",
       p2i((oopDesc*)chunk), chunk->stack_size(), sp_before, stack_argsize);
-    assert (sp_before <= chunk->stack_size(), "");
-    assert (sp_before >= size, "");
+    assert(sp_before <= chunk->stack_size(), "");
+    assert(sp_before >= size, "");
 
     const int sp_after = sp_before - size; // the chunk's new sp, after freeze
-    assert (!is_chunk_available0 || orig_chunk_sp - (chunk->start_address() + sp_after) == is_chunk_available_size, "");
+    assert(!is_chunk_available0 || orig_chunk_sp - (chunk->start_address() + sp_after) == is_chunk_available_size, "");
 
     intptr_t* chunk_top = chunk->start_address() + sp_after;
-    assert (empty || *(address*)(orig_chunk_sp - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");
+    assert(empty || *(address*)(orig_chunk_sp - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");
 
     log_develop_trace(jvmcont)("freeze_fast start: " INTPTR_FORMAT " sp: %d chunk_top: " INTPTR_FORMAT,
                                 p2i(chunk->start_address()), sp_after, p2i(chunk_top));
@@ -1268,13 +1268,13 @@ public:
 
     // patch pc
     intptr_t* chunk_bottom_sp = chunk_top + size - stack_argsize;
-    assert (empty || *(address*)(chunk_bottom_sp-frame::sender_sp_ret_address_offset()) == StubRoutines::cont_returnBarrier(), "");
+    assert(empty || *(address*)(chunk_bottom_sp-frame::sender_sp_ret_address_offset()) == StubRoutines::cont_returnBarrier(), "");
     *(address*)(chunk_bottom_sp - frame::sender_sp_ret_address_offset()) = chunk->pc();
 
     // We're always writing to a young chunk, so the GC can't see it until the next safepoint.
     OrderAccess::storestore();
     chunk->set_sp(sp_after);
-    assert (chunk->sp_address() == chunk_top, "");
+    assert(chunk->sp_address() == chunk_top, "");
     chunk->set_pc(*(address*)(stack_top - frame::sender_sp_ret_address_offset()));
 
     _cont.write();
@@ -1286,8 +1286,8 @@ public:
       chunk->print_on(true, &ls);
     }
 
-    assert (_cont.chunk_invariant(tty), "");
-    assert (VERIFY_STACK_CHUNK(chunk), "");
+    assert(_cont.chunk_invariant(tty), "");
+    assert(VERIFY_STACK_CHUNK(chunk), "");
 
   #if CONT_JFR
     EventContinuationFreezeYoung e;
@@ -1308,7 +1308,7 @@ public:
   #endif
 
     log_develop_trace(jvmcont)("freeze_slow  #" INTPTR_FORMAT, _cont.hash());
-    assert (_thread->thread_state() == _thread_in_vm || _thread->thread_state() == _thread_blocked, "");
+    assert(_thread->thread_state() == _thread_in_vm || _thread->thread_state() == _thread_blocked, "");
 
     init_rest();
 
@@ -1337,7 +1337,7 @@ public:
   frame freeze_start_frame() {
     frame f = _thread->last_frame();
     if (LIKELY(!_preempt)) {
-      assert (StubRoutines::cont_doYield_stub()->contains(f.pc()), "");
+      assert(StubRoutines::cont_doYield_stub()->contains(f.pc()), "");
       return freeze_start_frame_yield_stub(f);
     } else {
       return freeze_start_frame_safepoint_stub(f);
@@ -1358,8 +1358,8 @@ public:
     Unimplemented();
 #endif
     if (!Interpreter::contains(f.pc())) {
-      assert (Frame::is_stub(f.cb()), "must be");
-      assert (f.oop_map() != nullptr, "must be");
+      assert(Frame::is_stub(f.cb()), "must be");
+      assert(f.oop_map() != nullptr, "must be");
 
       if (Interpreter::contains(StubF::return_pc(f))) {
         f = sender<StubF>(f); // Safepoint stub in interpreter
@@ -1369,8 +1369,8 @@ public:
   }
 
   NOINLINE freeze_result freeze(frame& f, frame& caller, int callee_argsize, bool callee_interpreted, bool top) {
-    assert (f.unextended_sp() < _bottom_address, ""); // see recurse_freeze_java_frame
-    assert (f.is_interpreted_frame() || ((top && _preempt) == Frame::is_stub(f.cb())), "");
+    assert(f.unextended_sp() < _bottom_address, ""); // see recurse_freeze_java_frame
+    assert(f.is_interpreted_frame() || ((top && _preempt) == Frame::is_stub(f.cb())), "");
 
     if (stack_overflow()) {
       return freeze_exception;
@@ -1387,7 +1387,7 @@ public:
 
       return recurse_freeze_compiled_frame(f, caller, callee_argsize, callee_interpreted);
     } else if (f.is_interpreted_frame()) {
-      assert ((_preempt && top) || !f.interpreter_frame_method()->is_native(), "");
+      assert((_preempt && top) || !f.interpreter_frame_method()->is_native(), "");
       if (Interpreted::is_owning_locks(f)) {
         return freeze_pinned_monitor;
       }
@@ -1406,9 +1406,9 @@ public:
 
   template<typename FKind>
   inline freeze_result recurse_freeze_java_frame(const frame& f, frame& caller, int fsize, int argsize) {
-    assert (FKind::is_instance(f), "");
+    assert(FKind::is_instance(f), "");
 
-    assert (fsize > 0 && argsize >= 0, "");
+    assert(fsize > 0 && argsize >= 0, "");
     _size += fsize;
     NOT_PRODUCT(_frames++;)
 
@@ -1416,7 +1416,7 @@ public:
       return finalize_freeze<FKind>(f, caller, argsize); // recursion end
     } else {
       frame senderf = sender<FKind>(f);
-      assert (FKind::interpreted || senderf.sp() == senderf.unextended_sp(), "");
+      assert(FKind::interpreted || senderf.sp() == senderf.unextended_sp(), "");
       freeze_result result = freeze(senderf, caller, argsize, FKind::interpreted, false); // recursive call
       return result;
     }
@@ -1430,7 +1430,7 @@ public:
       ls.print_cr("fsize: %d argsize: %d", fsize, argsize);
       f.print_on(&ls);
     }
-    assert (caller.is_interpreted_frame() == Interpreter::contains(caller.pc()), "");
+    assert(caller.is_interpreted_frame() == Interpreter::contains(caller.pc()), "");
   }
 
   inline void after_freeze_java_frame(const frame& hf, bool bottom) {
@@ -1449,7 +1449,7 @@ public:
 
   template<typename FKind> // the callee's type
   freeze_result finalize_freeze(const frame& callee, frame& caller, int argsize) {
-    assert (FKind::interpreted || argsize == _cont.argsize(), "argsize: %d cont.argsize: %d", argsize, _cont.argsize());
+    assert(FKind::interpreted || argsize == _cont.argsize(), "argsize: %d cont.argsize: %d", argsize, _cont.argsize());
     log_develop_trace(jvmcont)("bottom: " INTPTR_FORMAT " count %d size: %d argsize: %d",
       p2i(_bottom_address), _frames, _size << LogBytesPerWord, argsize);
 
@@ -1462,7 +1462,7 @@ public:
 
     stackChunkOop chunk = _cont.tail();
 
-    assert (chunk == nullptr || (chunk->max_size() == 0) == chunk->is_empty(), "");
+    assert(chunk == nullptr || (chunk->max_size() == 0) == chunk->is_empty(), "");
 
     _size += ContinuationHelper::frame_metadata; // for top frame's metadata
 
@@ -1486,14 +1486,14 @@ public:
     log_develop_trace(jvmcont)("finalize _size: %d overlap: %d unextended_sp: %d", _size, overlap, unextended_sp);
 
     _size -= overlap;
-    assert (_size >= 0, "");
+    assert(_size >= 0, "");
 
-    assert (chunk == nullptr || chunk->is_empty()
-            || unextended_sp == chunk->to_offset(StackChunkFrameStream<chunk_frames::MIXED>(chunk).unextended_sp()), "");
-    assert (chunk != nullptr || unextended_sp < _size, "");
+    assert(chunk == nullptr || chunk->is_empty()
+           || unextended_sp == chunk->to_offset(StackChunkFrameStream<chunk_frames::MIXED>(chunk).unextended_sp()), "");
+    assert(chunk != nullptr || unextended_sp < _size, "");
 
      // _barriers can be set to true by an allocation in freeze_fast, in which case the chunk is available
-    assert (!_barriers || (unextended_sp >= _size && chunk->is_empty()),
+    assert(!_barriers || (unextended_sp >= _size && chunk->is_empty()),
       "unextended_sp: %d size: %d is_empty: %d", unextended_sp, _size, chunk->is_empty());
 
     DEBUG_ONLY(bool empty_chunk = true);
@@ -1521,7 +1521,7 @@ public:
       int sp = chunk->stack_size() - argsize;
       chunk->set_sp(sp);
       chunk->set_argsize(argsize);
-      assert (chunk->is_empty(), "");
+      assert(chunk->is_empty(), "");
 
       if (_barriers) {
         log_develop_trace(jvmcont)("allocation requires barriers");
@@ -1533,17 +1533,17 @@ public:
         chunk->set_sp(sp);
         chunk->set_argsize(argsize);
         _size += overlap;
-        assert (chunk->max_size() == 0, "");
+        assert(chunk->max_size() == 0, "");
       } DEBUG_ONLY(else empty_chunk = false;)
     }
     chunk->set_has_mixed_frames(true);
 
-    assert (chunk->requires_barriers() == _barriers, "");
-    assert (!_barriers || chunk->is_empty(), "");
+    assert(chunk->requires_barriers() == _barriers, "");
+    assert(!_barriers || chunk->is_empty(), "");
 
-    assert (!chunk->has_bitmap(), "");
-    assert (!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).is_done(), "");
-    assert (!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame().is_empty(), "");
+    assert(!chunk->has_bitmap(), "");
+    assert(!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).is_done(), "");
+    assert(!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame().is_empty(), "");
 
     // We unwind frames after the last safepoint so that the GC will have found the oops in the frames, but before
     // writing into the chunk. This is so that an asynchronous stack walk (not at a safepoint) that suspends us here
@@ -1572,12 +1572,12 @@ public:
       caller.print_on(&ls);
     }
 
-    assert (!empty || Continuation::is_continuation_entry_frame(callee, nullptr), "");
+    assert(!empty || Continuation::is_continuation_entry_frame(callee, nullptr), "");
 
     frame entry = sender<FKind>(callee);
 
-    assert (Continuation::is_return_barrier_entry(entry.pc()) || Continuation::is_continuation_enterSpecial(entry), "");
-    assert (FKind::interpreted || entry.sp() == entry.unextended_sp(), "");
+    assert(Continuation::is_return_barrier_entry(entry.pc()) || Continuation::is_continuation_enterSpecial(entry), "");
+    assert(FKind::interpreted || entry.sp() == entry.unextended_sp(), "");
 #endif
 
     return freeze_ok_bottom;
@@ -1585,15 +1585,15 @@ public:
 
   template <typename FKind>
   void patch(const frame& f, frame& hf, const frame& caller, bool bottom) {
-    assert (FKind::is_instance(f), "");
+    assert(FKind::is_instance(f), "");
 
     if (bottom) {
       address last_pc = caller.pc();
-      assert ((last_pc == nullptr) == _cont.tail()->is_empty(), "");
+      assert((last_pc == nullptr) == _cont.tail()->is_empty(), "");
       FKind::patch_pc(caller, last_pc);
       patch_pd<FKind, true>(hf, caller);
     } else {
-      assert (!caller.is_empty(), "");
+      assert(!caller.is_empty(), "");
       patch_pd<FKind, false>(hf, caller);
     }
     if (FKind::interpreted) {
@@ -1603,11 +1603,11 @@ public:
 
 #ifdef ASSERT
     if (!FKind::interpreted && !FKind::stub) {
-      assert (hf.get_cb()->is_compiled(), "");
+      assert(hf.get_cb()->is_compiled(), "");
       if (f.is_deoptimized_frame()) { // TODO DEOPT: long term solution: unroll on freeze and patch pc
         log_develop_trace(jvmcont)("Freezing deoptimized frame");
-        assert (f.cb()->as_compiled_method()->is_deopt_pc(f.raw_pc()), "");
-        assert (f.cb()->as_compiled_method()->is_deopt_pc(Frame::real_pc(f)), "");
+        assert(f.cb()->as_compiled_method()->is_deopt_pc(f.raw_pc()), "");
+        assert(f.cb()->as_compiled_method()->is_deopt_pc(Frame::real_pc(f)), "");
       }
     }
 #endif
@@ -1616,7 +1616,7 @@ public:
   NOINLINE freeze_result recurse_freeze_interpreted_frame(frame& f, frame& caller, int callee_argsize, bool callee_interpreted) {
 #if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
     { // TODO PD
-      assert ((f.at(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
+      assert((f.at(frame::interpreter_frame_last_sp_offset) != 0) || (f.unextended_sp() == f.sp()), "");
       intptr_t* real_unextended_sp = (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset);
       if (real_unextended_sp != nullptr) f.set_unextended_sp(real_unextended_sp); // can be null at a safepoint
     }
@@ -1627,7 +1627,7 @@ public:
     intptr_t* const vsp = Interpreted::frame_top(f, callee_argsize, callee_interpreted);
     const int argsize = Interpreted::stack_argsize(f);
     const int locals = f.interpreter_frame_method()->max_locals();
-    assert (Interpreted::frame_bottom(f) >= f.fp() + ContinuationHelper::frame_metadata + locals, "");// = on x86
+    assert(Interpreted::frame_bottom(f) >= f.fp() + ContinuationHelper::frame_metadata + locals, "");// = on x86
     const int fsize = f.fp() + ContinuationHelper::frame_metadata + locals - vsp;
 
 #ifdef ASSERT
@@ -1635,7 +1635,7 @@ public:
     ResourceMark rm;
     InterpreterOopMap mask;
     f.interpreted_frame_oop_map(&mask);
-    assert (vsp <= Interpreted::frame_top(f, &mask), "vsp: " INTPTR_FORMAT " Interpreted::frame_top: " INTPTR_FORMAT,
+    assert(vsp <= Interpreted::frame_top(f, &mask), "vsp: " INTPTR_FORMAT " Interpreted::frame_top: " INTPTR_FORMAT,
       p2i(vsp), p2i(Interpreted::frame_top(f, &mask)));
   }
 #endif
@@ -1645,7 +1645,7 @@ public:
     log_develop_trace(jvmcont)("recurse_freeze_interpreted_frame %s _size: %d fsize: %d argsize: %d",
       frame_method->name_and_sig_as_C_string(), _size, fsize, argsize);
     // we'd rather not yield inside methods annotated with @JvmtiMountTransition
-    assert (!Frame::frame_method(f)->jvmti_mount_transition(), "");
+    assert(!Frame::frame_method(f)->jvmti_mount_transition(), "");
 
     freeze_result result = recurse_freeze_java_frame<Interpreted>(f, caller, fsize, argsize);
     if (UNLIKELY(result > freeze_ok_bottom)) {
@@ -1659,13 +1659,13 @@ public:
     frame hf = new_hframe<Interpreted>(f, caller);
 
     intptr_t* hsp = Interpreted::frame_top(hf, callee_argsize, callee_interpreted);
-    assert (Interpreted::frame_bottom(hf) == hsp + fsize, "");
+    assert(Interpreted::frame_bottom(hf) == hsp + fsize, "");
 
     // on AArch64 we add padding between the locals and the rest of the frame to keep the fp 16-byte-aligned
     copy_to_chunk<copy_alignment::WORD_ALIGNED>(Interpreted::frame_bottom(f) - locals,
                                              Interpreted::frame_bottom(hf) - locals, locals); // copy locals
     copy_to_chunk<copy_alignment::WORD_ALIGNED>(vsp, hsp, fsize - locals); // copy rest
-    assert (!bottom || !caller.is_interpreted_frame() || (hsp + fsize) == (caller.unextended_sp() + argsize), "");
+    assert(!bottom || !caller.is_interpreted_frame() || (hsp + fsize) == (caller.unextended_sp() + argsize), "");
 
     relativize_interpreted_frame_metadata(f, hf);
 
@@ -1689,7 +1689,7 @@ public:
     log_develop_trace(jvmcont)("recurse_freeze_compiled_frame %s _size: %d fsize: %d argsize: %d",
       Frame::frame_method(f) != nullptr ? Frame::frame_method(f)->name_and_sig_as_C_string():"", _size,fsize,argsize);
     // we'd rather not yield inside methods annotated with @JvmtiMountTransition
-    assert (!Frame::frame_method(f)->jvmti_mount_transition(), "");
+    assert(!Frame::frame_method(f)->jvmti_mount_transition(), "");
 
     freeze_result result = recurse_freeze_java_frame<Compiled>(f, caller, fsize, argsize);
     if (UNLIKELY(result > freeze_ok_bottom)) {
@@ -1705,7 +1705,7 @@ public:
     intptr_t* hsp = Compiled::frame_top(hf, callee_argsize, callee_interpreted);
 
     copy_to_chunk<copy_alignment::WORD_ALIGNED>(vsp, hsp, fsize);
-    assert (!bottom || !caller.is_compiled_frame() || (hsp + fsize) == (caller.unextended_sp() + argsize), "");
+    assert(!bottom || !caller.is_compiled_frame() || (hsp + fsize) == (caller.unextended_sp() + argsize), "");
 
     if (caller.is_interpreted_frame()) {
       _align_size += ContinuationHelper::align_wiggle; // See Thaw::align
@@ -1736,8 +1736,8 @@ public:
     ContinuationHelper::update_register_map<StubF>(f, &map);
     f.oop_map()->update_register_map(&f, &map); // we have callee-save registers in this case
     frame senderf = sender<StubF>(f);
-    assert (senderf.unextended_sp() < _bottom_address - 1, "");
-    assert (senderf.is_compiled_frame(), "");
+    assert(senderf.unextended_sp() < _bottom_address - 1, "");
+    assert(senderf.is_compiled_frame(), "");
 
     if (UNLIKELY(senderf.oop_map() == nullptr)) {
       // native frame
@@ -1749,8 +1749,8 @@ public:
 
     freeze_result result = recurse_freeze_compiled_frame(senderf, caller, 0, 0); // This might be deoptimized
     if (UNLIKELY(result > freeze_ok_bottom)) return result;
-    assert (result != freeze_ok_bottom, "");
-    assert (!caller.is_interpreted_frame(), "");
+    assert(result != freeze_ok_bottom, "");
+    assert(!caller.is_interpreted_frame(), "");
 
     DEBUG_ONLY(before_freeze_java_frame(f, caller, fsize, 0, false);)
     frame hf = new_hframe<StubF>(f, caller);
@@ -1764,7 +1764,7 @@ public:
 
   NOINLINE void finish_freeze(const frame& f, const frame& top) {
     stackChunkOop chunk = _cont.tail();
-    assert (chunk->to_offset(top.sp()) <= chunk->sp(), "");
+    assert(chunk->to_offset(top.sp()) <= chunk->sp(), "");
 
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
@@ -1774,7 +1774,7 @@ public:
     }
 
     set_top_frame_metadata_pd(top);
-    assert (top.pc() == Frame::real_pc(top), "");
+    assert(top.pc() == Frame::real_pc(top), "");
 
     OrderAccess::storestore();
     chunk->set_sp(chunk->to_offset(top.sp()));
@@ -1801,7 +1801,7 @@ public:
 
   inline bool stack_overflow() { // detect stack overflow in recursive native code
     JavaThread* t = !_preempt ? _thread : JavaThread::current();
-    assert (t == JavaThread::current(), "");
+    assert(t == JavaThread::current(), "");
     if ((address)&t < t->stack_overflow_state()->stack_overflow_limit()) {
       Exceptions::_throw_msg(t, __FILE__, __LINE__, vmSymbols::java_lang_StackOverflowError(), "Stack overflow while freezing");
       return true;
@@ -1843,9 +1843,9 @@ public:
       _barriers = ConfigT::requires_barriers(chunk);
     }
 
-    assert (chunk->stack_size() == (int)stack_size, "");
-    assert (chunk->size() >= stack_size, "chunk->size(): %zu size: %zu", chunk->size(), stack_size);
-    assert ((intptr_t)chunk->start_address() % 8 == 0, "");
+    assert(chunk->stack_size() == (int)stack_size, "");
+    assert(chunk->size() >= stack_size, "chunk->size(): %zu size: %zu", chunk->size(), stack_size);
+    assert((intptr_t)chunk->start_address() % 8 == 0, "");
 
     // TODO PERF: maybe just memset 0, and only set non-zero fields.
     chunk->clear_flags();
@@ -1854,21 +1854,21 @@ public:
     // chunk->set_pc(nullptr);
     // chunk->set_argsize(0);
 
-    assert (chunk->flags() == 0, "");
-    assert (chunk->is_gc_mode() == false, "");
-    assert (chunk->max_size() == 0, "");
+    assert(chunk->flags() == 0, "");
+    assert(chunk->is_gc_mode() == false, "");
+    assert(chunk->max_size() == 0, "");
 
     chunk->set_mark(chunk->mark().set_age(15)); // Promote young chunks quickly
 
     stackChunkOop chunk0 = _cont.tail();
     if (chunk0 != (oop)nullptr && chunk0->is_empty()) {
       chunk0 = chunk0->parent();
-      assert (chunk0 == (oop)nullptr || !chunk0->is_empty(), "");
+      assert(chunk0 == (oop)nullptr || !chunk0->is_empty(), "");
     }
     // fields are uninitialized
     chunk->set_parent_raw<typename ConfigT::OopT>(chunk0);
     chunk->set_cont_raw<typename ConfigT::OopT>(_cont.mirror());
-    assert (chunk->parent() == (oop)nullptr || chunk->parent()->is_stackChunk(), "");
+    assert(chunk->parent() == (oop)nullptr || chunk->parent()->is_stackChunk(), "");
 
     if (start != nullptr) {
       assert(!ConfigT::requires_barriers(chunk), "Unfamiliar GC requires barriers on TLAB allocation");
@@ -1947,12 +1947,12 @@ static bool interpreted_native_or_deoptimized_on_stack(JavaThread* thread) {
 static inline bool can_freeze_fast(JavaThread* thread) {
   // There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c adapter or called Deoptimization::unpack_frames
   // Calls from native frames also go through the interpreter (see JavaCalls::call_helper)
-  assert (!thread->cont_fastpath()
-              || (thread->cont_fastpath_thread_state() && !interpreted_native_or_deoptimized_on_stack(thread)), "");
+  assert(!thread->cont_fastpath()
+         || (thread->cont_fastpath_thread_state() && !interpreted_native_or_deoptimized_on_stack(thread)), "");
 
   // We also clear thread->cont_fastpath on deoptimization (notify_deopt) and when we thaw interpreted frames
   bool fast = thread->cont_fastpath() && UseContinuationFastPath;
-  assert (!fast || monitors_on_stack(thread) == (thread->held_monitor_count() > 0), "");
+  assert(!fast || monitors_on_stack(thread) == (thread->held_monitor_count() > 0), "");
   fast = fast && thread->held_monitor_count() == 0;
   return fast;
 }
@@ -1964,8 +1964,8 @@ static int early_return(int res, JavaThread* thread) {
 }
 
 static inline int freeze_epilog(JavaThread* thread, ContMirror& cont) {
-  assert (VERIFY_CONTINUATION(cont.mirror()), "");
-  assert (!cont.is_empty(), "");
+  assert(VERIFY_CONTINUATION(cont.mirror()), "");
+  assert(!cont.is_empty(), "");
 
   thread->set_cont_yield(false);
   log_develop_debug(jvmcont)("=== End of freeze cont ### #" INTPTR_FORMAT, cont.hash());
@@ -1975,7 +1975,7 @@ static inline int freeze_epilog(JavaThread* thread, ContMirror& cont) {
 
 static int freeze_epilog(JavaThread* thread, ContMirror& cont, freeze_result res) {
   if (UNLIKELY(res != freeze_ok)) {
-    assert (VERIFY_CONTINUATION(cont.mirror()), "");
+    assert(VERIFY_CONTINUATION(cont.mirror()), "");
     return early_return(res, thread);
   }
 
@@ -1985,11 +1985,11 @@ static int freeze_epilog(JavaThread* thread, ContMirror& cont, freeze_result res
 
 template<typename ConfigT, bool preempt>
 static inline int freeze0(JavaThread* current, intptr_t* const sp) {
-  assert (!current->cont_yield(), "");
-  assert (!current->has_pending_exception(), ""); // if (current->has_pending_exception()) return early_return(freeze_exception, current, fi);
-  assert (current->deferred_updates() == nullptr || current->deferred_updates()->count() == 0, "");
-  assert (!preempt || current->thread_state() == _thread_in_vm || current->thread_state() == _thread_blocked,
-          "thread_state: %d %s", current->thread_state(), current->thread_state_name());
+  assert(!current->cont_yield(), "");
+  assert(!current->has_pending_exception(), ""); // if (current->has_pending_exception()) return early_return(freeze_exception, current, fi);
+  assert(current->deferred_updates() == nullptr || current->deferred_updates()->count() == 0, "");
+  assert(!preempt || current->thread_state() == _thread_in_vm || current->thread_state() == _thread_blocked,
+         "thread_state: %d %s", current->thread_state(), current->thread_state_name());
 
   LogTarget(Trace, jvmcont) lt;
 #ifdef ASSERT
@@ -2007,23 +2007,23 @@ static inline int freeze0(JavaThread* current, intptr_t* const sp) {
   ContinuationEntry* entry = current->last_continuation();
 
   oop oopCont = ContinuationHelper::get_continuation(current);
-  assert (oopCont == current->last_continuation()->cont_oop(), "");
-  assert (ContinuationEntry::assert_entry_frame_laid_out(current), "");
+  assert(oopCont == current->last_continuation()->cont_oop(), "");
+  assert(ContinuationEntry::assert_entry_frame_laid_out(current), "");
 
-  assert (VERIFY_CONTINUATION(oopCont), "");
+  assert(VERIFY_CONTINUATION(oopCont), "");
   ContMirror cont(current, oopCont);
   log_develop_debug(jvmcont)("FREEZE #" INTPTR_FORMAT " " INTPTR_FORMAT, cont.hash(), p2i((oopDesc*)oopCont));
 
-  assert (entry->is_virtual_thread() == (entry->scope() == java_lang_VirtualThread::vthread_scope()), "");
+  assert(entry->is_virtual_thread() == (entry->scope() == java_lang_VirtualThread::vthread_scope()), "");
 
   if (jdk_internal_vm_Continuation::critical_section(oopCont) > 0) {
     log_develop_debug(jvmcont)("PINNED due to critical section");
-    assert (VERIFY_CONTINUATION(cont.mirror()), "");
+    assert(VERIFY_CONTINUATION(cont.mirror()), "");
     return early_return(freeze_pinned_cs, current);
   }
 
   bool fast = can_freeze_fast(current);
-  assert (!fast || current->held_monitor_count() == 0, "");
+  assert(!fast || current->held_monitor_count() == 0, "");
 
   // no need to templatize on preempt, as it's currently only used on the slow path
   Freeze<ConfigT> fr(current, cont, preempt);
@@ -2037,7 +2037,7 @@ static inline int freeze0(JavaThread* current, intptr_t* const sp) {
 
   if (fast && fr.is_chunk_available(sp)) {
     freeze_result res = fr.template try_freeze_fast<true>(sp);
-    assert (res == freeze_ok, "");
+    assert(res == freeze_ok, "");
     CONT_JFR_ONLY(cont.post_jfr_event(&event, current);)
     freeze_epilog(current, cont);
     StackWatermarkSet::after_unwind(current);
@@ -2082,8 +2082,8 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
     Unimplemented();
 #endif
     if (!Interpreter::contains(f.pc())) {
-      assert (Frame::is_stub(f.cb()), "must be");
-      assert (f.oop_map() != nullptr, "must be");
+      assert(Frame::is_stub(f.cb()), "must be");
+      assert(f.oop_map() != nullptr, "must be");
       f.oop_map()->update_register_map(&f, &map); // we have callee-save registers in this case
     }
   }
@@ -2113,7 +2113,7 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
 }
 
 static bool is_safe_frame_to_preempt(JavaThread* thread) {
-  assert (thread->has_last_Java_frame(), "");
+  assert(thread->has_last_Java_frame(), "");
   vframeStream st(thread);
   st.dont_walk_cont();
 
@@ -2140,7 +2140,7 @@ static bool is_safe_pc_to_preempt(address pc) {
       if (codelet->bytecode() >= 0 && Bytecodes::is_return(codelet->bytecode())) {
         log_trace(jvmcont, preempt)("is_safe_to_preempt: safe bytecode: %s",
                                     Bytecodes::name(codelet->bytecode()));
-        assert (codelet->kind() == InterpreterCodelet::codelet_bytecode, "");
+        assert(codelet->kind() == InterpreterCodelet::codelet_bytecode, "");
         return true;
       } else if (codelet->kind() == InterpreterCodelet::codelet_safepoint_entry) {
         log_trace(jvmcont, preempt)("is_safe_to_preempt: safepoint entry: %s", codelet->description());
@@ -2194,21 +2194,21 @@ static bool is_safe_to_preempt(JavaThread* thread) {
 static inline int prepare_thaw0(JavaThread* thread, bool return_barrier) {
   log_develop_trace(jvmcont)("~~~~ prepare_thaw return_barrier: %d", return_barrier);
 
-  assert (thread == JavaThread::current(), "");
+  assert(thread == JavaThread::current(), "");
 
   oop cont = thread->last_continuation()->cont_oop();
-  assert (cont == ContinuationHelper::get_continuation(thread), "");
-  assert (VERIFY_CONTINUATION(cont), "");
+  assert(cont == ContinuationHelper::get_continuation(thread), "");
+  assert(VERIFY_CONTINUATION(cont), "");
 
   stackChunkOop chunk = jdk_internal_vm_Continuation::tail(cont);
-  assert (chunk != nullptr, "");
+  assert(chunk != nullptr, "");
   if (UNLIKELY(chunk->is_empty())) {
     chunk = chunk->parent();
     jdk_internal_vm_Continuation::set_tail(cont, chunk);
   }
-  assert (chunk != nullptr, "");
-  assert (!chunk->is_empty(), "");
-  assert (VERIFY_STACK_CHUNK(chunk), "");
+  assert(chunk != nullptr, "");
+  assert(!chunk->is_empty(), "");
+  assert(VERIFY_STACK_CHUNK(chunk), "");
 
   int size = chunk->max_size();
   guarantee (size > 0, "");
@@ -2275,14 +2275,14 @@ public:
   }
 
   intptr_t* thaw(thaw_kind kind) {
-    assert (!Interpreter::contains(_cont.entryPC()), "");
+    assert(!Interpreter::contains(_cont.entryPC()), "");
 
-    assert (VERIFY_CONTINUATION(_cont.mirror()), "");
-    assert (!jdk_internal_vm_Continuation::done(_cont.mirror()), "");
-    assert (!_cont.is_empty(), "");
+    assert(VERIFY_CONTINUATION(_cont.mirror()), "");
+    assert(!jdk_internal_vm_Continuation::done(_cont.mirror()), "");
+    assert(!_cont.is_empty(), "");
 
     stackChunkOop chunk = _cont.tail();
-    assert (chunk != nullptr && !chunk->is_empty(), ""); // guaranteed by prepare_thaw
+    assert(chunk != nullptr && !chunk->is_empty(), ""); // guaranteed by prepare_thaw
 
     _barriers = ConfigT::requires_barriers(chunk);
     return (LIKELY(can_thaw_fast(chunk))) ? thaw_fast(chunk)
@@ -2290,13 +2290,13 @@ public:
   }
 
   NOINLINE intptr_t* thaw_fast(stackChunkOop chunk) {
-    assert (chunk != (oop) nullptr, "");
-    assert (chunk == _cont.tail(), "");
-    assert (!chunk->is_empty(), "");
-    assert (!chunk->has_mixed_frames(), "");
-    assert (!chunk->requires_barriers(), "");
-    assert (!chunk->has_bitmap(), "");
-    assert (!_thread->is_interp_only_mode(), "");
+    assert(chunk != (oop) nullptr, "");
+    assert(chunk == _cont.tail(), "");
+    assert(!chunk->is_empty(), "");
+    assert(!chunk->has_mixed_frames(), "");
+    assert(!chunk->requires_barriers(), "");
+    assert(!chunk->has_bitmap(), "");
+    assert(!_thread->is_interp_only_mode(), "");
 
     // TODO: explain why we're not setting the tail
 
@@ -2336,12 +2336,12 @@ public:
       partial = true;
 
       StackChunkFrameStream<chunk_frames::COMPILED_ONLY> f(chunk);
-      assert (chunk_sp == f.sp() && chunk_sp == f.unextended_sp(), "");
+      assert(chunk_sp == f.sp() && chunk_sp == f.unextended_sp(), "");
       size = f.cb()->frame_size();
       argsize = f.stack_argsize();
       f.next(SmallRegisterMap::instance);
       empty = f.is_done();
-      assert (!empty || argsize == chunk->argsize(), "");
+      assert(!empty || argsize == chunk->argsize(), "");
 
       if (empty) {
         chunk->set_sp(chunk->stack_size());
@@ -2355,7 +2355,7 @@ public:
         address top_pc = *(address*)(chunk_sp + size - frame::sender_sp_ret_address_offset());
         chunk->set_pc(top_pc);
       }
-      assert (empty == chunk->is_empty(), "");
+      assert(empty == chunk->is_empty(), "");
       size += argsize;
     }
 
@@ -2368,25 +2368,25 @@ public:
     intptr_t* bottom_sp = ContinuationHelper::frame_align_pointer(stack_sp - argsize);
 
     stack_sp -= size;
-    assert (argsize != 0 || stack_sp == ContinuationHelper::frame_align_pointer(stack_sp), "");
+    assert(argsize != 0 || stack_sp == ContinuationHelper::frame_align_pointer(stack_sp), "");
     stack_sp = ContinuationHelper::frame_align_pointer(stack_sp);
 
     intptr_t* from = chunk_sp - ContinuationHelper::frame_metadata;
     intptr_t* to   = stack_sp - ContinuationHelper::frame_metadata;
     copy_from_chunk(from, to, size + ContinuationHelper::frame_metadata);
-    assert (_cont.entrySP() - 1 <= to + size + ContinuationHelper::frame_metadata
+    assert(_cont.entrySP() - 1 <= to + size + ContinuationHelper::frame_metadata
               && to + size + ContinuationHelper::frame_metadata <= _cont.entrySP(), "");
-    assert (argsize != 0 || to + size + ContinuationHelper::frame_metadata == _cont.entrySP(), "");
+    assert(argsize != 0 || to + size + ContinuationHelper::frame_metadata == _cont.entrySP(), "");
 
-    assert (!is_last || argsize == 0, "");
+    assert(!is_last || argsize == 0, "");
     _cont.set_argsize(argsize);
     log_develop_trace(jvmcont)("setting entry argsize: %d", _cont.argsize());
     patch_chunk(bottom_sp, is_last);
 
     DEBUG_ONLY(address pc = *(address*)(bottom_sp - frame::sender_sp_ret_address_offset());)
-    assert (is_last ? CodeCache::find_blob(pc)->as_compiled_method()->method()->is_continuation_enter_intrinsic()
+    assert(is_last ? CodeCache::find_blob(pc)->as_compiled_method()->method()->is_continuation_enter_intrinsic()
                     : pc == StubRoutines::cont_returnBarrier(), "is_last: %d", is_last);
-    assert (is_last == _cont.is_empty(), "");
+    assert(is_last == _cont.is_empty(), "");
     assert(_cont.chunk_invariant(tty), "");
 
   #if CONT_JFR
@@ -2417,7 +2417,7 @@ public:
 
   template <copy_alignment aligned = copy_alignment::DWORD_ALIGNED>
   void copy_from_chunk(intptr_t* from, intptr_t* to, int size) {
-    assert (to + size <= _cont.entrySP(), "");
+    assert(to + size <= _cont.entrySP(), "");
     _cont.tail()->template copy_from_chunk_to_stack<aligned>(from, to, size);
     CONT_JFR_ONLY(_cont.record_size_copied(size);)
   }
@@ -2432,9 +2432,9 @@ public:
   }
 
   NOINLINE intptr_t* thaw_slow(stackChunkOop chunk, bool return_barrier) {
-    assert (!_cont.is_empty(), "");
-    assert (chunk != nullptr, "");
-    assert (!chunk->is_empty(), "");
+    assert(!_cont.is_empty(), "");
+    assert(chunk != nullptr, "");
+    assert(!chunk->is_empty(), "");
 
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
@@ -2487,13 +2487,13 @@ public:
         ls.print_cr("Jumping to frame (thaw): [" JLONG_FORMAT "]", java_tid(_thread));
         f.print_on(&ls);
       }
-      assert (f.is_interpreted_frame() || f.is_compiled_frame() || f.is_safepoint_blob_frame(), "");
+      assert(f.is_interpreted_frame() || f.is_compiled_frame() || f.is_safepoint_blob_frame(), "");
     }
   #endif
 
     if (last_interpreted && _cont.is_preempted()) {
-      assert (f.pc() == *(address*)(sp - frame::sender_sp_ret_address_offset()), "");
-      assert (Interpreter::contains(f.pc()), "");
+      assert(f.pc() == *(address*)(sp - frame::sender_sp_ret_address_offset()), "");
+      assert(Interpreter::contains(f.pc()), "");
       sp = push_interpreter_return_frame(sp);
     }
 
@@ -2503,10 +2503,10 @@ public:
   void thaw(const frame& hf, frame& caller, int num_frames, bool top) {
     log_develop_debug(jvmcont)("thaw num_frames: %d", num_frames);
     assert(!_cont.is_empty(), "no more frames");
-    assert (num_frames > 0 && !hf.is_empty(), "");
+    assert(num_frames > 0 && !hf.is_empty(), "");
 
     if (top && hf.is_safepoint_blob_frame()) {
-      assert (Frame::is_stub(hf.cb()), "cb: %s", hf.cb()->name());
+      assert(Frame::is_stub(hf.cb()), "cb: %s", hf.cb()->name());
       recurse_thaw_stub_frame(hf, caller, num_frames);
     } else if (!hf.is_interpreted_frame()) {
       recurse_thaw_compiled_frame(hf, caller, num_frames, false);
@@ -2517,14 +2517,14 @@ public:
 
   template<typename FKind>
   bool recurse_thaw_java_frame(frame& caller, int num_frames) {
-    assert (num_frames > 0, "");
+    assert(num_frames > 0, "");
 
     DEBUG_ONLY(_frames++;)
 
     int argsize = _stream.stack_argsize();
 
     _stream.next(SmallRegisterMap::instance);
-    assert (_stream.to_frame().is_empty() == _stream.is_done(), "");
+    assert(_stream.to_frame().is_empty() == _stream.is_done(), "");
 
     // we never leave a compiled caller of an interpreted frame as the top frame in the chunk
     // as it makes detecting that situation and adjusting unextended_sp tricky
@@ -2548,7 +2548,7 @@ public:
 
     OrderAccess::storestore();
     if (!_stream.is_done()) {
-      assert (_stream.sp() >= chunk->sp_address(), "");
+      assert(_stream.sp() >= chunk->sp_address(), "");
       chunk->set_sp(chunk->to_offset(_stream.sp()));
       chunk->set_pc(_stream.pc());
     } else {
@@ -2564,9 +2564,9 @@ public:
     _cont.set_argsize(FKind::interpreted ? 0 : argsize);
     entry = new_entry_frame();
 
-    assert (entry.sp() == _cont.entrySP(), "");
-    assert (Continuation::is_continuation_enterSpecial(entry), "");
-    assert (_cont.is_entry_frame(entry), "");
+    assert(entry.sp() == _cont.entrySP(), "");
+    assert(Continuation::is_continuation_enterSpecial(entry), "");
+    assert(_cont.is_entry_frame(entry), "");
   }
 
   inline void before_thaw_java_frame(const frame& hf, const frame& caller, bool bottom, int num_frame) {
@@ -2577,7 +2577,7 @@ public:
       assert(hf.is_interpreted_heap_frame(), "should be");
       hf.print_on(&ls);
     }
-    assert (bottom == _cont.is_entry_frame(caller), "bottom: %d is_entry_frame: %d", bottom, _cont.is_entry_frame(hf));
+    assert(bottom == _cont.is_entry_frame(caller), "bottom: %d is_entry_frame: %d", bottom, _cont.is_entry_frame(hf));
   }
 
   inline void after_thaw_java_frame(const frame& f, bool bottom) {
@@ -2601,8 +2601,8 @@ public:
       Interpreted::patch_sender_sp(f, caller.unextended_sp());
     }
 
-    assert (!bottom || !_cont.is_empty() || Continuation::is_continuation_entry_frame(f, nullptr), "");
-    assert (!bottom || (_cont.is_empty() != Continuation::is_cont_barrier_frame(f)), "");
+    assert(!bottom || !_cont.is_empty() || Continuation::is_continuation_entry_frame(f, nullptr), "");
+    assert(!bottom || (_cont.is_empty() != Continuation::is_cont_barrier_frame(f)), "");
   }
 
   void clear_bitmap_bits(intptr_t* start, int range) {
@@ -2614,7 +2614,7 @@ public:
   }
 
   NOINLINE void recurse_thaw_interpreted_frame(const frame& hf, frame& caller, int num_frames) {
-    assert (hf.is_interpreted_frame(), "");
+    assert(hf.is_interpreted_frame(), "");
 
     if (UNLIKELY(_barriers)) {
       InstanceStackChunkKlass::do_barriers<InstanceStackChunkKlass::barrier_type::STORE>(_cont.tail(), _stream, SmallRegisterMap::instance);
@@ -2633,10 +2633,10 @@ public:
     assert(hf.is_interpreted_heap_frame(), "should be");
     const int fsize = Interpreted::frame_bottom(hf) - hsp;
 
-    assert (!bottom || vsp + fsize >= _cont.entrySP() - 2, "");
-    assert (!bottom || vsp + fsize <= _cont.entrySP(), "");
+    assert(!bottom || vsp + fsize >= _cont.entrySP() - 2, "");
+    assert(!bottom || vsp + fsize <= _cont.entrySP(), "");
 
-    assert (Interpreted::frame_bottom(f) == vsp + fsize, "");
+    assert(Interpreted::frame_bottom(f) == vsp + fsize, "");
 
     // on AArch64 we add padding between the locals and the rest of the frame to keep the fp 16-byte-aligned
     const int locals = hf.interpreter_frame_method()->max_locals();
@@ -2679,7 +2679,7 @@ public:
   }
 
   void recurse_thaw_compiled_frame(const frame& hf, frame& caller, int num_frames, bool stub_caller) {
-    assert (!hf.is_interpreted_frame(), "");
+    assert(!hf.is_interpreted_frame(), "");
     assert(_cont.is_preempted() || !stub_caller, "stub caller not at preemption");
 
     if (!stub_caller && UNLIKELY(_barriers)) { // recurse_thaw_stub_frame already invoked our barriers with a full regmap
@@ -2690,7 +2690,7 @@ public:
 
     DEBUG_ONLY(before_thaw_java_frame(hf, caller, bottom, num_frames);)
 
-    assert (caller.sp() == caller.unextended_sp(), "");
+    assert(caller.sp() == caller.unextended_sp(), "");
 
     if ((!bottom && caller.is_interpreted_frame()) || (bottom && Interpreter::contains(_cont.tail()->pc()))) {
       _align_size += ContinuationHelper::align_wiggle; // we add one whether or not we've aligned because we add it in freeze_interpreted_frame
@@ -2703,14 +2703,14 @@ public:
     int fsize = Compiled::size(hf);
     const int added_argsize = (bottom || caller.is_interpreted_frame()) ? hf.compiled_frame_stack_argsize() : 0;
     fsize += added_argsize;
-    assert (fsize <= (int)(caller.unextended_sp() - f.unextended_sp()), "");
+    assert(fsize <= (int)(caller.unextended_sp() - f.unextended_sp()), "");
 
     intptr_t* from = hsp - ContinuationHelper::frame_metadata;
     intptr_t* to   = vsp - ContinuationHelper::frame_metadata;
     int sz = fsize + ContinuationHelper::frame_metadata;
 
-    assert (!bottom || _cont.entrySP() - 1 <= to + sz && to + sz <= _cont.entrySP(), "");
-    assert (!bottom || hf.compiled_frame_stack_argsize() != 0 || to + sz && to + sz == _cont.entrySP(), "");
+    assert(!bottom || _cont.entrySP() - 1 <= to + sz && to + sz <= _cont.entrySP(), "");
+    assert(!bottom || hf.compiled_frame_stack_argsize() != 0 || to + sz && to + sz == _cont.entrySP(), "");
 
     copy_from_chunk(from, to, sz);
 
@@ -2732,7 +2732,7 @@ public:
       DEBUG_ONLY(Frame::patch_pc(f, nullptr));
 
       f.deoptimize(nullptr); // we're assuming there are no monitors; this doesn't revoke biased locks
-      assert (f.is_deoptimized_frame() && Frame::is_deopt_return(f.raw_pc(), f), "");
+      assert(f.is_deoptimized_frame() && Frame::is_deopt_return(f.raw_pc(), f), "");
       maybe_set_fastpath(f.sp());
     }
 
@@ -2754,11 +2754,11 @@ public:
       RegisterMap map(nullptr, true, false, false);
       map.set_include_argument_oops(false);
       _stream.next(&map);
-      assert (!_stream.is_done(), "");
+      assert(!_stream.is_done(), "");
       if (UNLIKELY(_barriers)) { // we're now doing this on the stub's caller
         InstanceStackChunkKlass::do_barriers<InstanceStackChunkKlass::barrier_type::STORE>(_cont.tail(), _stream, &map);
       }
-      assert (!_stream.is_done(), "");
+      assert(!_stream.is_done(), "");
     }
 
     recurse_thaw_compiled_frame(_stream.to_frame(), caller, num_frames, true); // this could be deoptimized
@@ -2766,8 +2766,8 @@ public:
     DEBUG_ONLY(before_thaw_java_frame(hf, caller, false, num_frames);)
 
     assert(Frame::is_stub(hf.cb()), "");
-    assert (caller.sp() == caller.unextended_sp(), "");
-    assert (!caller.is_interpreted_frame(), "");
+    assert(caller.sp() == caller.unextended_sp(), "");
+    assert(!caller.is_interpreted_frame(), "");
 
     int fsize = StubF::size(hf);
 
@@ -2800,20 +2800,20 @@ public:
         chunk->set_has_mixed_frames(false);
       }
       chunk->set_max_size(0);
-      assert (chunk->argsize() == 0, "");
+      assert(chunk->argsize() == 0, "");
     } else {
       chunk->set_max_size(chunk->max_size() - _align_size);
     }
-    assert (chunk->is_empty() == (chunk->max_size() == 0), "");
+    assert(chunk->is_empty() == (chunk->max_size() == 0), "");
 
     if ((intptr_t)f.sp() % 16 != 0) {
-      assert (f.is_interpreted_frame(), "");
+      assert(f.is_interpreted_frame(), "");
       f.set_sp(f.sp() - 1);
     }
     push_return_frame(f);
     InstanceStackChunkKlass::fix_thawed_frame(chunk, f, SmallRegisterMap::instance); // can only fix caller after push_return_frame (due to callee saved regs)
 
-    assert (_cont.is_empty() == _cont.last_frame().is_empty(), "");
+    assert(_cont.is_empty() == _cont.last_frame().is_empty(), "");
 
     log_develop_trace(jvmcont)("thawed %d frames", _frames);
 
@@ -2827,8 +2827,8 @@ public:
   }
 
   void push_return_frame(frame& f) { // see generate_cont_thaw
-    assert (!f.is_compiled_frame() || f.is_deoptimized_frame() == f.cb()->as_compiled_method()->is_deopt_pc(f.raw_pc()), "");
-    assert (!f.is_compiled_frame() || f.is_deoptimized_frame() == (f.pc() != f.raw_pc()), "");
+    assert(!f.is_compiled_frame() || f.is_deoptimized_frame() == f.cb()->as_compiled_method()->is_deopt_pc(f.raw_pc()), "");
+    assert(!f.is_compiled_frame() || f.is_deoptimized_frame() == (f.pc() != f.raw_pc()), "");
 
     LogTarget(Trace, jvmcont) lt;
     if (lt.develop_is_enabled()) {
@@ -2869,16 +2869,16 @@ static inline intptr_t* thaw0(JavaThread* thread, const thaw_kind kind) {
   }
   log_develop_trace(jvmcont)("~~~~ thaw kind: %d sp: " INTPTR_FORMAT, kind, p2i(thread->last_continuation()->entry_sp()));
 
-  assert (thread == JavaThread::current(), "");
+  assert(thread == JavaThread::current(), "");
 
   ContinuationEntry* entry = thread->last_continuation();
   oop oopCont = entry->cont_oop();
 
-  assert (!jdk_internal_vm_Continuation::done(oopCont), "");
-  assert (oopCont == ContinuationHelper::get_continuation(thread), "");
-  assert (VERIFY_CONTINUATION(oopCont), "");
+  assert(!jdk_internal_vm_Continuation::done(oopCont), "");
+  assert(oopCont == ContinuationHelper::get_continuation(thread), "");
+  assert(VERIFY_CONTINUATION(oopCont), "");
 
-  assert (entry->is_virtual_thread() == (entry->scope() == java_lang_VirtualThread::vthread_scope()), "");
+  assert(entry->is_virtual_thread() == (entry->scope() == java_lang_VirtualThread::vthread_scope()), "");
 
   ContMirror cont(thread, oopCont);
   log_develop_debug(jvmcont)("THAW #" INTPTR_FORMAT " " INTPTR_FORMAT, cont.hash(), p2i((oopDesc*)oopCont));
@@ -2892,11 +2892,11 @@ static inline intptr_t* thaw0(JavaThread* thread, const thaw_kind kind) {
 
   Thaw<ConfigT> thw(thread, cont);
   intptr_t* const sp = thw.thaw(kind);
-  assert ((intptr_t)sp % 16 == 0, "");
+  assert((intptr_t)sp % 16 == 0, "");
 
   thread->reset_held_monitor_count();
 
-  assert (VERIFY_CONTINUATION(cont.mirror()), "");
+  assert(VERIFY_CONTINUATION(cont.mirror()), "");
 
 #ifdef ASSERT
   intptr_t* sp0 = sp;
@@ -2911,7 +2911,7 @@ static inline intptr_t* thaw0(JavaThread* thread, const thaw_kind kind) {
   if (LoomVerifyAfterThaw) {
     assert(do_verify_after_thaw(thread, thw._mode, thw.barriers(), cont.tail(), tty), "");
   }
-  assert (ContinuationEntry::assert_entry_frame_laid_out(thread), "");
+  assert(ContinuationEntry::assert_entry_frame_laid_out(thread), "");
   ContinuationHelper::clear_anchor(thread);
 
   if (lt.develop_is_enabled()) {
@@ -2922,7 +2922,7 @@ static inline intptr_t* thaw0(JavaThread* thread, const thaw_kind kind) {
 
   CONT_JFR_ONLY(cont.post_jfr_event(&event, thread);)
 
-  assert (VERIFY_CONTINUATION(cont.mirror()), "");
+  assert(VERIFY_CONTINUATION(cont.mirror()), "");
   log_develop_debug(jvmcont)("=== End of thaw #" INTPTR_FORMAT, cont.hash());
 
   return sp;
@@ -3024,13 +3024,13 @@ nmethod* ContinuationEntry::continuation_enter = nullptr;
 address ContinuationEntry::return_pc = nullptr;
 
 void ContinuationEntry::set_enter_nmethod(nmethod* nm) {
-  assert (return_pc_offset != 0, "");
+  assert(return_pc_offset != 0, "");
   continuation_enter = nm;
   return_pc = nm->code_begin() + return_pc_offset;
 }
 
 ContinuationEntry* ContinuationEntry::from_frame(const frame& f) {
-  assert (Continuation::is_continuation_enterSpecial(f), "");
+  assert(Continuation::is_continuation_enterSpecial(f), "");
   return (ContinuationEntry*)f.unextended_sp();
 }
 
@@ -3042,11 +3042,11 @@ void ContinuationEntry::flush_stack_processing(JavaThread* thread) const {
 
 #ifdef ASSERT
 bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
-  assert (thread->has_last_Java_frame(), "Wrong place to use this assertion");
+  assert(thread->has_last_Java_frame(), "Wrong place to use this assertion");
 
   ContinuationEntry* cont =
     Continuation::get_continuation_entry_for_continuation(thread, ContinuationHelper::get_continuation(thread));
-  assert (cont != nullptr, "");
+  assert(cont != nullptr, "");
 
   intptr_t* unextended_sp = cont->entry_sp();
   intptr_t* sp;
@@ -3062,16 +3062,16 @@ bool ContinuationEntry::assert_entry_frame_laid_out(JavaThread* thread) {
          f = f.sender(&map)) {
       interpreted_bottom = f.is_interpreted_frame();
     }
-    assert (Continuation::is_continuation_enterSpecial(f), "");
+    assert(Continuation::is_continuation_enterSpecial(f), "");
     sp = interpreted_bottom ? f.sp() : cont->bottom_sender_sp();
   }
 
-  assert (sp != nullptr && sp <= cont->entry_sp(), "");
+  assert(sp != nullptr && sp <= cont->entry_sp(), "");
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
 
   if (pc != StubRoutines::cont_returnBarrier()) {
     CodeBlob* cb = pc != nullptr ? CodeCache::find_blob(pc) : nullptr;
-    assert (cb->as_compiled_method()->method()->is_continuation_enter_intrinsic(), "");
+    assert(cb->as_compiled_method()->method()->is_continuation_enter_intrinsic(), "");
   }
 
   return true;
@@ -3086,7 +3086,7 @@ static jlong java_tid(JavaThread* thread) {
 static void print_frame_layout(const frame& f, outputStream* st) {
   ResourceMark rm;
   FrameValues values;
-  assert (f.get_cb() != nullptr, "");
+  assert(f.get_cb() != nullptr, "");
   RegisterMap map(f._pointers == frame::addressing::RELATIVE ?
                      (JavaThread*)nullptr :
                      JavaThread::current(), true, false, false);
@@ -3128,12 +3128,12 @@ static address thaw_entry   = nullptr;
 static address freeze_entry = nullptr;
 
 address Continuation::thaw_entry() {
-  assert (::thaw_entry != nullptr,  "");
+  assert(::thaw_entry != nullptr,  "");
   return ::thaw_entry;
 }
 
 address Continuation::freeze_entry() {
-  assert (::freeze_entry != nullptr, "");
+  assert(::freeze_entry != nullptr, "");
   return ::freeze_entry;
 }
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -134,9 +134,9 @@ oop RegisterMap::cont() const {
 }
 
 void RegisterMap::set_stack_chunk(stackChunkOop chunk) {
-  assert (chunk == NULL || _walk_cont, "");
-  assert (chunk == NULL || chunk->is_stackChunk(), "");
-  assert (chunk == NULL || _chunk.not_null(), "");
+  assert(chunk == NULL || _walk_cont, "");
+  assert(chunk == NULL || chunk->is_stackChunk(), "");
+  assert(chunk == NULL || _chunk.not_null(), "");
   if (_chunk.is_null()) return;
   log_trace(jvmcont)("set_stack_chunk: " INTPTR_FORMAT " this: " INTPTR_FORMAT, p2i((oopDesc*)chunk), p2i(this));
   *(_chunk.raw_value()) = chunk; // reuse handle. see comment above in the constructor
@@ -487,7 +487,7 @@ jint frame::interpreter_frame_expression_stack_size() const {
     stack_size = (interpreter_frame_tos_address() -
                   interpreter_frame_expression_stack() + 1)/element_size;
   }
-  assert (stack_size <= (size_t)max_jint, "stack size too big");
+  assert(stack_size <= (size_t)max_jint, "stack size too big");
   return (jint)stack_size;
 }
 
@@ -1276,7 +1276,7 @@ public:
   virtual void do_derived_oop(oop* base_loc, derived_pointer* derived_loc) override {
     // oop base = *base_loc;
     // intptr_t offset = *(intptr_t*)derived_loc - cast_from_oop<intptr_t>(base);
-    // assert (offset >= 0 && offset <= (intptr_t)(base->size() << LogHeapWordSize), "offset: %ld base->size: %zu relative: %d", offset, base->size() << LogHeapWordSize, *(intptr_t*)derived_loc <= 0);
+    // assert(offset >= 0 && offset <= (intptr_t)(base->size() << LogHeapWordSize), "offset: %ld base->size: %zu relative: %d", offset, base->size() << LogHeapWordSize, *(intptr_t*)derived_loc <= 0);
 
     _base->push(base_loc);
     _derived->push(derived_loc);
@@ -1446,7 +1446,7 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
         assert(sig_index == sizeargs, "");
       }
       int out_preserve = SharedRuntime::java_calling_convention(sig_bt, regs, sizeargs);
-      assert (out_preserve ==  m->num_stack_arg_slots(), "");
+      assert(out_preserve ==  m->num_stack_arg_slots(), "");
       int sig_index = 0;
       int arg_index = (m->is_static() ? 0 : -1);
       for (SignatureStream ss(m->signature()); !ss.at_return_type(); ) {
@@ -1456,7 +1456,7 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
         assert(t == sig_bt[sig_index], "sigs in sync");
         VMReg fst = regs[sig_index].first();
         if (fst->is_stack()) {
-          assert (((int)fst->reg2stack()) >= 0, "reg2stack: " INTPTR_FORMAT, fst->reg2stack());
+          assert(((int)fst->reg2stack()) >= 0, "reg2stack: " INTPTR_FORMAT, fst->reg2stack());
           int offset = fst->reg2stack() * VMRegImpl::stack_slot_size + stack_slot_offset;
           intptr_t* stack_address = (intptr_t*)((address)unextended_sp() + offset);
           if (at_this) {
@@ -1612,7 +1612,7 @@ void FrameValues::print_on(JavaThread* thread, outputStream* st) {
 }
 
 void FrameValues::print_on(stackChunkOop chunk, outputStream* st) {
-  assert (chunk->is_stackChunk(), "");
+  assert(chunk->is_stackChunk(), "");
 
   _values.sort(compare);
 

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -106,8 +106,8 @@ inline CodeBlob* frame::get_cb() const {
 
 // inline void frame::set_cb(CodeBlob* cb) {
 //   if (_cb == NULL) _cb = cb;
-//   assert (_cb == cb, "");
-//   assert (_cb->contains(_pc), "");
+//   assert(_cb == cb, "");
+//   assert(_cb->contains(_pc), "");
 // }
 
 

--- a/src/hotspot/share/runtime/frame_helpers.inline.hpp
+++ b/src/hotspot/share/runtime/frame_helpers.inline.hpp
@@ -210,12 +210,12 @@ inline int Interpreted::stack_argsize(const frame& f) {
 
 inline int Interpreted::expression_stack_size(const frame &f, InterpreterOopMap* mask) {
   int size = mask->expression_stack_size();
-  assert (size <= f.interpreter_frame_expression_stack_size(), "size1: %d size2: %d", size, f.interpreter_frame_expression_stack_size());
+  assert(size <= f.interpreter_frame_expression_stack_size(), "size1: %d size2: %d", size, f.interpreter_frame_expression_stack_size());
   return size;
 }
 
 bool Interpreted::is_owning_locks(const frame& f) {
-  assert (f.interpreter_frame_monitor_end() <= f.interpreter_frame_monitor_begin(), "must be");
+  assert(f.interpreter_frame_monitor_end() <= f.interpreter_frame_monitor_begin(), "must be");
   if (f.interpreter_frame_monitor_end() == f.interpreter_frame_monitor_begin()) {
     return false;
   }
@@ -257,7 +257,7 @@ inline intptr_t* NonInterpreted<Self>::frame_bottom(const frame& f) { // exclusi
 
 template<typename Self>
 inline int NonInterpreted<Self>::size(const frame& f) {
-  assert (!f.is_interpreted_frame() && Self::is_instance(f), "");
+  assert(!f.is_interpreted_frame() && Self::is_instance(f), "");
   return f.cb()->frame_size();
 }
 
@@ -268,16 +268,16 @@ inline int NonInterpreted<Self>::stack_argsize(const frame& f) {
 
 template<typename Self>
 inline int NonInterpreted<Self>::num_oops(const frame& f) {
-  assert (!f.is_interpreted_frame() && Self::is_instance(f), "");
+  assert(!f.is_interpreted_frame() && Self::is_instance(f), "");
   return f.num_oops() + Self::extra_oops;
 }
 
 template<typename RegisterMapT>
 bool Compiled::is_owning_locks(JavaThread* thread, RegisterMapT* map, const frame& f) {
-  assert (!f.is_interpreted_frame() && Compiled::is_instance(f), "");
+  assert(!f.is_interpreted_frame() && Compiled::is_instance(f), "");
 
   CompiledMethod* cm = f.cb()->as_compiled_method();
-  assert (!cm->is_compiled() || !cm->as_compiled_method()->is_native_method(), ""); // See compiledVFrame::compiledVFrame(...) in vframe_hp.cpp
+  assert(!cm->is_compiled() || !cm->as_compiled_method()->is_native_method(), ""); // See compiledVFrame::compiledVFrame(...) in vframe_hp.cpp
 
   if (!cm->has_monitors()) {
     return false;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1167,7 +1167,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
 
     // Retrieve from a compiled argument list
     receiver = Handle(current, callerFrame.retrieve_receiver(&reg_map2));
-    assert (oopDesc::is_oop_or_null(receiver()), ""); // if (receiver() != NULL) oopDesc::verify(receiver()); //
+    assert(oopDesc::is_oop_or_null(receiver()), ""); // if (receiver() != NULL) oopDesc::verify(receiver()); //
 
     if (receiver.is_null()) {
       THROW_(vmSymbols::java_lang_NullPointerException(), nullHandle);

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -179,7 +179,7 @@ void Fingerprinter::compute_fingerprint_and_return_type(bool static_flag) {
   _stack_arg_slots = align_up(_stack_arg_slots, 2);
 #ifdef ASSERT
   int dbg_stack_arg_slots = compute_num_stack_arg_slots(_signature, _param_size, static_flag);
-  assert (_stack_arg_slots == dbg_stack_arg_slots, "fingerprinter: %d full: %d", _stack_arg_slots, dbg_stack_arg_slots);
+  assert(_stack_arg_slots == dbg_stack_arg_slots, "fingerprinter: %d full: %d", _stack_arg_slots, dbg_stack_arg_slots);
 #endif
 
   // Detect overflow.  (We counted _param_size correctly.)

--- a/src/hotspot/share/runtime/stackValue.cpp
+++ b/src/hotspot/share/runtime/stackValue.cpp
@@ -101,7 +101,7 @@ StackValue* StackValue::create_stack_value(ScopeValue* sv, address value_addr, c
       // Long   value in an aligned adjacent pair
       return new StackValue(*(intptr_t*)value_addr);
     case Location::narrowoop: {
-      assert (UseCompressedOops, "");
+      assert(UseCompressedOops, "");
       union { intptr_t p; narrowOop noop;} value;
       value.p = (intptr_t) CONST64(0xDEADDEAFDEADDEAF);
       if (loc.is_register()) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1595,7 +1595,7 @@ bool JavaThread::is_lock_owned_current(address adr) const {
 }
 
 bool JavaThread::is_lock_owned_carrier(address adr) const {
-  assert (is_vthread_mounted(), "");
+  assert(is_vthread_mounted(), "");
   address stack_end = _stack_base - _stack_size;
   address stack_base = (address)vthread_continuation()->entry_sp();
   return stack_base > adr && adr >= stack_end;
@@ -2153,7 +2153,7 @@ const char* _get_thread_state_name(JavaThreadState _thread_state) {
 void JavaThread::print_thread_state_on(outputStream *st) const {
   if (is_vthread_mounted()) {
     oop vt = vthread();
-    assert (vt != NULL, "");
+    assert(vt != NULL, "");
     st->print_cr("   Carrying virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
   }
   st->print_cr("   JavaThread state: %s", _get_thread_state_name(_thread_state));
@@ -2180,7 +2180,7 @@ void JavaThread::print_on(outputStream *st, bool print_extended_info) const {
   if (thread_oop != NULL) {
     if (is_vthread_mounted()) {
       oop vt = vthread();
-      assert (vt != NULL, "");
+      assert(vt != NULL, "");
       st->print_cr("   Carrying virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
     } else {
       st->print_cr("   java.lang.Thread.State: %s", java_lang_Thread::thread_status_name(thread_oop));

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1197,7 +1197,7 @@ private:
   int held_monitor_count() { return _held_monitor_count; }
   void reset_held_monitor_count() { _held_monitor_count = 0; }
   void inc_held_monitor_count() { _held_monitor_count++; }
-  void dec_held_monitor_count() { assert (_held_monitor_count > 0, ""); _held_monitor_count--; }
+  void dec_held_monitor_count() { assert(_held_monitor_count > 0, ""); _held_monitor_count--; }
 
   inline bool is_vthread_mounted() const;
   inline const ContinuationEntry* vthread_continuation() const;

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -65,7 +65,7 @@ vframe::vframe(const frame* fr, JavaThread* thread)
 : _reg_map(thread), _thread(thread), _chunk() {
   assert(fr != NULL, "must have frame");
   _fr = *fr;
-  assert (!_reg_map.in_cont(), "");
+  assert(!_reg_map.in_cont(), "");
 }
 
 vframe* vframe::new_vframe(StackFrameStream& fst, JavaThread* thread) {
@@ -292,12 +292,12 @@ u_char* interpretedVFrame::bcp() const {
 }
 
 void interpretedVFrame::set_bcp(u_char* bcp) {
-  assert (stack_chunk() == NULL, ""); // unsupported for now because seems to be unused
+  assert(stack_chunk() == NULL, ""); // unsupported for now because seems to be unused
   fr().interpreter_frame_set_bcp(bcp);
 }
 
 intptr_t* interpretedVFrame::locals_addr_at(int offset) const {
-  assert (stack_chunk() == NULL, ""); // unsupported for now because seems to be unused
+  assert(stack_chunk() == NULL, ""); // unsupported for now because seems to be unused
   assert(fr().is_interpreted_frame(), "frame should be an interpreted frame");
   return fr().interpreter_frame_local_at(offset);
 }
@@ -320,7 +320,7 @@ int interpretedVFrame::bci() const {
 }
 
 Method* interpretedVFrame::method() const {
-  // assert ((stack_chunk() != NULL) == register_map()->in_cont(), "_in_cont: %d register_map()->in_cont(): %d", stack_chunk() != NULL, register_map()->in_cont());
+  // assert((stack_chunk() != NULL) == register_map()->in_cont(), "_in_cont: %d register_map()->in_cont(): %d", stack_chunk() != NULL, register_map()->in_cont());
   return stack_chunk() == NULL ? fr().interpreter_frame_method() : stack_chunk()->interpreter_frame_method(fr());
 }
 

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -66,9 +66,9 @@ inline void vframeStreamCommon::next() {
   do {
     bool cont_entry = false;
     if (Continuation::is_continuation_enterSpecial(_frame)) {
-      assert (!_reg_map.in_cont(), "");
-      assert (_cont != NULL, "");
-      assert (_cont->cont_oop() != NULL, "_cont: " INTPTR_FORMAT, p2i(_cont));
+      assert(!_reg_map.in_cont(), "");
+      assert(_cont != NULL, "");
+      assert(_cont->cont_oop() != NULL, "_cont: " INTPTR_FORMAT, p2i(_cont));
       cont_entry = true;
 
       // TODO: handle ShowCarrierFrames
@@ -77,7 +77,7 @@ inline void vframeStreamCommon::next() {
         break;
       }
     } else if (_reg_map.in_cont() && Continuation::is_continuation_entry_frame(_frame, &_reg_map)) {
-      assert (_reg_map.cont() != NULL, "");
+      assert(_reg_map.cont() != NULL, "");
       oop scope = jdk_internal_vm_Continuation::scope(_reg_map.cont());
       if (scope == java_lang_VirtualThread::vthread_scope() || (_continuation_scope.not_null() && scope == _continuation_scope())) {
         _mode = at_end_mode;
@@ -187,7 +187,7 @@ inline bool vframeStreamCommon::fill_from_frame() {
   // Compiled frame
 
   if (cb() != NULL && cb()->is_compiled()) {
-    assert (nm()->method() != NULL, "must be");
+    assert(nm()->method() != NULL, "must be");
     if (nm()->is_native_method()) {
       // Do not rely on scopeDesc since the pc might be unprecise due to the _last_native_pc trick.
       fill_from_compiled_native_frame();
@@ -255,7 +255,7 @@ inline bool vframeStreamCommon::fill_from_frame() {
     return true;
   }
 
-  assert (!Continuation::is_continuation_enterSpecial(_frame), "");
+  assert(!Continuation::is_continuation_enterSpecial(_frame), "");
   return false;
 }
 

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -901,7 +901,7 @@ void ThreadSnapshot::initialize(ThreadsList * t_list, JavaThread* thread) {
   if (thread->is_vthread_mounted() && thread->vthread() != threadObj) { // ThreadSnapshot only captures platform threads
     _thread_status = JavaThreadStatus::IN_OBJECT_WAIT;
     oop vthread = thread->vthread();
-    assert (vthread != NULL, "");
+    assert(vthread != NULL, "");
     blocker_object = vthread;
     blocker_object_owner = vthread;
   } else if (_thread_status == JavaThreadStatus::BLOCKED_ON_MONITOR_ENTER ||


### PR DESCRIPTION
Simple textual replacement of `assert (` with `assert(`. I've only changed asserts introduced/changed for Loom. 