### PR TITLE
Fix compilation with gcc 11.2

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
@@ -72,6 +72,8 @@ void JvmtiThreadState::set_head_env_thread_state(JvmtiEnvThreadState* ets) {
   _head_env_thread_state = ets;
 }
 
+PRAGMA_DIAG_PUSH
+PRAGMA_NONNULL_IGNORED
 inline JvmtiThreadState* JvmtiThreadState::state_for_while_locked(JavaThread *thread, oop thread_oop) {
   assert(JvmtiThreadState_lock->is_locked(), "sanity check");
   assert(thread != NULL || thread_oop != NULL, "sanity check");
@@ -100,6 +102,7 @@ inline JvmtiThreadState* JvmtiThreadState::state_for_while_locked(JavaThread *th
   }
   return state;
 }
+PRAGMA_DIAG_POP
 
 inline JvmtiThreadState* JvmtiThreadState::state_for(JavaThread *thread, Handle thread_handle) {
   // in a case of unmounted virtual thread the thread can be NULL


### PR DESCRIPTION
Hi all,

  please review this small change to add code that disables the `-Wnonnull` warning for `JvmtiThreadState::state_for_while_locked`; the warning/error seems to be in error.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**) ⚠️ Review applies to effedb633110e0197a1c5801c785a5891f950b9a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.java.net/loom pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/109.diff">https://git.openjdk.java.net/loom/pull/109.diff</a>

</details>
