### PR TITLE
Remove Config

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -105,14 +105,14 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
 
 // Fast path
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void Freeze::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
   *(vsp - frame::sender_sp_offset) = *(hsp - frame::sender_sp_offset);
 }
 
 // Slow path
 
 template<typename FKind>
-inline frame FreezeBase::sender(const frame& f) {
+inline frame Freeze::sender(const frame& f) {
   assert(FKind::is_instance(f), "");
   if (FKind::interpreted) {
     return frame(f.sender_sp(), f.interpreter_frame_sender_sp(), f.link(), f.sender_pc());
@@ -133,7 +133,7 @@ inline frame FreezeBase::sender(const frame& f) {
 }
 
 template<typename FKind>
-frame FreezeBase::new_hframe(frame& f, frame& caller) {
+frame Freeze::new_hframe(frame& f, frame& caller) {
   assert(FKind::is_instance(f), "");
   assert(!caller.is_interpreted_frame()
     || caller.unextended_sp() == (intptr_t*)caller.at(frame::interpreter_frame_last_sp_offset), "");
@@ -177,7 +177,7 @@ static inline void relativize_one(intptr_t* const vfp, intptr_t* const hfp, int 
   *addr = value;
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+inline void Freeze::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   intptr_t* vfp = f.fp();
   intptr_t* hfp = hf.fp();
   assert(hfp == hf.unextended_sp() + (f.fp() - f.unextended_sp()), "");
@@ -203,7 +203,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
   assert(hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
 }
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+inline void Freeze::set_top_frame_metadata_pd(const frame& hf) {
   stackChunkOop chunk = _cont.tail();
   assert(chunk->is_in_chunk(hf.sp() - 1), "");
   assert(chunk->is_in_chunk(hf.sp() - frame::sender_sp_offset), "");
@@ -215,7 +215,7 @@ inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
                                        : (intptr_t)hf.fp();
 }
 
-inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+inline void Freeze::patch_pd(frame& hf, const frame& caller) {
   if (caller.is_interpreted_frame()) {
     assert(!caller.is_empty(), "");
     patch_callee_link_relative(caller, caller.fp());
@@ -228,25 +228,25 @@ inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
 
 // Fast path
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+inline void Thaw::prefetch_chunk_pd(void* start, int size) {
   size <<= LogBytesPerWord;
   Prefetch::read(start, size);
   Prefetch::read(start, size - 64);
 }
 
-void ThawBase::patch_chunk_pd(intptr_t* sp) {
+void Thaw::patch_chunk_pd(intptr_t* sp) {
   intptr_t* fp = _cont.entryFP();
   *(intptr_t**)(sp - frame::sender_sp_offset) = fp;
 }
 
 // Slow path
 
-inline frame ThawBase::new_entry_frame() {
+inline frame Thaw::new_entry_frame() {
   intptr_t* sp = _cont.entrySP();
   return frame(sp, sp, _cont.entryFP(), _cont.entryPC()); // TODO PERF: This finds code blob and computes deopt state
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame Thaw::new_frame(const frame& hf, frame& caller, bool bottom) {
   assert(FKind::is_instance(hf), "");
 
   if (FKind::interpreted) {
@@ -291,7 +291,7 @@ template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& calle
   }
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* Thaw::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
 #ifdef _LP64
   if (((intptr_t)vsp & 0xf) != 0) {
     assert(caller.is_interpreted_frame() || (bottom && hf.compiled_frame_stack_argsize() % 2 != 0), "");
@@ -304,11 +304,11 @@ inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, 
   return vsp;
 }
 
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+inline void Thaw::patch_pd(frame& f, const frame& caller) {
   patch_callee_link(caller, caller.fp());
 }
 
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
+intptr_t* Thaw::push_interpreter_return_frame(intptr_t* sp) {
   address pc = StubRoutines::cont_interpreter_forced_preempt_return();
   intptr_t* fp = sp - frame::sender_sp_offset;
 
@@ -329,14 +329,14 @@ static inline void derelativize_one(intptr_t* const fp, int offset) {
   *addr = (intptr_t)(fp + *addr);
 }
 
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+inline void Thaw::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   intptr_t* vfp = f.fp();
 
   derelativize_one(vfp, frame::interpreter_frame_last_sp_offset);
   derelativize_one(vfp, frame::interpreter_frame_initial_sp_offset);
 }
 
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+inline void Thaw::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   *(intptr_t**)f.addr_at(frame::interpreter_frame_locals_offset) = bottom - 1;
 }
 

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -79,70 +79,70 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   Unimplemented();
 }
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+inline void Freeze::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
 template<typename FKind>
-inline frame FreezeBase::sender(const frame& f) {
+inline frame Freeze::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame Freeze::new_hframe(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+inline void Freeze::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+inline void Freeze::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void Freeze::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
   Unimplemented();
 }
 
-inline frame ThawBase::new_entry_frame() {
-  Unimplemented();
-  return frame();
-}
-
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+inline frame Thaw::new_entry_frame() {
   Unimplemented();
   return frame();
 }
 
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+template<typename FKind> frame Thaw::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+inline void Thaw::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+inline void Thaw::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* Thaw::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }
 
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+inline void Thaw::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }
 
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
+intptr_t* Thaw::push_interpreter_return_frame(intptr_t* sp) {
   Unimplemented();
   return NULL;
 }
 
-void ThawBase::patch_chunk_pd(intptr_t* sp) {
+void Thaw::patch_chunk_pd(intptr_t* sp) {
   Unimplemented();
 }
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+inline void Thaw::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -79,70 +79,70 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   Unimplemented();
 }
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+inline void Freeze::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
 template<typename FKind>
-inline frame FreezeBase::sender(const frame& f) {
+inline frame Freeze::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame Freeze::new_hframe(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+inline void Freeze::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+inline void Freeze::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void Freeze::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
   Unimplemented();
 }
 
-inline frame ThawBase::new_entry_frame() {
-  Unimplemented();
-  return frame();
-}
-
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+inline frame Thaw::new_entry_frame() {
   Unimplemented();
   return frame();
 }
 
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+template<typename FKind> frame Thaw::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+inline void Thaw::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+inline void Thaw::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* Thaw::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }
 
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+inline void Thaw::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }
 
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
+intptr_t* Thaw::push_interpreter_return_frame(intptr_t* sp) {
   Unimplemented();
   return NULL;
 }
 
-void ThawBase::patch_chunk_pd(intptr_t* sp) {
+void Thaw::patch_chunk_pd(intptr_t* sp) {
   Unimplemented();
 }
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+inline void Thaw::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -79,70 +79,70 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   Unimplemented();
 }
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+inline void Freeze::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
 template<typename FKind>
-inline frame FreezeBase::sender(const frame& f) {
+inline frame Freeze::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame Freeze::new_hframe(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+inline void Freeze::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+inline void Freeze::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void Freeze::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
   Unimplemented();
 }
 
-inline frame ThawBase::new_entry_frame() {
-  Unimplemented();
-  return frame();
-}
-
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+inline frame Thaw::new_entry_frame() {
   Unimplemented();
   return frame();
 }
 
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+template<typename FKind> frame Thaw::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+inline void Thaw::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+inline void Thaw::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* Thaw::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }
 
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+inline void Thaw::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }
 
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
+intptr_t* Thaw::push_interpreter_return_frame(intptr_t* sp) {
   Unimplemented();
   return NULL;
 }
 
-void ThawBase::patch_chunk_pd(intptr_t* sp) {
+void Thaw::patch_chunk_pd(intptr_t* sp) {
   Unimplemented();
 }
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+inline void Thaw::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -79,70 +79,70 @@ void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   Unimplemented();
 }
 
-inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+inline void Freeze::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
 template<typename FKind>
-inline frame FreezeBase::sender(const frame& f) {
+inline frame Freeze::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame Freeze::new_hframe(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
 
-inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+inline void Freeze::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+inline void Freeze::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void Freeze::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
   Unimplemented();
 }
 
-inline frame ThawBase::new_entry_frame() {
-  Unimplemented();
-  return frame();
-}
-
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+inline frame Thaw::new_entry_frame() {
   Unimplemented();
   return frame();
 }
 
-inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+template<typename FKind> frame Thaw::new_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+inline void Thaw::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 
-inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+inline void Thaw::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* Thaw::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }
 
-inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+inline void Thaw::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }
 
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
+intptr_t* Thaw::push_interpreter_return_frame(intptr_t* sp) {
   Unimplemented();
   return NULL;
 }
 
-void ThawBase::patch_chunk_pd(intptr_t* sp) {
+void Thaw::patch_chunk_pd(intptr_t* sp) {
   Unimplemented();
 }
 
-inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+inline void Thaw::prefetch_chunk_pd(void* start, int size) {
   Unimplemented();
 }
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1154,9 +1154,7 @@ class jdk_internal_vm_StackChunk: AllStatic {
   // Accessors
   static inline oop parent(oop ref);
   static inline void set_parent(oop ref, oop value);
-  template<typename P>
   static inline bool is_parent_null(oop ref); // bypasses barriers for a faster test
-  template<typename P>
   static inline void set_parent_raw(oop ref, oop value);
 
   static inline int size(oop ref);
@@ -1177,9 +1175,7 @@ class jdk_internal_vm_StackChunk: AllStatic {
  // cont oop's processing is essential for the chunk's GC protocol
   static inline oop cont(oop ref);
   static inline void set_cont(oop ref, oop value);
-  template<typename P>
   static inline oop cont_raw(oop ref);
-  template<typename P>
   static inline void set_cont_raw(oop ref, oop value);
 };
 

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -31,6 +31,7 @@
 #include "oops/instanceKlass.inline.hpp"
 #include "logging/log.hpp"
 #include "oops/method.hpp"
+#include "logging/log.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "oops/stackChunkOop.inline.hpp"
@@ -272,14 +273,12 @@ inline void jdk_internal_vm_StackChunk::set_parent(oop ref, oop value) {
   ref->obj_field_put(_parent_offset, value);
 }
 
-template<typename P>
 inline bool jdk_internal_vm_StackChunk::is_parent_null(oop ref) {
-  return (oop)RawAccess<>::oop_load(ref->field_addr<P>(_parent_offset)) == NULL;
+  return (oop)RawAccess<>::oop_load_at(ref, _parent_offset) == NULL;
 }
 
-template<typename P>
 inline void jdk_internal_vm_StackChunk::set_parent_raw(oop ref, oop value) {
-  RawAccess<IS_DEST_UNINITIALIZED>::oop_store(ref->field_addr<P>(_parent_offset), value);
+  RawAccess<IS_DEST_UNINITIALIZED>::oop_store_at(ref, _parent_offset, value);
 }
 
 inline oop jdk_internal_vm_StackChunk::cont(oop ref) {
@@ -290,14 +289,12 @@ inline void jdk_internal_vm_StackChunk::set_cont(oop ref, oop value) {
   ref->obj_field_put(_cont_offset, value);
 }
 
-template<typename P>
 inline oop jdk_internal_vm_StackChunk::cont_raw(oop ref) {
-  return (oop)RawAccess<>::oop_load(ref->field_addr<P>(_cont_offset));
+  return (oop)RawAccess<>::oop_load_at(ref, _cont_offset);
 }
 
-template<typename P>
 inline void jdk_internal_vm_StackChunk::set_cont_raw(oop ref, oop value) {
-  RawAccess<IS_DEST_UNINITIALIZED>::oop_store(ref->field_addr<P>(_cont_offset), value);
+  RawAccess<IS_DEST_UNINITIALIZED>::oop_store_at(ref, _cont_offset, value);
 }
 
 inline int jdk_internal_vm_StackChunk::size(oop ref) {

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -35,6 +35,7 @@
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/iterator.inline.hpp"
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/klass.hpp"

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -58,11 +58,9 @@ private:
 public:
   static inline stackChunkOop cast(oop obj);
 
-  inline stackChunkOop parent() const;
-  inline void set_parent(stackChunkOop value);
-  template<typename P>
+  inline stackChunkOopDesc* parent() const;
+  inline void set_parent(stackChunkOopDesc* value);
   inline bool is_parent_null() const;
-  template<typename P>
   inline void set_parent_raw(oop value);
 
   inline int stack_size() const;
@@ -83,9 +81,7 @@ public:
   inline void set_max_size(int value);
 
   inline oop cont() const;
-  template<typename P> inline oop cont() const;
   inline void set_cont(oop value);
-  template<typename P>
   inline void set_cont_raw(oop value);
 
   inline int bottom() const;
@@ -96,7 +92,6 @@ public:
   inline intptr_t* end_address() const;
   inline intptr_t* bottom_address() const; // = end_address - argsize
   inline intptr_t* sp_address() const;
-
 
   inline int to_offset(intptr_t* p) const;
   inline intptr_t* from_offset(int offset) const;

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -45,12 +45,10 @@ inline stackChunkOop stackChunkOopDesc::cast(oop obj) {
   return stackChunkOop(obj);
 }
 
-inline stackChunkOop stackChunkOopDesc::parent() const         { return stackChunkOopDesc::cast(jdk_internal_vm_StackChunk::parent(as_oop())); }
-template<typename P>
-inline bool stackChunkOopDesc::is_parent_null() const          { return jdk_internal_vm_StackChunk::is_parent_null<P>(as_oop()); }
-inline void stackChunkOopDesc::set_parent(stackChunkOop value) { jdk_internal_vm_StackChunk::set_parent(this, value); }
-template<typename P>
-inline void stackChunkOopDesc::set_parent_raw(oop value)       { jdk_internal_vm_StackChunk::set_parent_raw<P>(this, value); }
+inline stackChunkOopDesc* stackChunkOopDesc::parent() const         { return (stackChunkOopDesc*)(oopDesc*)jdk_internal_vm_StackChunk::parent(as_oop()); }
+inline bool stackChunkOopDesc::is_parent_null() const               { return jdk_internal_vm_StackChunk::is_parent_null(as_oop()); }
+inline void stackChunkOopDesc::set_parent(stackChunkOopDesc* value) { jdk_internal_vm_StackChunk::set_parent(this, (oop)value); }
+inline void stackChunkOopDesc::set_parent_raw(oop value)            { jdk_internal_vm_StackChunk::set_parent_raw(this, value); }
 
 inline int stackChunkOopDesc::stack_size() const        { return jdk_internal_vm_StackChunk::size(as_oop()); }
 
@@ -69,16 +67,9 @@ inline void stackChunkOopDesc::set_flags(uint8_t value) { jdk_internal_vm_StackC
 inline int stackChunkOopDesc::max_size() const          { return jdk_internal_vm_StackChunk::maxSize(as_oop()); }
 inline void stackChunkOopDesc::set_max_size(int value)  { jdk_internal_vm_StackChunk::set_maxSize(this, (jint)value); }
 
-inline oop stackChunkOopDesc::cont() const              { return UseCompressedOops ? cont<narrowOop>() : cont<oop>(); /* jdk_internal_vm_StackChunk::cont(as_oop()); */ }
-template<typename P>
-inline oop stackChunkOopDesc::cont() const              {
-  oop obj = jdk_internal_vm_StackChunk::cont_raw<P>(as_oop());
-  obj = (oop)NativeAccess<>::oop_load(&obj);
-  return obj;
-}
+inline oop stackChunkOopDesc::cont() const              { return jdk_internal_vm_StackChunk::cont(as_oop()); }
 inline void stackChunkOopDesc::set_cont(oop value)      { jdk_internal_vm_StackChunk::set_cont(this, value); }
-template<typename P>
-inline void stackChunkOopDesc::set_cont_raw(oop value)  {  jdk_internal_vm_StackChunk::set_cont_raw<P>(this, value); }
+inline void stackChunkOopDesc::set_cont_raw(oop value)  { jdk_internal_vm_StackChunk::set_cont_raw(this, value); }
 
 inline int stackChunkOopDesc::bottom() const { return stack_size() - argsize(); }
 


### PR DESCRIPTION
For you to consider.
- Adds 1-2ns (thaw+freeze) (<0.5%)
- Passes t1-3 (no new issues found)
- Reduces compilation time with over 30 seconds (15-20%).
- Loom have the same compile time as vanilla jdk/jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer) ⚠️ Review applies to 858efba85e544fcdef487b84e64be556a4e5f886
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer) ⚠️ Review applies to 07af4de3d7e7c152f46b7e953456cda82d30c067


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.java.net/loom pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/110.diff">https://git.openjdk.java.net/loom/pull/110.diff</a>

</details>
