### PR TITLE
Make compile on other platforms.

### DIFF
--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -63,18 +63,12 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
-// creates the yield stub frame faster than JavaThread::last_frame
-inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+frame ContinuationEntry::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-frame ContinuationEntry::to_frame() {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) {
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
   Unimplemented();
 }
 
@@ -91,9 +85,8 @@ inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
-template <typename ConfigT>
 template<typename FKind>
-inline frame Freeze<ConfigT>::sender(const frame& f) {
+inline frame FreezeBase::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
@@ -131,8 +124,7 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
   return frame();
 }
 
-template <typename ConfigT>
-inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -275,7 +275,7 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
   assert((intptr_t) fp() >  (intptr_t) result, "result must <  than frame pointer");
@@ -493,7 +493,7 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   return type;
 }
 
-inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
+intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   int index = (Interpreter::expr_offset_in_bytes(offset)/wordSize);
   return &interpreter_frame_tos_address()[index];
 }
@@ -519,10 +519,6 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
 // This is a generic constructor which is only used by pns() in debug.cpp.
 frame::frame(void* sp, void* fp, void* pc) {
   init((intptr_t*)sp, (intptr_t*)fp, (address)pc);
-}
-
-void frame::describe_top_pd(FrameValues& values) {
-  Unimplemented();
 }
 #endif
 

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -63,18 +63,12 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
-// creates the yield stub frame faster than JavaThread::last_frame
-inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+frame ContinuationEntry::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-frame ContinuationEntry::to_frame() {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) {
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
   Unimplemented();
 }
 
@@ -91,9 +85,8 @@ inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
-template <typename ConfigT>
 template<typename FKind>
-inline frame Freeze<ConfigT>::sender(const frame& f) {
+inline frame FreezeBase::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
@@ -131,8 +124,7 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
   return frame();
 }
 
-template <typename ConfigT>
-inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -374,10 +374,6 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
       DESCRIBE_ADDRESS(fresult);
   }
 }
-
-void frame::describe_top_pd(FrameValues& values) {
-  Unimplemented();
-}
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {
@@ -396,10 +392,10 @@ frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp),
 #endif
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_ijava_state()->monitors;
 }
 
-inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
+intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -63,18 +63,12 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
-// creates the yield stub frame faster than JavaThread::last_frame
-inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+frame ContinuationEntry::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-frame ContinuationEntry::to_frame() {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) {
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
   Unimplemented();
 }
 
@@ -91,9 +85,8 @@ inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
-template <typename ConfigT>
 template<typename FKind>
-inline frame Freeze<ConfigT>::sender(const frame& f) {
+inline frame FreezeBase::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
@@ -131,8 +124,7 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
   return frame();
 }
 
-template <typename ConfigT>
-inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -632,10 +632,6 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
     DESCRIBE_ADDRESS(fresult);
   }
 }
-
-void frame::describe_top_pd(FrameValues& values) {
-  Unimplemented();
-}
 #endif // !PRODUCT
 
 intptr_t *frame::initial_deoptimization_info() {
@@ -644,11 +640,11 @@ intptr_t *frame::initial_deoptimization_info() {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return interpreter_frame_monitors();
 }
 
-inline intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
+intptr_t* frame::interpreter_frame_tos_at(jint offset) const {
   return &interpreter_frame_tos_address()[offset];
 }
 

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -63,18 +63,12 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
-// creates the yield stub frame faster than JavaThread::last_frame
-inline frame ContinuationHelper::last_frame(JavaThread* thread) {
+frame ContinuationEntry::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-frame ContinuationEntry::to_frame() {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) {
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
   Unimplemented();
 }
 
@@ -91,9 +85,8 @@ inline void Freeze<ConfigT>::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
 
-template <typename ConfigT>
 template<typename FKind>
-inline frame Freeze<ConfigT>::sender(const frame& f) {
+inline frame FreezeBase::sender(const frame& f) {
   Unimplemented();
   return frame();
 }
@@ -131,8 +124,7 @@ template<typename FKind> frame Thaw<ConfigT>::new_frame(const frame& hf, frame& 
   return frame();
 }
 
-template <typename ConfigT>
-inline void Thaw<ConfigT>::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
   Unimplemented();
 }
 

--- a/src/hotspot/cpu/zero/frame_zero.cpp
+++ b/src/hotspot/cpu/zero/frame_zero.cpp
@@ -83,7 +83,7 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.
-inline BasicObjectLock* frame::interpreter_frame_monitor_end() const {
+BasicObjectLock* frame::interpreter_frame_monitor_end() const {
   return (BasicObjectLock*) get_interpreterState()->stack_base();
 }
 
@@ -414,11 +414,6 @@ void ZeroFrame::identify_vp_word(int       frame_index,
 void frame::describe_pd(FrameValues& values, int frame_no) {
 
 }
-
-void frame::describe_top_pd(FrameValues& values) {
-
-}
-
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {

--- a/src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,6 @@ inline D Atomic::PlatformAdd<4>::add_and_fetch(D volatile* dest, I add_value,
   STATIC_ASSERT(4 == sizeof(D));
   return add_using_helper<int32_t>(os::atomic_add_func, dest, add_value);
 }
-
 
 template<>
 template<typename T>

--- a/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -260,6 +260,10 @@ inline void stackChunkOopDesc::copy_from_chunk_to_stack(intptr_t* from, intptr_t
   assert(from >= start_address(), "");
   assert(from + size <= end_address(), "");
 
+#if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
+  // Suppress compilation error from dummy function (somewhere).
+  if (to != nullptr)
+#endif
   memcpy(to, from, size << LogBytesPerWord);
 }
 

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@
 #include "runtime/safepointVerifiers.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/signature.hpp"
+#include "runtime/sharedRuntime.hpp"
 
 // Implementation of SignatureIterator
 
@@ -215,6 +216,7 @@ void Fingerprinter::initialize_calling_convention(bool static_flag) {
 }
 
 void Fingerprinter::do_type_calling_convention(BasicType type) {
+#if (defined(AMD64) || defined(AARCH64)) && !defined(ZERO)
   switch (type) {
   case T_VOID:
     break;
@@ -245,6 +247,7 @@ void Fingerprinter::do_type_calling_convention(BasicType type) {
     ShouldNotReachHere();
     break;
   }
+#endif // x64 or aarch64
 }
 
 // Implementation of SignatureStream

--- a/src/hotspot/share/runtime/threadIdentifiers.cpp
+++ b/src/hotspot/share/runtime/threadIdentifiers.cpp
@@ -26,7 +26,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/threadIdentifiers.hpp"
 
-static volatile int64_t next_thread_id = 2; // starting at 2, excluding the primordial thread id
+static volatile intptr_t next_thread_id = 2; // starting at 2, excluding the primordial thread id
 
 int64_t ThreadIdentifiers::unsafe_offset() {
   return reinterpret_cast<int64_t>(&next_thread_id);

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,11 +174,6 @@ inline void vframeStreamCommon::fill_from_compiled_native_frame() {
 }
 
 inline bool vframeStreamCommon::fill_from_frame() {
-  if (_frame.is_empty()) {
-    _mode = at_end_mode;
-    return true;
-  }
-
   // Interpreted frame
   if (_frame.is_interpreted_frame()) {
     fill_from_interpreter_frame();


### PR DESCRIPTION
This patch with additions and deletions of dummy stubs gets loom to compile on zero, ppc, s390, arm, linux 32 bit open, ie platforms that Oracle doesn't support.
There are two not nice 
#if !defined(AMD64) || !defined(AARCH64) || defined(ZERO)
changes.  One for platform dependent code in signature.cpp and the other is because linux zero product inlining detects the dummy null return as input to memcpy.
Also has a stack walking change that makes zero not complete compilation with the built compiler because of dummy returns.  Removing this doesn't cause any test failures in the loom tier1-3 code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.java.net/loom pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/111.diff">https://git.openjdk.java.net/loom/pull/111.diff</a>

</details>
