### PR TITLE
Simplify G1CodeBlobClosure

### DIFF
--- a/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
@@ -76,7 +76,7 @@ void G1CodeBlobClosure::MarkingOopClosure::do_oop(narrowOop* o) {
 
 void G1CodeBlobClosure::do_evacuation_and_fixup(nmethod* nm) {
   _oc.set_nm(nm);
-  if (_keepalive_is_strong) {
+  if (_strong) {
     nm->mark_as_maybe_on_continuation();
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != NULL) {

--- a/src/hotspot/share/gc/g1/g1CodeBlobClosure.hpp
+++ b/src/hotspot/share/gc/g1/g1CodeBlobClosure.hpp
@@ -71,11 +71,10 @@ class G1CodeBlobClosure : public CodeBlobClosure {
   MarkingOopClosure _marking_oc;
 
   bool _strong;
-  bool _keepalive_is_strong;
 
 public:
-  G1CodeBlobClosure(uint worker_id, OopClosure* oc, bool strong, bool keepalive_is_strong) :
-    _oc(oc), _marking_oc(worker_id), _strong(strong), _keepalive_is_strong(keepalive_is_strong) { }
+  G1CodeBlobClosure(uint worker_id, OopClosure* oc, bool strong) :
+    _oc(oc), _marking_oc(worker_id), _strong(strong) { }
 
   void do_evacuation_and_fixup(nmethod* nm);
   void do_marking(nmethod* nm);

--- a/src/hotspot/share/gc/g1/g1RootClosures.cpp
+++ b/src/hotspot/share/gc/g1/g1RootClosures.cpp
@@ -43,8 +43,8 @@ public:
   CLDClosure* weak_clds()             { return &_closures._clds; }
   CLDClosure* strong_clds()           { return &_closures._clds; }
 
-  CodeBlobClosure* strong_codeblobs()      { return &_closures._strong_codeblobs; }
-  CodeBlobClosure* weak_codeblobs()        { return &_closures._weak_codeblobs; }
+  CodeBlobClosure* weak_codeblobs()   { return &_closures._codeblobs; }
+  CodeBlobClosure* strong_codeblobs() { return &_closures._codeblobs; }
 };
 
 // Closures used during concurrent start.
@@ -67,8 +67,8 @@ public:
   CLDClosure* weak_clds()             { return &_weak._clds; }
   CLDClosure* strong_clds()           { return &_strong._clds; }
 
-  CodeBlobClosure* strong_codeblobs()      { return &_strong._strong_codeblobs; }
-  CodeBlobClosure* weak_codeblobs()        { return &_weak._weak_codeblobs; }
+  CodeBlobClosure* strong_codeblobs() { return &_strong._codeblobs; }
+  CodeBlobClosure* weak_codeblobs()   { return &_weak._codeblobs; }
 };
 
 G1EvacuationRootClosures* G1EvacuationRootClosures::create_root_closures(G1ParScanThreadState* pss, G1CollectedHeap* g1h) {

--- a/src/hotspot/share/gc/g1/g1SharedClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1SharedClosures.hpp
@@ -45,14 +45,12 @@ public:
   G1ParCopyClosure<G1BarrierNoOptRoots, should_mark> _oops_in_nmethod;
 
   G1CLDScanClosure                _clds;
-  G1CodeBlobClosure               _strong_codeblobs;
-  G1CodeBlobClosure               _weak_codeblobs;
+  G1CodeBlobClosure               _codeblobs;
 
   G1SharedClosures(G1CollectedHeap* g1h, G1ParScanThreadState* pss, bool process_only_dirty) :
     _oops(g1h, pss),
     _oops_in_cld(g1h, pss),
     _oops_in_nmethod(g1h, pss),
     _clds(&_oops_in_cld, process_only_dirty),
-    _strong_codeblobs(pss->worker_id(), &_oops_in_nmethod, should_mark, true),
-    _weak_codeblobs(pss->worker_id(), &_oops_in_nmethod, should_mark, false) {}
+    _codeblobs(pss->worker_id(), &_oops_in_nmethod, should_mark) {}
 };


### PR DESCRIPTION
There's no need to introduce a new _keepalive_is_strong property in the G1CodeBlobClosure. The existing _strong is set to true when the evacuation participates in the marking of the old gen, which is when we need to mark the nmethods as "maybe on continuation". The name _strong in this context is not great and it doesn't convey the actual meaning. Maybe something for a future G1 cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - no project role)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.java.net/loom pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/112.diff">https://git.openjdk.java.net/loom/pull/112.diff</a>

</details>
