### PR TITLE
Small fixes - shipment one

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -209,7 +209,7 @@ frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   if (caller.is_interpreted_frame()) {
     assert (!caller.is_empty(), "");
@@ -308,9 +308,8 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
-  assert (!bottom || caller.fp() == _cont.entryFP(), "");
   patch_callee_link(caller, caller.fp());
 }
 

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -102,7 +102,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
@@ -139,7 +139,7 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -102,7 +102,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
@@ -139,7 +139,7 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -102,7 +102,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
@@ -139,7 +139,7 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -206,7 +206,7 @@ frame Freeze<ConfigT>::new_hframe(frame& f, frame& caller) {
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   if (caller.is_interpreted_frame()) {
     assert(!caller.is_empty(), "");
@@ -298,9 +298,8 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
-  assert(!bottom || caller.fp() == _cont.entryFP(), "");
   patch_callee_link(caller, caller.fp());
 }
 

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -102,7 +102,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
 }
 
 template <typename ConfigT>
-template <typename FKind, bool bottom>
+template <typename FKind>
 inline void Freeze<ConfigT>::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
@@ -139,7 +139,7 @@ inline intptr_t* Thaw<ConfigT>::align(const frame& hf, intptr_t* vsp, frame& cal
 }
 
 template <typename ConfigT>
-template<typename FKind, bool bottom>
+template<typename FKind>
 inline void Thaw<ConfigT>::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
 }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1031,7 +1031,6 @@ private:
   const bool _preempt; // used only on the slow path
 
   intptr_t *_bottom_address;
-  intptr_t *_top_address;
 
   int _size; // total size of all frames plus metadata in words.
   int _align_size;
@@ -1328,7 +1327,6 @@ public:
       f.print_on(&ls);
     }
 
-    _top_address = f.sp();
     frame caller;
     freeze_result res = freeze(f, caller, 0, false, true);
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1048,7 +1048,8 @@ public:
   Freeze(JavaThread* thread, ContMirror& mirror, bool preempt) :
       _thread(thread), _cont(mirror), _barriers(false), _preempt(preempt) {
 
-    assert(thread->last_continuation()->entry_sp() == _cont.entrySP(), "");
+    assert(_thread != nullptr, "");
+    assert(_thread->last_continuation()->entry_sp() == _cont.entrySP(), "");
 
     int argsize = _cont.argsize();
     _bottom_address = _cont.entrySP() - argsize;
@@ -1093,10 +1094,9 @@ public:
 
   // Called _after_ the last possible sfepoint during the freeze operation (chunk allocation)
   void unwind_frames() {
-    JavaThread* thread = _thread;
     ContinuationEntry* entry = _cont.entry();
-    ContinuationHelper::maybe_flush_stack_processing(thread, entry);
-    ContinuationHelper::set_anchor_to_entry(thread, entry);
+    ContinuationHelper::maybe_flush_stack_processing(_thread, entry);
+    ContinuationHelper::set_anchor_to_entry(_thread, entry);
   }
 
   template <bool chunk_available>
@@ -1104,7 +1104,7 @@ public:
     if (freeze_fast<chunk_available>(sp)) {
       return freeze_ok;
     }
-    if (_thread != nullptr && _thread->has_pending_exception()) {
+    if (_thread->has_pending_exception()) {
       return freeze_exception;
     }
 
@@ -1155,10 +1155,16 @@ public:
 
   template <bool chunk_available>
   bool freeze_fast(intptr_t* top_sp) {
+<<<<<<< HEAD
     assert(_thread != nullptr, "");
     assert(_cont.chunk_invariant(tty), "");
     assert(!Interpreter::contains(_cont.entryPC()), "");
     assert(StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
+=======
+    assert (_cont.chunk_invariant(tty), "");
+    assert (!Interpreter::contains(_cont.entryPC()), "");
+    assert (StubRoutines::cont_doYield_stub()->frame_size() == ContinuationHelper::frame_metadata, "");
+>>>>>>> 157d5a80961 (Freeze::_thread fixes)
 
     // properties of the continuation on the stack; all sizes are in words
     intptr_t* const stack_top     = top_sp + ContinuationHelper::frame_metadata;

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1224,9 +1224,7 @@ public:
       assert(_thread->cont_fastpath(), "");
 
       chunk = allocate_chunk(size + ContinuationHelper::frame_metadata);
-      if (UNLIKELY(chunk == nullptr)) return false; // OOME
-      if (UNLIKELY(!_thread->cont_fastpath()
-                  || _barriers)) { // probably humongous
+      if (UNLIKELY(chunk == nullptr || !_thread->cont_fastpath() || _barriers)) { // OOME/probably humongous
         log_develop_trace(jvmcont)("Retrying slow. Barriers: %d", _barriers);
         init_empty_chunk(chunk);
         return false;

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1182,7 +1182,7 @@ public:
 
       assert(is_chunk_available0, "");
 
-      if (chunk_start_sp < chunk->stack_size()) { // we are copying into a non-empty chunk
+      if (chunk->sp() < chunk->stack_size()) { // we are copying into a non-empty chunk
         DEBUG_ONLY(empty = false;)
         assert(chunk_start_sp < (chunk->stack_size() - chunk->argsize()), "");
         assert(*(address*)(chunk->sp_address() - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -772,7 +772,9 @@ javaVFrame* Continuation::last_java_vframe(Handle continuation, RegisterMap *map
   if (!ContMirror(continuation()).is_empty()) {
     frame f = last_frame(continuation(), map);
     for (vframe* vf = vframe::new_vframe(&f, map, nullptr); vf; vf = vf->sender()) {
-      if (vf->is_java_frame()) return javaVFrame::cast(vf);
+      if (vf->is_java_frame()) {
+        return javaVFrame::cast(vf);
+      }
     }
   }
   return nullptr;
@@ -930,7 +932,9 @@ void Continuation::notify_deopt(JavaThread* thread, intptr_t* sp) {
     cont = cont->parent();
   } while (cont != nullptr && !is_sp_in_continuation(cont, sp));
 
-  if (cont == nullptr) return;
+  if (cont == nullptr) {
+    return;
+  }
   assert(is_sp_in_continuation(cont, sp), "");
   if (sp > prev->parent_cont_fastpath()) {
     prev->set_parent_cont_fastpath(sp);

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1183,7 +1183,7 @@ public:
 
       if (chunk->sp() < chunk->stack_size()) { // we are copying into a non-empty chunk
         DEBUG_ONLY(empty = false;)
-        assert(chunk_start_sp < (chunk->stack_size() - chunk->argsize()), "");
+        assert(chunk->sp() < (chunk->stack_size() - chunk->argsize()), "");
         assert(*(address*)(chunk->sp_address() - frame::sender_sp_ret_address_offset()) == chunk->pc(), "");
 
         chunk_start_sp = chunk->sp() + _cont.argsize(); // we overlap; we'll overwrite the chunk's top frame's callee arguments

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1168,7 +1168,7 @@ public:
     assert(cont_size > 0, "");
 
   #ifdef ASSERT
-    bool allocated, empty;
+    bool empty = true;
     int is_chunk_available_size;
     bool is_chunk_available0 = is_chunk_available(top_sp, &is_chunk_available_size);
     intptr_t* orig_chunk_sp = nullptr;
@@ -1177,7 +1177,6 @@ public:
     stackChunkOop chunk = _cont.tail();
     int chunk_start_sp; // the chunk's sp before the freeze, adjusted to point beyond the stack-passed arguments in the topmost frame
     if (chunk_available) { // LIKELY
-      DEBUG_ONLY(allocated = false;)
       DEBUG_ONLY(orig_chunk_sp = chunk->sp_address();)
 
       assert(is_chunk_available0, "");
@@ -1200,15 +1199,12 @@ public:
       } else { // the chunk is empty
         chunk_start_sp = chunk->sp();
 
-        DEBUG_ONLY(empty = true;)
         assert(chunk_start_sp == chunk->stack_size(), "");
 
         chunk->set_max_size(cont_size);
         chunk->set_argsize(_cont.argsize());
       }
     } else { // no chunk; allocate
-      DEBUG_ONLY(empty = true; allocated = true;)
-
       assert(_thread->thread_state() == _thread_in_vm, "");
       assert(!is_chunk_available(top_sp), "");
       assert(_thread->cont_fastpath(), "");

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -459,7 +459,9 @@ inline void ContMirror::post_safepoint(Handle conth) {
 
 const frame ContMirror::last_frame() {
   stackChunkOop chunk = last_nonempty_chunk();
-  if (chunk == nullptr) return frame();
+  if (chunk == nullptr) {
+    return frame();
+  }
   return StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame();
 }
 
@@ -669,7 +671,9 @@ ContinuationEntry* Continuation::get_continuation_entry_for_continuation(JavaThr
   }
 
   for (ContinuationEntry* entry = thread->last_continuation(); entry != nullptr; entry = entry->parent()) {
-    if (cont == entry->continuation()) return entry;
+    if (cont == entry->continuation()) {
+      return entry;
+    }
   }
   return nullptr;
 }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -249,8 +249,6 @@ public:
   }
 };
 
-class SmallRegisterMap;
-
 class ContinuationHelper {
 public:
   static const int frame_metadata; // size, in words, of frame metadata (e.g. pc and link)

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -174,10 +174,10 @@ Address |   |                            |    |   Caller is still in the chunk.
 #ifdef ASSERT
 extern "C" bool dbg_is_safe(const void* p, intptr_t errvalue); // address p is readable and *(intptr_t*)p != errvalue
 
-template<int x> NOINLINE static bool verify_continuation(oop cont) { return Continuation::debug_verify_continuation(cont); }
-#define VERIFY_CONTINUATION(cont) verify_continuation<__LINE__>((cont))
-template<int x> NOINLINE static bool verify_stack_chunk(oop chunk) { return InstanceStackChunkKlass::verify(chunk); }
-#define VERIFY_STACK_CHUNK(chunk) verify_stack_chunk<__LINE__>((chunk))
+NOINLINE static bool verify_continuation(oop cont) { return Continuation::debug_verify_continuation(cont); }
+#define VERIFY_CONTINUATION(cont) verify_continuation((cont))
+NOINLINE static bool verify_stack_chunk(oop chunk) { return InstanceStackChunkKlass::verify(chunk); }
+#define VERIFY_STACK_CHUNK(chunk) verify_stack_chunk((chunk))
 
 static void do_deopt_after_thaw(JavaThread* thread);
 static bool do_verify_after_thaw(JavaThread* thread, int mode, bool barriers, stackChunkOop chunk, outputStream* st);


### PR DESCRIPTION
Reducing the number of variables, the number of assignment to each variable, white-spaces, renamed some variables, removed unnecessary template, etc...
Except the removal of template 'bottom', the code is the same. (assert is moved up one level)

Passes 1-3 (no new failures)
It seem to be slightly faster than before, but at least on par.

This is not complete at all, but to avoid merge conflict I want to ship, and also make someone happy about removing a template.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.java.net/loom pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/114.diff">https://git.openjdk.java.net/loom/pull/114.diff</a>

</details>
