### PR TITLE
Garbage collectors explicitly transform stack chunk

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -40,7 +40,6 @@
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/collectedHeap.hpp"
-#include "gc/shared/continuationGCSupport.inline.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "logging/log.hpp"
@@ -286,6 +285,8 @@ void HeapShared::clear_root(int index) {
 oop HeapShared::archive_object(oop obj) {
   assert(DumpSharedSpaces, "dump-time only");
 
+  assert(!obj->is_stackChunk(), "do not archive stack chunks");
+
   oop ao = find_archived_heap_object(obj);
   if (ao != NULL) {
     // already archived
@@ -302,7 +303,6 @@ oop HeapShared::archive_object(oop obj) {
   oop archived_oop = cast_to_oop(G1CollectedHeap::heap()->archive_mem_allocate(len));
   if (archived_oop != NULL) {
     Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), cast_from_oop<HeapWord*>(archived_oop), len);
-    ContinuationGCSupport::transform_stack_chunk(archived_oop);
     // Reinitialize markword to remove age/marking/locking/etc.
     //
     // We need to retain the identity_hash, because it may have been used by some hashtables

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -40,6 +40,7 @@
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/continuationGCSupport.inline.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "logging/log.hpp"
@@ -300,7 +301,8 @@ oop HeapShared::archive_object(oop obj) {
 
   oop archived_oop = cast_to_oop(G1CollectedHeap::heap()->archive_mem_allocate(len));
   if (archived_oop != NULL) {
-    obj->copy_disjoint(cast_from_oop<HeapWord*>(archived_oop), len);
+    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), cast_from_oop<HeapWord*>(archived_oop), len);
+    ContinuationGCSupport::transform_stack_chunk(archived_oop);
     // Reinitialize markword to remove age/marking/locking/etc.
     //
     // We need to retain the identity_hash, because it may have been used by some hashtables

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -87,7 +87,8 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
   HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
   assert(size <= INT_MAX, "sanity check");
   assert(obj_addr != destination, "everything in this pass should be moving or compressed in place");
-  obj->copy_conjoint(destination, size);
+  Copy::aligned_conjoint_words(obj_addr, destination, size);
+  // There is no need to transform potential stack chunks - marking already did that.
   cast_to_oop(destination)->init_mark();
   assert(cast_to_oop(destination)->klass() != NULL, "should have a class");
 

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -88,7 +88,8 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
   assert(size <= INT_MAX, "sanity check");
   assert(obj_addr != destination, "everything in this pass should be moving or compressed in place");
   Copy::aligned_conjoint_words(obj_addr, destination, size);
-  // There is no need to transform potential stack chunks - marking already did that.
+
+  // There is no need to transform stack chunks - marking already did that.
   cast_to_oop(destination)->init_mark();
   assert(cast_to_oop(destination)->klass() != NULL, "should have a class");
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -486,7 +486,7 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
 
   // We're going to allocate linearly, so might as well prefetch ahead.
   Prefetch::write(obj_ptr, PrefetchCopyIntervalInBytes);
-  old->copy_disjoint(obj_ptr, word_sz);
+  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(old), obj_ptr, word_sz);
 
   const oop obj = cast_to_oop(obj_ptr);
   // Because the forwarding is done with memory_order_relaxed there is no
@@ -526,6 +526,8 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
       }
       return obj;
     }
+
+    ContinuationGCSupport::transform_stack_chunk(obj);
 
     // Check for deduplicating young Strings.
     if (G1StringDedup::is_candidate_from_evacuation(klass,

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -737,7 +737,8 @@ oop DefNewGeneration::copy_to_survivor_space(oop old) {
     Prefetch::write(obj, interval);
 
     // Copy obj
-    old->copy_disjoint(cast_from_oop<HeapWord*>(obj), s);
+    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(old), cast_from_oop<HeapWord*>(obj), s);
+    ContinuationGCSupport::transform_stack_chunk(obj);
 
     // Increment age if obj still in new generation
     obj->incr_age();

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -1229,18 +1229,3 @@ void GenCollectedHeap::ensure_parsability(bool retire_tlabs) {
   GenEnsureParsabilityClosure ep_cl;
   generation_iterate(&ep_cl, false);
 }
-
-oop GenCollectedHeap::handle_failed_promotion(Generation* old_gen,
-                                              oop obj,
-                                              size_t obj_size) {
-  guarantee(old_gen == _old_gen, "We only get here with an old generation");
-  assert(obj_size == obj->size(), "bad obj_size passed in");
-  HeapWord* result = NULL;
-
-  result = old_gen->expand_and_allocate(obj_size, false);
-
-  if (result != NULL) {
-    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), result, obj_size);
-  }
-  return cast_to_oop(result);
-}

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -1240,7 +1240,7 @@ oop GenCollectedHeap::handle_failed_promotion(Generation* old_gen,
   result = old_gen->expand_and_allocate(obj_size, false);
 
   if (result != NULL) {
-    obj->copy_disjoint(result, obj_size);
+    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), result, obj_size);
   }
   return cast_to_oop(result);
 }

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -554,7 +554,9 @@ void CompactibleSpace::compact() {
 
       // copy object and reinit its mark
       assert(cur_obj != compaction_top, "everything in this pass should be moving");
-      cast_to_oop(cur_obj)->copy_conjoint(compaction_top, size);
+      Copy::aligned_conjoint_words(cur_obj, compaction_top, size);
+
+      ContinuationGCSupport::transform_stack_chunk(cast_to_oop(compaction_top));
       cast_to_oop(compaction_top)->init_mark();
       assert(cast_to_oop(compaction_top)->klass() != NULL, "should have a class");
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -555,10 +555,11 @@ void CompactibleSpace::compact() {
       // copy object and reinit its mark
       assert(cur_obj != compaction_top, "everything in this pass should be moving");
       Copy::aligned_conjoint_words(cur_obj, compaction_top, size);
+      oop new_obj = cast_to_oop(compaction_top);
 
-      ContinuationGCSupport::transform_stack_chunk(cast_to_oop(compaction_top));
-      cast_to_oop(compaction_top)->init_mark();
-      assert(cast_to_oop(compaction_top)->klass() != NULL, "should have a class");
+      ContinuationGCSupport::transform_stack_chunk(new_obj);
+      new_obj->init_mark();
+      assert(new_obj->klass() != NULL, "should have a class");
 
       debug_only(prev_obj = cur_obj);
       cur_obj += size;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -842,10 +842,9 @@ public:
       HeapWord* compact_from = cast_from_oop<HeapWord*>(p);
       HeapWord* compact_to = cast_from_oop<HeapWord*>(p->forwardee());
       Copy::aligned_conjoint_words(compact_from, compact_to, size);
-
       oop new_obj = cast_to_oop(compact_to);
-      ContinuationGCSupport::transform_stack_chunk(new_obj);
 
+      ContinuationGCSupport::transform_stack_chunk(new_obj);
       new_obj->init_mark();
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -957,7 +957,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());
 
       Copy::aligned_conjoint_words(r->bottom(), heap->get_region(new_start)->bottom(), words_size);
-      assert(!old_obj->is_stackChunk(), "We assume that stack chunks are not humongous.");
+      ContinuationGCSupport::transform_stack_chunk(cast_to_oop<HeapWord*>(r->bottom()));
 
       oop new_obj = cast_to_oop(heap->get_region(new_start)->bottom());
       new_obj->init_mark();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -958,9 +958,9 @@ void ShenandoahFullGC::compact_humongous_objects() {
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());
 
       Copy::aligned_conjoint_words(r->bottom(), heap->get_region(new_start)->bottom(), words_size);
+      assert(!old_obj->is_stackChunk(), "We assume that stack chunks are not humongous.");
 
       oop new_obj = cast_to_oop(heap->get_region(new_start)->bottom());
-      ContinuationGCSupport::transform_stack_chunk(new_obj);
       new_obj->init_mark();
 
       {

--- a/src/hotspot/share/gc/z/zUtils.inline.hpp
+++ b/src/hotspot/share/gc/z/zUtils.inline.hpp
@@ -46,7 +46,7 @@ inline size_t ZUtils::object_size(uintptr_t addr) {
 }
 
 inline void ZUtils::object_copy_disjoint(uintptr_t from, uintptr_t to, size_t size) {
-  Copy::aligned_disjoint_words((HeapWord*)from, (HeapWord*) to, bytes_to_words(size));
+  Copy::aligned_disjoint_words((HeapWord*)from, (HeapWord*)to, bytes_to_words(size));
 }
 
 inline void ZUtils::object_copy_conjoint(uintptr_t from, uintptr_t to, size_t size) {

--- a/src/hotspot/share/gc/z/zUtils.inline.hpp
+++ b/src/hotspot/share/gc/z/zUtils.inline.hpp
@@ -46,12 +46,12 @@ inline size_t ZUtils::object_size(uintptr_t addr) {
 }
 
 inline void ZUtils::object_copy_disjoint(uintptr_t from, uintptr_t to, size_t size) {
-  ZOop::from_address(from)->copy_disjoint((HeapWord*)to, bytes_to_words(size));
+  Copy::aligned_disjoint_words((HeapWord*)from, (HeapWord*) to, bytes_to_words(size));
 }
 
 inline void ZUtils::object_copy_conjoint(uintptr_t from, uintptr_t to, size_t size) {
   if (from != to) {
-    ZOop::from_address(from)->copy_conjoint((HeapWord*)to, bytes_to_words(size));
+    Copy::aligned_conjoint_words((HeapWord*)from, (HeapWord*)to, bytes_to_words(size));
   }
 }
 

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -51,7 +51,6 @@
 #include "runtime/smallRegisterMap.inline.hpp"
 #include "runtime/stackChunkFrameStream.inline.hpp"
 #include "utilities/bitMap.inline.hpp"
-#include "utilities/copy.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
@@ -82,33 +81,6 @@ InstanceStackChunkKlass::InstanceStackChunkKlass(const ClassFileParser& parser)
 size_t InstanceStackChunkKlass::oop_size(oop obj) const {
   // see oopDesc::size_given_klass
   return instance_size(jdk_internal_vm_StackChunk::size(obj));
-}
-
-size_t InstanceStackChunkKlass::copy(oop obj, HeapWord* to_addr, size_t word_size, bool disjoint) {
-  assert(obj->is_stackChunk(), "Wrong object type");
-
-  HeapWord* from_addr = cast_from_oop<HeapWord*>(obj);
-
-  disjoint ? Copy::aligned_disjoint_words(from_addr, to_addr, word_size)
-           : Copy::aligned_conjoint_words(from_addr, to_addr, word_size);
-
-  // Build bitmap
-  stackChunkOop to_chunk = (stackChunkOop) cast_to_oop(to_addr);
-  if (!to_chunk->has_bitmap()) {
-    build_bitmap(to_chunk);
-  } else {
-    assert(to_chunk->is_gc_mode(), "Should be set when bitmaps were built");
-  }
-
-  return word_size;
-}
-
-void InstanceStackChunkKlass::copy_disjoint(oop obj, HeapWord* to, size_t word_size) {
-  copy(obj, to, word_size, true /* disjoint */);
-}
-
-void InstanceStackChunkKlass::copy_conjoint(oop obj, HeapWord* to, size_t word_size) {
-  copy(obj, to, word_size, false /* disjoint */);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -140,9 +140,6 @@ public:
   // Returns the size of the instance including the stack data.
   virtual size_t oop_size(oop obj) const override;
 
-  virtual void copy_disjoint(oop obj, HeapWord* to, size_t word_size) override;
-  virtual void copy_conjoint(oop obj, HeapWord* to, size_t word_size) override;
-
   static void serialize_offsets(class SerializeClosure* f) NOT_CDS_RETURN;
 
   static void print_chunk(const stackChunkOop chunk, bool verbose, outputStream* st = tty);

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -164,7 +164,6 @@ void InstanceStackChunkKlass::oop_oop_iterate_stack(stackChunkOop chunk, OopClos
   if (LIKELY(chunk->has_bitmap())) {
     oop_oop_iterate_stack_helper(chunk, closure, chunk->sp_address() - metadata_words(), chunk->end_address());
   } else {
-    guarantee(!UseG1GC && !UseParallelGC && !UseSerialGC, "Scavenging collectors should always use bitmap");
     oop_oop_iterate_stack_slow(chunk, closure, chunk->range());
   }
 }

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -164,6 +164,7 @@ void InstanceStackChunkKlass::oop_oop_iterate_stack(stackChunkOop chunk, OopClos
   if (LIKELY(chunk->has_bitmap())) {
     oop_oop_iterate_stack_helper(chunk, closure, chunk->sp_address() - metadata_words(), chunk->end_address());
   } else {
+    guarantee(!UseG1GC && !UseParallelGC && !UseSerialGC, "Scavenging collectors should always use bitmap");
     oop_oop_iterate_stack_slow(chunk, closure, chunk->range());
   }
 }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -49,7 +49,6 @@
 #include "runtime/arguments.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
-#include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/powerOfTwo.hpp"
 #include "utilities/stack.inline.hpp"
@@ -709,14 +708,6 @@ const char* Klass::signature_name() const {
     return result;
   }
   return name()->as_C_string();
-}
-
-void Klass::copy_disjoint(oop obj, HeapWord* to, size_t word_size) {
-  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), to, word_size);
-}
-
-void Klass::copy_conjoint(oop obj, HeapWord* to, size_t word_size) {
-  Copy::aligned_conjoint_words(cast_from_oop<HeapWord*>(obj), to, word_size);
 }
 
 const char* Klass::external_kind() const {

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -594,9 +594,6 @@ protected:
   // Returns "interface", "abstract class" or "class".
   const char* external_kind() const;
 
-  virtual void copy_disjoint(oop obj, HeapWord* to, size_t word_size);
-  virtual void copy_conjoint(oop obj, HeapWord* to, size_t word_size);
-
   // type testing operations
 #ifdef ASSERT
  protected:

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -35,7 +35,6 @@
 #include "oops/verifyOopClosure.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/thread.inline.hpp"
-#include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
 
 void oopDesc::print_on(outputStream* st) const {

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -106,10 +106,6 @@ class oopDesc {
   // to be able to figure out the size of an object knowing its klass.
   inline size_t size_given_klass(Klass* klass);
 
-  // Copies the object
-  inline void copy_disjoint(HeapWord* to, size_t word_size);
-  inline void copy_conjoint(HeapWord* to, size_t word_size);
-
   // type test operations (inlined in oop.inline.hpp)
   inline bool is_instance()            const;
   inline bool is_array()               const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -38,7 +38,6 @@
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "utilities/align.hpp"
-#include "utilities/copy.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -381,26 +380,6 @@ bool oopDesc::mark_must_be_preserved() const {
 
 bool oopDesc::mark_must_be_preserved(markWord m) const {
   return m.must_be_preserved(this);
-}
-
-void oopDesc::copy_disjoint(HeapWord* to, size_t word_size) {
-  assert(word_size == (size_t)size() || size_might_change(), "");
-  int lh = klass()->layout_helper();
-  if (lh > Klass::_lh_neutral_value && Klass::layout_helper_needs_slow_path(lh)) {
-    klass()->copy_disjoint(this, to, word_size);
-  } else {
-    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(this), to, word_size);
-  }
-}
-
-void oopDesc::copy_conjoint(HeapWord* to, size_t word_size) {
-  assert(word_size == (size_t)size() || size_might_change(), "");
-  int lh = klass()->layout_helper();
-  if (lh > Klass::_lh_neutral_value && Klass::layout_helper_needs_slow_path(lh)) {
-    klass()->copy_conjoint(this, to, word_size);
-  } else {
-    Copy::aligned_conjoint_words(cast_from_oop<HeapWord*>(this), to, word_size);
-  }
 }
 
 #endif // SHARE_OOPS_OOP_INLINE_HPP


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes garbage collectors explicitly transform stack chunks instead of relying on magic happening in `InstanceStackChunkKlass::copy_dis/conjoint`.

It also contains some refactoring suggested by @stefank in `Generation::promote`. Other than that it is a fairly straightforward change to replace `InstanceStackChunkKlass::copy_dis/conjoint` calls with explicit calls to `Copy::aligned_dis/conjoint_words` and `ContinuationGCSupport::transform_stack_chunk`.

This reduces code, and makes the code more understandable.

Test: tier1-5

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - no project role)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.java.net/loom pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/116.diff">https://git.openjdk.java.net/loom/pull/116.diff</a>

</details>
