### PR TITLE
Renamed ContMirror ContinuationWrapper, make cont variable names into…

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -93,8 +93,8 @@ frame ContinuationEntry::to_frame() const {
 }
 
 
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  anchor->set_last_Java_fp(cont->entry_fp());
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry) {
+  anchor->set_last_Java_fp(entry->entry_fp());
 }
 
 void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -91,8 +91,8 @@ frame ContinuationEntry::to_frame() const {
   return frame(entry_sp(), entry_sp(), entry_fp(), entry_pc(), cb);
 }
 
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  anchor->set_last_Java_fp(cont->entry_fp());
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry) {
+  anchor->set_last_Java_fp(entry->entry_fp());
 }
 
 void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2771,7 +2771,7 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
   bool skip_throwableInit_check = false;
   bool skip_hidden = !ShowHiddenFrames;
   bool show_carrier = ShowCarrierFrames;
-  ContinuationEntry* cont = thread->last_continuation();
+  ContinuationEntry* cont_entry = thread->last_continuation();
   for (frame fr = thread->last_frame(); max_depth == 0 || max_depth != total_count;) {
     Method* method = NULL;
     int bci = 0;
@@ -2786,11 +2786,11 @@ void java_lang_Throwable::fill_in_stack_trace(Handle throwable, const methodHand
       if (fr.is_first_frame()) break;
 
       if (Continuation::is_continuation_enterSpecial(fr)) {
-        assert(cont == Continuation::get_continuation_entry_for_entry_frame(thread, fr), "");
-        if (!show_carrier && cont->is_virtual_thread()) {
+        assert(cont_entry == Continuation::get_continuation_entry_for_entry_frame(thread, fr), "");
+        if (!show_carrier && cont_entry->is_virtual_thread()) {
           break;
         }
-        cont = cont->parent();
+        cont_entry = cont_entry->parent();
       }
 
       address pc = fr.pc();

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1283,11 +1283,11 @@ JvmtiEnvBase::cthread_with_mounted_vthread(JavaThread* jt) {
 
 bool
 JvmtiEnvBase::cthread_with_continuation(JavaThread* jt) {
-  const ContinuationEntry* cont = NULL;
+  const ContinuationEntry* cont_entry = NULL;
   if (jt->has_last_Java_frame()) {
-    cont = jt->vthread_continuation();
+    cont_entry = jt->vthread_continuation();
   }
-  return (cont != NULL && cthread_with_mounted_vthread(jt));
+  return (cont_entry != NULL && cthread_with_mounted_vthread(jt));
 }
 
 jvmtiError

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,10 +93,10 @@ LiveFrameStream::LiveFrameStream(JavaThread* thread, RegisterMap* rm, Handle con
     _map = rm;
     if (cont.is_null()) {
       _jvf  = thread->last_java_vframe(rm);
-      _cont = thread->last_continuation();
+      _cont_entry = thread->last_continuation();
     } else {
       _jvf  = Continuation::last_java_vframe(cont, rm);
-      _cont = NULL;
+      _cont_entry = NULL;
     }
 }
 
@@ -116,7 +116,7 @@ void LiveFrameStream::next() {
       _jvf = NULL;
       return;
     }
-    _cont = _cont->parent();
+    _cont_entry = _cont_entry->parent();
   }
   assert(!Continuation::is_scope_bottom(_cont_scope(), _jvf->fr(), _jvf->register_map()), "");
 

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ private:
 
   RegisterMap*        _map;
   javaVFrame*         _jvf;
-  ContinuationEntry* _cont;
+  ContinuationEntry*  _cont_entry;
 
   void fill_live_stackframe(Handle stackFrame, const methodHandle& method, TRAPS);
   static oop create_primitive_slot_instance(StackValueCollection* values,
@@ -133,7 +133,7 @@ public:
 
   Method* method() override { return _jvf->method(); }
   int bci()        override { return _jvf->bci(); }
-  oop cont() override { return continuation() != NULL ? continuation(): _cont->cont_oop(); }
+  oop cont() override { return continuation() != NULL ? continuation(): _cont_entry->cont_oop(); }
 
   void fill_frame(int index, objArrayHandle  frames_array,
                   const methodHandle& method, TRAPS) override;

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -63,9 +63,9 @@ public:
 
   static ContinuationEntry* get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f) {
     assert(is_continuation_enterSpecial(f), "");
-    ContinuationEntry* cont = (ContinuationEntry*)f.unextended_sp();
-    assert(cont == get_continuation_entry_for_sp(thread, f.sp()-2), "mismatched entry");
-    return cont;
+    ContinuationEntry* entry = (ContinuationEntry*)f.unextended_sp();
+    assert(entry == get_continuation_entry_for_sp(thread, f.sp()-2), "mismatched entry");
+    return entry;
   }
 
   static bool is_continuation_mounted(JavaThread* thread, oop cont);
@@ -76,10 +76,10 @@ public:
   static bool is_continuation_enterSpecial(const frame& f);
   static bool is_continuation_entry_frame(const frame& f, const RegisterMap *map);
 
-  static bool is_frame_in_continuation(const ContinuationEntry* cont, const frame& f);
+  static bool is_frame_in_continuation(const ContinuationEntry* entry, const frame& f);
   static bool is_frame_in_continuation(JavaThread* thread, const frame& f);
 
-  static bool has_last_Java_frame(oop continuation);
+  static bool has_last_Java_frame(oop continuation, frame* frame, RegisterMap* map);
   static frame last_frame(oop continuation, RegisterMap *map);
   static frame top_frame(const frame& callee, RegisterMap* map);
   static javaVFrame* last_java_vframe(Handle continuation, RegisterMap *map);

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -54,11 +54,11 @@ public:
   static int prepare_thaw(JavaThread* thread, bool return_barrier);
   static address thaw_entry();
   // static intptr_t* thaw(JavaThread* thread, int kind);
-  static int try_force_yield(JavaThread* thread, oop cont);
+  static int try_force_yield(JavaThread* thread, oop continuation);
   static void jump_from_safepoint(JavaThread* thread);
 
   static const ContinuationEntry* last_continuation(const JavaThread* thread, oop cont_scope);
-  static ContinuationEntry* get_continuation_entry_for_continuation(JavaThread* thread, oop cont);
+  static ContinuationEntry* get_continuation_entry_for_continuation(JavaThread* thread, oop continuation);
   static ContinuationEntry* get_continuation_entry_for_sp(JavaThread* thread, intptr_t* const sp);
 
   static ContinuationEntry* get_continuation_entry_for_entry_frame(JavaThread* thread, const frame& f) {
@@ -68,7 +68,7 @@ public:
     return entry;
   }
 
-  static bool is_continuation_mounted(JavaThread* thread, oop cont);
+  static bool is_continuation_mounted(JavaThread* thread, oop continuation);
   static bool is_continuation_scope_mounted(JavaThread* thread, oop cont_scope);
 
   static bool is_cont_barrier_frame(const frame& f);
@@ -85,7 +85,7 @@ public:
   static javaVFrame* last_java_vframe(Handle continuation, RegisterMap *map);
   static frame continuation_parent_frame(RegisterMap* map);
 
-  static oop continuation_scope(oop cont);
+  static oop continuation_scope(oop continuation);
   static bool is_scope_bottom(oop cont_scope, const frame& fr, const RegisterMap* map);
 
   static bool is_in_usable_stack(address addr, const RegisterMap* map);
@@ -111,8 +111,8 @@ private:
 
 #ifdef ASSERT
 public:
-  static bool debug_verify_continuation(oop cont);
-  static void debug_print_continuation(oop cont, outputStream* st = NULL);
+  static bool debug_verify_continuation(oop continuation);
+  static void debug_print_continuation(oop continuation, outputStream* st = NULL);
 #endif
 };
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1595,8 +1595,8 @@ bool JavaThread::is_lock_owned(address adr) const {
 
 bool JavaThread::is_lock_owned_current(address adr) const {
   address stack_end = _stack_base - _stack_size;
-  const ContinuationEntry* cont = vthread_continuation();
-  address stack_base = cont != nullptr ? (address)cont->entry_sp() : _stack_base;
+  const ContinuationEntry* ce = vthread_continuation();
+  address stack_base = ce != nullptr ? (address)ce->entry_sp() : _stack_base;
   if (stack_base > adr && adr >= stack_end) {
     return true;
   }
@@ -2528,13 +2528,13 @@ void JavaThread::trace_stack() {
 #endif // PRODUCT
 
 frame JavaThread::vthread_carrier_last_frame(RegisterMap* reg_map) {
-  const ContinuationEntry* cont = vthread_continuation();
-  guarantee (cont != NULL, "Not a carrier thread");
-  frame f = cont->to_frame();
+  const ContinuationEntry* entry = vthread_continuation();
+  guarantee (entry != NULL, "Not a carrier thread");
+  frame f = entry->to_frame();
   if (reg_map->process_frames()) {
-    cont->flush_stack_processing(this);
+    entry->flush_stack_processing(this);
   }
-  cont->update_register_map(reg_map);
+  entry->update_register_map(reg_map);
   return f.sender(reg_map);
 }
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1195,7 +1195,6 @@ private:
 
   // Continuation support
   ContinuationEntry* last_continuation() const { return _cont_entry; }
-  const ContinuationEntry* last_continuation(oop cont_scope) const { return Continuation::last_continuation(this, cont_scope); }
   bool cont_yield() { return _cont_yield; }
   void set_cont_yield(bool x) { _cont_yield = x; }
   void set_cont_fastpath(intptr_t* x) { _cont_fastpath = x; }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -211,8 +211,8 @@ const ContinuationEntry* JavaThread::vthread_continuation() const {
 JavaThread::CarrierOrVirtual JavaThread::which_stack(address adr) const {
   address stack_end = _stack_base - _stack_size;
   if (adr >= stack_end) {
-    const ContinuationEntry* cont = vthread_continuation();
-    if (cont != nullptr && (address)cont->entry_sp() > adr) {
+    const ContinuationEntry* entry = vthread_continuation();
+    if (entry != nullptr && (address)entry->entry_sp() > adr) {
       return CarrierOrVirtual::VIRTUAL;
     }
     if (_stack_base > adr) {

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -553,7 +553,7 @@ vframeStream::vframeStream(JavaThread* thread, Handle continuation_scope, bool s
   }
 
   _frame = _thread->last_frame();
-  _cont = _thread->last_continuation();
+  _cont_entry = _thread->last_continuation();
   while (!fill_from_frame()) {
     _frame = _frame.sender(&_reg_map);
   }
@@ -565,12 +565,11 @@ vframeStream::vframeStream(oop continuation, Handle continuation_scope)
   _stop_at_java_call_stub = false;
   _continuation_scope = continuation_scope;
 
-  if (!Continuation::has_last_Java_frame(continuation)) {
+  if (!Continuation::has_last_Java_frame(continuation, &_frame, &_reg_map)) {
     _mode = at_end_mode;
     return;
   }
 
-  _frame = Continuation::last_frame(continuation, &_reg_map);
   // _chunk = _reg_map.stack_chunk();
   while (!fill_from_frame()) {
     _frame = _frame.sender(&_reg_map);

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,7 +290,7 @@ class vframeStreamCommon : StackObj {
   // Cached information
   Method* _method;
   int       _bci;
-  ContinuationEntry* _cont;
+  ContinuationEntry* _cont_entry;
 
   // Should VM activations be ignored or not
   bool _stop_at_java_call_stub;


### PR DESCRIPTION
… continuation if pointing at the Java instance.  Now cont variable names are only for the ContinuationWrapper.
There's only one non-variable name change in vframe.cpp
Running loom-tier1-3 testing in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**) ⚠️ Review applies to 903c5c04dbc2922edfeb2767363351644e23851e
 * [Patricio Chilano Mateo](https://openjdk.java.net/census#pchilanomate) (@pchilano - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.java.net/loom pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/121.diff">https://git.openjdk.java.net/loom/pull/121.diff</a>

</details>
