### PR TITLE
Lower case verify calls

### DIFF
--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -111,8 +111,9 @@ private:
 
 #ifdef ASSERT
 public:
-  static bool debug_verify_continuation(oop continuation);
-  static void debug_print_continuation(oop continuation, outputStream* st = NULL);
+  static void debug_verify_continuation(oop continuation);
+  static void print(oop continuation);
+  static void print_on(outputStream* st, oop continuation);
 #endif
 };
 


### PR DESCRIPTION
This is another cosmetic change to fix the verify functions so that there is one less null string assert.

This change also removes the copy_alignment template parameter as Patricio, Robbin and I noticed it's unused.  Which is good because then we'd have to wonder when and why it would be less than the default. Also DWORD is a windows thing so looked odd in shared code and not sure if it matches what windows thinks DWORD is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.java.net/loom pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/122.diff">https://git.openjdk.java.net/loom/pull/122.diff</a>

</details>
