### PR TITLE
Reverted unrelated, wrong or unused changes

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/prefetch_bsd_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/prefetch_bsd_aarch64.inline.hpp
@@ -35,10 +35,6 @@ inline void Prefetch::read (const void *loc, intx interval) {
     asm("prfm PLDL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));
 }
 
-inline void Prefetch::read_streaming(const void *loc, intx interval) {
-  read (loc, interval);
-}
-
 inline void Prefetch::write(void *loc, intx interval) {
   if (interval >= 0)
     asm("prfm PSTL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));

--- a/src/hotspot/os_cpu/bsd_x86/prefetch_bsd_x86.inline.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/prefetch_bsd_x86.inline.hpp
@@ -34,12 +34,6 @@ inline void Prefetch::read (const void *loc, intx interval) {
 #endif // AMD64
 }
 
-inline void Prefetch::read_streaming(const void *loc, intx interval) {
-#ifdef AMD64
-  __asm__ ("prefetchnta (%0,%1,1)" : : "r" (loc), "r" (interval));
-#endif // AMD64
-}
-
 inline void Prefetch::write(void *loc, intx interval) {
 #ifdef AMD64
 

--- a/src/hotspot/os_cpu/linux_aarch64/prefetch_linux_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/prefetch_linux_aarch64.inline.hpp
@@ -34,10 +34,6 @@ inline void Prefetch::read (const void *loc, intx interval) {
     asm("prfm PLDL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));
 }
 
-inline void Prefetch::read_streaming(const void *loc, intx interval) {
-  read (loc, interval);
-}
-
 inline void Prefetch::write(void *loc, intx interval) {
   if (interval >= 0)
     asm("prfm PSTL1KEEP, [%0, %1]" : : "r"(loc), "r"(interval));

--- a/src/hotspot/os_cpu/linux_x86/prefetch_linux_x86.inline.hpp
+++ b/src/hotspot/os_cpu/linux_x86/prefetch_linux_x86.inline.hpp
@@ -34,12 +34,6 @@ inline void Prefetch::read (const void *loc, intx interval) {
 #endif // AMD64
 }
 
-inline void Prefetch::read_streaming(const void *loc, intx interval) {
-#ifdef AMD64
-  __asm__ ("prefetchnta (%0,%1,1)" : : "r" (loc), "r" (interval));
-#endif // AMD64
-}
-
 inline void Prefetch::write(void *loc, intx interval) {
 #ifdef AMD64
 

--- a/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
@@ -31,10 +31,6 @@
 inline void Prefetch::read (const void *loc, intx interval) {
 }
 
-inline void Prefetch::read_streaming(const void *loc, intx interval) {
-  read (loc, interval);
-}
-
 inline void Prefetch::write(void *loc, intx interval) {
 }
 

--- a/src/hotspot/os_cpu/windows_x86/prefetch_windows_x86.inline.hpp
+++ b/src/hotspot/os_cpu/windows_x86/prefetch_windows_x86.inline.hpp
@@ -29,6 +29,5 @@
 
 inline void Prefetch::read (const void *loc, intx interval) {}
 inline void Prefetch::write(void *loc, intx interval) {}
-inline void Prefetch::read_streaming(const void *loc, intx interval) {}
 
 #endif // OS_CPU_WINDOWS_X86_PREFETCH_WINDOWS_X86_INLINE_HPP

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -171,7 +171,6 @@ jint init_globals() {
     JVMFlag::printFlags(tty, false, PrintFlagsRanges);
   }
 
-
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -84,7 +84,7 @@ class ThreadStateTransition : public StackObj {
   }
 
   static inline void transition_from_java(JavaThread *thread, JavaThreadState to) {
-    assert(thread->thread_state() == _thread_in_Java, "coming from wrong thread state: %s", thread->thread_state_name());
+    assert(thread->thread_state() == _thread_in_Java, "coming from wrong thread state");
     assert(to == _thread_in_vm || to == _thread_in_native, "invalid transition");
     thread->set_thread_state(to);
   }

--- a/src/hotspot/share/runtime/objectMonitor.inline.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.inline.hpp
@@ -34,7 +34,7 @@
 
 inline intptr_t ObjectMonitor::is_entered(JavaThread* current) const {
   void* owner = owner_raw();
-  if (current == owner || current->is_lock_owned((address)owner)) { // is_lock_owned_current((address)owner)); see JDK-8281642
+  if (current == owner || current->is_lock_owned((address)owner)) {
     return 1;
   }
   return 0;

--- a/src/hotspot/share/runtime/prefetch.hpp
+++ b/src/hotspot/share/runtime/prefetch.hpp
@@ -43,7 +43,6 @@ class Prefetch : AllStatic {
 
   // Prefetch anticipating read; must not fault, semantically a no-op
   static void read(const void* loc, intx interval);
-  static void read_streaming(const void* loc, intx interval);
 
   // Prefetch anticipating write; must not fault, semantically a no-op
   static void write(void* loc, intx interval);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -600,14 +600,6 @@ public:
       OopStorage::trigger_cleanup_if_needed();
     }
 
-    if (_subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_KEEPALIVES)) {
-      const char* name = "cleaning keepalive jweak handles";
-      EventSafepointCleanupTask event;
-      TraceTime timer(name, TRACETIME_LOG(Info, safepoint, cleanup));
-
-      post_safepoint_cleanup_task_event(event, SafepointSynchronize::safepoint_id(), name);
-    }
-
     _subtasks.all_tasks_claimed();
   }
 };

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -77,7 +77,6 @@ class SafepointSynchronize : AllStatic {
     SAFEPOINT_CLEANUP_STRING_TABLE_REHASH,
     SAFEPOINT_CLEANUP_SYSTEM_DICTIONARY_RESIZE,
     SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP,
-    SAFEPOINT_CLEANUP_KEEPALIVES,
     // Leave this one last.
     SAFEPOINT_CLEANUP_NUM_TASKS
   };
@@ -134,9 +133,9 @@ class SafepointSynchronize : AllStatic {
   // If true the VMThread may safely process the handshake operation for the JavaThread.
   static bool handshake_safe(JavaThread *thread);
 
-public:
-
   static uint64_t safepoint_counter()             { return _safepoint_counter; }
+
+public:
 
   static void init(Thread* vmthread);
 

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -345,9 +345,6 @@ static frame next_frame(frame fr, Thread* t) {
 }
 
 void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, char* buf, int buf_size) {
-  if (t != NULL) {
-    st->print_cr("Thread " INTPTR_FORMAT " [%ld]", p2i(t), (long) t->osthread()->thread_id());
-  }
 
   // see if it's a valid frame
   if (fr.pc()) {


### PR DESCRIPTION
Reverted to master unrelated, wrong or unused changes.

Running loom-t1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/126/head:pull/126` \
`$ git checkout pull/126`

Update a local copy of the PR: \
`$ git checkout pull/126` \
`$ git pull https://git.openjdk.java.net/loom pull/126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 126`

View PR using the GUI difftool: \
`$ git pr show -t 126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/126.diff">https://git.openjdk.java.net/loom/pull/126.diff</a>

</details>
