### PR TITLE
Invoke implDeregister() at wakeup()

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -336,6 +336,7 @@ public abstract class Poller {
     private void wakeup(int fdVal) {
         Thread t = map.remove(fdVal);
         if (t != null) {
+            implDeregister(fdVal);
             LockSupport.unpark(t);
         }
     }
@@ -344,7 +345,10 @@ public abstract class Poller {
      * Called by the polling facility when the file descriptor is polled
      */
     final void polled(int fdVal) {
-        wakeup(fdVal);
+        Thread t = map.remove(fdVal);
+        if (t != null) {
+            LockSupport.unpark(t);
+        }
     }
 
     /**


### PR DESCRIPTION
A virtual thread may park itself and register an event of EPoll when it invoke an operation of NioSocket. If the Inputstream or NioSocket closed, the call stack is like:
```
Poller::wakeup
Poller::stopPoll
NioSocketImpl.close()
···
```

I have a question that do we need invoke implDeregister() before unpark virtual thread?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.java.net/loom pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/128.diff">https://git.openjdk.java.net/loom/pull/128.diff</a>

</details>
