### PR TITLE
Renamed a plain 'relativize' function to be more precise, and added some comments

### DIFF
--- a/src/hotspot/share/gc/shared/continuationGCSupport.inline.hpp
+++ b/src/hotspot/share/gc/shared/continuationGCSupport.inline.hpp
@@ -38,7 +38,7 @@ inline bool ContinuationGCSupport::relativize_stack_chunk(oop obj) {
 
   stackChunkOop chunk = stackChunkOopDesc::cast(obj);
   if (!chunk->is_gc_mode()) {
-    chunk->relativize();
+    chunk->relativize_derived_oops();
   }
 
   return true;

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -135,11 +135,9 @@ public:
   template <class StackChunkFrameClosureType>
   inline void iterate_stack(StackChunkFrameClosureType* closure);
 
-  void relativize();
+  // Derived oop pointers are relativised, with respect to their oop base.
+  void relativize_derived_oops();
   void transform();
-
-  inline frame relativize(frame fr) const;
-  inline frame derelativize(frame fr) const;
 
   inline BitMapView bitmap() const;
   inline BitMap::idx_t bit_index_for(intptr_t* p) const;
@@ -149,9 +147,12 @@ public:
 
   MemRegion range();
 
-  // Returns a relative frame (with offset_sp, offset_unextended_sp, and offset_fp) that can be held during safepoints.
-  // This is orthogonal to the relativizing of the actual content of interpreted frames.
+  // Returns a relative frame (with offset_sp, offset_unextended_sp, and offset_fp) that can be held
+  // during safepoints.  This is orthogonal to the relativizing of the actual content of interpreted frames.
   // To be used, frame objects need to be derelativized with `derelativize`.
+  inline frame relativize(frame fr) const;
+  inline frame derelativize(frame fr) const;
+
   frame top_frame(RegisterMap* map);
   frame sender(const frame& fr, RegisterMap* map);
 
@@ -159,7 +160,7 @@ public:
   inline address usp_offset_to_location(const frame& fr, const int usp_offset_in_bytes) const;
   inline address reg_to_location(const frame& fr, const RegisterMap* map, VMReg reg) const;
 
-  // access to relativized interpreter frames (both the frame object and frame content are relativized)
+  // Access to relativized interpreter frames (both the frame object and frame content are relativized)
   inline Method* interpreter_frame_method(const frame& fr);
   inline address interpreter_frame_bcp(const frame& fr);
   inline intptr_t* interpreter_frame_expression_stack_at(const frame& fr, int index) const;


### PR DESCRIPTION
There are 3 kinds of relativize and this makes it less confusing.
Tested with jdk/internal/vm/Continuation tests locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.java.net/loom pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/129.diff">https://git.openjdk.java.net/loom/pull/129.diff</a>

</details>
