### PR TITLE
Split && asserts

### DIFF
--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -146,7 +146,8 @@ frame FreezeBase::new_hframe(frame& f, frame& caller) {
     bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
     fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? Interpreted::stack_argsize(f) : 0);
     sp = fp - (f.fp() - f.unextended_sp());
-    assert(sp <= fp && fp <= caller.unextended_sp(), "");
+    assert(sp <= fp, "");
+    assert(fp <= caller.unextended_sp(), "");
     caller.set_sp(fp + frame::sender_sp_offset);
 
     assert(_cont.tail()->is_in_chunk(sp), "");
@@ -283,7 +284,8 @@ template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& calle
       vsp = align(hf, vsp, caller, bottom);
     }
 
-    assert(hf.cb() != nullptr && hf.oop_map() != nullptr, "");
+    assert(hf.cb() != nullptr, "");
+    assert(hf.oop_map() != nullptr, "");
     intptr_t* fp = FKind::stub
       ? vsp + fsize - frame::sender_sp_offset // on AArch64, this value is used for the safepoint stub
       : *(intptr_t**)(hf.sp() - frame::sender_sp_offset); // we need to re-read fp because it may be an oop and we might have fixed the frame.

--- a/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
@@ -72,7 +72,7 @@ inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) con
 
 template <chunk_frames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   return derelativize(frame::interpreter_frame_last_sp_offset);
 }
 
@@ -87,13 +87,13 @@ inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interprete
 
 template <chunk_frames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   return (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) ? _end : fp() + frame::sender_sp_offset;
 }
 
 template <chunk_frames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   if (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) {
     _unextended_sp = _end;
     _sp = _end;
@@ -106,7 +106,7 @@ inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   // InterpreterOopMap mask;
   // to_frame().interpreted_frame_oop_map(&mask);
   // intptr_t* top = derelativize(frame::interpreter_frame_initial_sp_offset) - mask.expression_stack_size();
@@ -118,14 +118,14 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   int diff = (int)(derelativize(frame::interpreter_frame_locals_offset) - derelativize(frame::interpreter_frame_sender_sp_offset) + 1);
   return diff;
 }
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   ResourceMark rm;
   InterpreterOopMap mask;
   frame f = to_frame();

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -143,7 +143,8 @@ frame FreezeBase::new_hframe(frame& f, frame& caller) {
     bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
     fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? Interpreted::stack_argsize(f) : 0);
     sp = fp - (f.fp() - f.unextended_sp());
-    assert(sp <= fp && fp <= caller.unextended_sp(), "");
+    assert(sp <= fp, "");
+    assert(fp <= caller.unextended_sp(), "");
     caller.set_sp(fp + frame::sender_sp_offset);
 
     assert(_cont.tail()->is_in_chunk(sp), "");
@@ -276,7 +277,8 @@ template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& calle
       vsp = align(hf, vsp, caller, bottom);
     }
 
-    assert(hf.cb() != nullptr && hf.oop_map() != nullptr, "");
+    assert(hf.cb() != nullptr, "");
+    assert(hf.oop_map() != nullptr, "");
     intptr_t* fp = *(intptr_t**)(hf.sp() - frame::sender_sp_offset); // we need to re-read fp because it may be an oop and we might have fixed the frame.
     return frame(vsp, vsp, fp, hf.pc(), hf.cb(), hf.oop_map(), false); // TODO PERF : this computes deopt state; is it necessary?
   }

--- a/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
@@ -72,7 +72,7 @@ inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) con
 
 template <chunk_frames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   return derelativize(frame::interpreter_frame_last_sp_offset);
 }
 
@@ -87,13 +87,13 @@ inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interprete
 
 template <chunk_frames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   return (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) ? _end : fp() + frame::sender_sp_offset;
 }
 
 template <chunk_frames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   if (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) {
     _unextended_sp = _end;
     _sp = _end;
@@ -106,7 +106,7 @@ inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   // InterpreterOopMap mask;
   // to_frame().interpreted_frame_oop_map(&mask);
   // intptr_t* top = derelativize(frame::interpreter_frame_initial_sp_offset) - mask.expression_stack_size();
@@ -118,14 +118,14 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   int diff = (int)(derelativize(frame::interpreter_frame_locals_offset) - derelativize(frame::interpreter_frame_sender_sp_offset) + 1);
   return diff;
 }
 
 template <chunk_frames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
-  assert(frame_kind == chunk_frames::MIXED && is_interpreted(), "");
+  assert_is_interpreted_and_frame_type_mixed();
   ResourceMark rm;
   InterpreterOopMap mask;
   frame f = to_frame();

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -711,7 +711,10 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
     if (out_frames != nullptr) *out_frames += closure._num_frames;
     if (out_interpreted_frames != nullptr) *out_interpreted_frames += closure._num_interpreted_frames;
   } else {
-    assert(out_size == nullptr && out_oops == nullptr && out_frames == nullptr && out_interpreted_frames == nullptr, "");
+    assert(out_size == nullptr, "");
+    assert(out_oops == nullptr, "");
+    assert(out_frames == nullptr, "");
+    assert(out_interpreted_frames == nullptr, "");
   }
 
   if (has_bitmap()) {

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -258,7 +258,8 @@ inline address stackChunkOopDesc::usp_offset_to_location(const frame& fr, const 
 
 inline address stackChunkOopDesc::reg_to_location(const frame& fr, const RegisterMap* map, VMReg reg) const {
   assert(fr.is_compiled_frame(), "");
-  assert(map != nullptr && map->stack_chunk() == as_oop(), "");
+  assert(map != nullptr, "");
+  assert(map->stack_chunk() == as_oop(), "");
 
   // the offsets are saved in the map after going through relativize_usp_offset, so they are sp - loc, in words
   intptr_t offset = (intptr_t)map->location(reg, nullptr); // see usp_offset_to_index for the chunk case
@@ -324,17 +325,17 @@ inline intptr_t* stackChunkOopDesc::relative_base() const {
 inline intptr_t* stackChunkOopDesc::derelativize_address(int offset) const {
   intptr_t* base = relative_base();
   intptr_t* p = base - offset;
-  // tty->print_cr(">>> derelativize_address: %d -> %p (base: %p)", offset, p, base);
-  assert(start_address() <= p && p <= base, "");
+  assert(start_address() <= p && p <= base, "start_address: " PTR_FORMAT " p: " PTR_FORMAT " base: " PTR_FORMAT,
+         p2i(start_address()), p2i(p), p2i(base));
   return p;
 }
 
 inline int stackChunkOopDesc::relativize_address(intptr_t* p) const {
   intptr_t* base = relative_base();
   intptr_t offset = base - p;
-  // tty->print_cr(">>> relativize_address: %p -> %ld (base: %p)", p, offset, base);
-  assert(start_address() <= p && p <= base, "");
-  assert(0 <= offset && offset <= std::numeric_limits<int>::max(), "");
+  assert(start_address() <= p && p <= base, "start_address: " PTR_FORMAT " p: " PTR_FORMAT " base: " PTR_FORMAT,
+         p2i(start_address()), p2i(p), p2i(base));
+  assert(0 <= offset && offset <= std::numeric_limits<int>::max(), "offset: " PTR_FORMAT, offset);
   return offset;
 }
 

--- a/src/hotspot/share/runtime/frame_helpers.inline.hpp
+++ b/src/hotspot/share/runtime/frame_helpers.inline.hpp
@@ -259,7 +259,8 @@ inline intptr_t* NonInterpreted<Self>::frame_bottom(const frame& f) { // exclusi
 
 template<typename Self>
 inline int NonInterpreted<Self>::size(const frame& f) {
-  assert(!f.is_interpreted_frame() && Self::is_instance(f), "");
+  assert(!f.is_interpreted_frame(), "");
+  assert(Self::is_instance(f), "");
   return f.cb()->frame_size();
 }
 
@@ -270,13 +271,15 @@ inline int NonInterpreted<Self>::stack_argsize(const frame& f) {
 
 template<typename Self>
 inline int NonInterpreted<Self>::num_oops(const frame& f) {
-  assert(!f.is_interpreted_frame() && Self::is_instance(f), "");
+  assert(!f.is_interpreted_frame(), "");
+  assert(Self::is_instance(f), "");
   return f.num_oops() + Self::extra_oops;
 }
 
 template<typename RegisterMapT>
 bool Compiled::is_owning_locks(JavaThread* thread, RegisterMapT* map, const frame& f) {
-  assert(!f.is_interpreted_frame() && Compiled::is_instance(f), "");
+  assert(!f.is_interpreted_frame(), "");
+  assert(Compiled::is_instance(f), "");
 
   CompiledMethod* cm = f.cb()->as_compiled_method();
   assert(!cm->is_compiled() || !cm->as_compiled_method()->is_native_method(), ""); // See compiledVFrame::compiledVFrame(...) in vframe_hp.cpp

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -776,8 +776,8 @@ bool HandshakeState::continue_resume(JavaThread* caller) {
     return false;
   }
   MutexLocker ml(&_lock, Mutex::_no_safepoint_check_flag);
-  assert(is_blocked() && caller_thread() == caller,
-         "this is the only thread that can continue this thread");
+  assert(is_blocked(), "should be blocked");
+  assert(caller_thread() == caller, "this is the only thread that can continue this thread");
 
   // Resume the thread.
   set_caller_thread(nullptr); // !is_blocked()

--- a/src/hotspot/share/runtime/stackChunkFrameStream.hpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.hpp
@@ -125,6 +125,8 @@ public:
   template <typename RegisterMapT>
   inline void* reg_to_loc(VMReg reg, const RegisterMapT* map) const;
 
+  void assert_is_interpreted_and_frame_type_mixed() const NOT_DEBUG_RETURN;
+
 public:
   template <class OopClosureType, class RegisterMapT>
   inline void iterate_oops(OopClosureType* closure, const RegisterMapT* map) const;

--- a/src/hotspot/share/runtime/stackChunkFrameStream.inline.hpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.inline.hpp
@@ -85,7 +85,8 @@ StackChunkFrameStream<frame_kind>::StackChunkFrameStream(stackChunkOop chunk, co
     assert(_unextended_sp >= _sp - InstanceStackChunkKlass::metadata_words(), "");
   }
   DEBUG_ONLY(else _unextended_sp = nullptr;)
-  assert(_sp >= chunk->start_address() && _sp <= chunk->end_address() + InstanceStackChunkKlass::metadata_words(), "");
+  assert(_sp >= chunk->start_address(), "");
+  assert(_sp <= chunk->end_address() + InstanceStackChunkKlass::metadata_words(), "");
 
   if (f.cb() != nullptr) {
     _oopmap = nullptr;
@@ -134,7 +135,8 @@ inline int StackChunkFrameStream<frame_kind>::stack_argsize() const {
   if (is_stub()) {
     return 0;
   }
-  assert(cb() != nullptr && cb()->is_compiled(), "");
+  assert(cb() != nullptr, "");
+  assert(cb()->is_compiled(), "");
   assert(cb()->as_compiled_method()->method() != nullptr, "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;
 }
@@ -192,7 +194,8 @@ inline void StackChunkFrameStream<frame_kind>::get_cb() {
     return;
   }
 
-  assert(pc() != nullptr && dbg_is_safe(pc(), -1), "");
+  assert(pc() != nullptr, "");
+  assert(dbg_is_safe(pc(), -1), "");
 
   _cb = CodeCache::find_blob_fast(pc());
 
@@ -248,7 +251,8 @@ inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map(RegisterM
 template<>
 template<>
 inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map(RegisterMap* map) {
-  assert(map->in_cont() && map->stack_chunk()() == _chunk, "");
+  assert(map->in_cont(), "");
+  assert(map->stack_chunk()() == _chunk, "");
   if (map->update_map()) {
     frame f = to_frame();
     oopmap()->update_register_map(&f, map); // we have callee-save registers in this case
@@ -270,7 +274,8 @@ inline address StackChunkFrameStream<frame_kind>::orig_pc() const {
     pc1 = *(address*)((address)unextended_sp() + cm->orig_pc_offset());
   }
 
-  assert(pc1 != nullptr && !cm->is_deopt_pc(pc1), "");
+  assert(pc1 != nullptr, "");
+  assert(!cm->is_deopt_pc(pc1), "");
   assert(_cb == CodeCache::find_blob_fast(pc1), "");
 
   return pc1;
@@ -385,6 +390,13 @@ bool StackChunkFrameStream<frame_kind>::is_in_oops(void* p, const RegisterMapT* 
   }
   return false;
 }
+
+template <chunk_frames frame_kind>
+void StackChunkFrameStream<frame_kind>::assert_is_interpreted_and_frame_type_mixed() const {
+  assert(is_interpreted(), "");
+  assert(frame_kind == chunk_frames::MIXED, "");
+}
+
 #endif
 
 #endif // SHARE_OOPS_STACKCHUNKFRAMESTREAM_INLINE_HPP


### PR DESCRIPTION
Simple change to split asserts that checks for two conditions. When these kind of asserts fail, you don't know which part failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.java.net/loom pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/130.diff">https://git.openjdk.java.net/loom/pull/130.diff</a>

</details>
