### PR TITLE
Revert refactoring frame::oops_interpreted_do

### DIFF
--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -451,7 +451,6 @@ class frame {
 
  private:
   void oops_interpreted_arguments_do(Symbol* signature, bool has_receiver, OopClosure* f) const;
-  void oops_interpreted_do0(OopClosure* f, const RegisterMap* map, methodHandle m, jint bci, const InterpreterOopMap& mask) const;
 
   // Iteration of oops
   void oops_do_internal(OopClosure* f, CodeBlobClosure* cf, DerivedOopClosure* df, DerivedPointerIterationMode derived_mode, const RegisterMap* map, bool use_interpreter_oop_map_cache) const;


### PR DESCRIPTION
I noticed that oops_interpreted_do had been refactored but didn't have any substantial changes or calls from outside, except for accepting null RegMap, so I reverted this change.
Tested with Continuation tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/loom pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/133.diff">https://git.openjdk.java.net/loom/pull/133.diff</a>

</details>
