### PR TITLE
Minor cosmetic cleanups from code reading continuation.cpp

### DIFF
--- a/src/hotspot/share/runtime/continuationHelper.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.hpp
@@ -35,23 +35,13 @@
 
 class ContinuationHelper {
 public:
-  static oop get_continuation(JavaThread* thread);
-  static bool stack_overflow_check(JavaThread* thread, int size, address sp);
-
-  static inline void clear_anchor(JavaThread* thread);
-  static void set_anchor(JavaThread* thread, intptr_t* sp);
   static void set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp);
-  static void set_anchor_to_entry(JavaThread* thread, ContinuationEntry* entry);
   static void set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry);
 
   template<typename FKind> static void update_register_map(const frame& f, RegisterMap* map);
   static void update_register_map_with_callee(const frame& f, RegisterMap* map);
 
   static inline void push_pd(const frame& f);
-
-  static inline void maybe_flush_stack_processing(JavaThread* thread, const ContinuationEntry* entry);
-  static inline void maybe_flush_stack_processing(JavaThread* thread, intptr_t* sp);
-  static NOINLINE void flush_stack_processing(JavaThread* thread, intptr_t* sp);
 
   static inline int frame_align_words(int size);
   static inline intptr_t* frame_align_pointer(intptr_t* sp);


### PR DESCRIPTION
ContinuationHelper functions should have belonged to continuationHelper.cpp but these functions can also be inlined since they're only called by continuation.cpp.
Removed unused #include directives.
Consolidated and cleaned up JVMTI calls.  Doesn't need to be capitalized.

Tested with make test TEST=jdk/jdk/internal/vm/Continuation also   jtreg:test/hotspot/jtreg/serviceability/jvmti/vthread

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.java.net/loom pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/136.diff">https://git.openjdk.java.net/loom/pull/136.diff</a>

</details>
