### PR TITLE
Tschatzl cleanups

### DIFF
--- a/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/stackChunkFrameStream_aarch64.inline.hpp
@@ -30,7 +30,7 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   assert(!is_done(), "");
   intptr_t* p = (intptr_t*)p0;
@@ -40,7 +40,7 @@ inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   if (is_done()) {
     return frame(_sp, _sp, nullptr, nullptr, nullptr, nullptr, true);
@@ -49,40 +49,40 @@ inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   assert(!is_done(), "");
   return *(address*)(_sp - 1);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   intptr_t* fp_addr = _sp - frame::sender_sp_offset;
-  return (frame_kind == chunk_frames::MIXED && is_interpreted())
+  return (frame_kind == ChunkFrames::Mixed && is_interpreted())
     ? fp_addr + *fp_addr // derelativize
     : *(intptr_t**)fp_addr;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   intptr_t* fp = this->fp();
   assert(fp != nullptr, "");
   return fp + fp[offset];
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   assert_is_interpreted_and_frame_type_mixed();
   return derelativize(frame::interpreter_frame_last_sp_offset);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   assert_is_interpreted_and_frame_type_mixed();
   return (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) ? _end : fp() + frame::sender_sp_offset;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   assert_is_interpreted_and_frame_type_mixed();
   if (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) {
@@ -95,7 +95,7 @@ inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   assert_is_interpreted_and_frame_type_mixed();
 
@@ -104,14 +104,14 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   return (int)(bottom - top);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   assert_is_interpreted_and_frame_type_mixed();
   int diff = (int)(derelativize(frame::interpreter_frame_locals_offset) - derelativize(frame::interpreter_frame_sender_sp_offset) + 1);
   return diff;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   assert_is_interpreted_and_frame_type_mixed();
   ResourceMark rm;
@@ -126,7 +126,7 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
     frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::sender_sp_offset
                                                           : (intptr_t**)(_sp - frame::sender_sp_offset));
@@ -135,14 +135,14 @@ inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(Regist
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
     frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::sender_sp_offset
                                                           : (intptr_t**)(_sp - frame::sender_sp_offset));
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/cpu/arm/stackChunkFrameStream_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/stackChunkFrameStream_arm.inline.hpp
@@ -30,67 +30,67 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
@@ -98,17 +98,17 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/cpu/ppc/stackChunkFrameStream_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/stackChunkFrameStream_ppc.inline.hpp
@@ -30,67 +30,67 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
@@ -98,17 +98,17 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/cpu/s390/stackChunkFrameStream_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/stackChunkFrameStream_s390.inline.hpp
@@ -30,67 +30,67 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
@@ -98,17 +98,17 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/stackChunkFrameStream_x86.inline.hpp
@@ -30,7 +30,7 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   assert(!is_done(), "");
   intptr_t* p = (intptr_t*)p0;
@@ -40,7 +40,7 @@ inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   if (is_done()) {
     return frame(_sp, _sp, nullptr, nullptr, nullptr, nullptr, true);
@@ -49,40 +49,40 @@ inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   assert(!is_done(), "");
   return *(address*)(_sp - 1);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   intptr_t* fp_addr = _sp - frame::sender_sp_offset;
-  return (frame_kind == chunk_frames::MIXED && is_interpreted())
+  return (frame_kind == ChunkFrames::Mixed && is_interpreted())
     ? fp_addr + *fp_addr // derelativize
     : *(intptr_t**)fp_addr;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   intptr_t* fp = this->fp();
   assert(fp != nullptr, "");
   return fp + fp[offset];
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   assert_is_interpreted_and_frame_type_mixed();
   return derelativize(frame::interpreter_frame_last_sp_offset);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   assert_is_interpreted_and_frame_type_mixed();
   return (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) ? _end : fp() + frame::sender_sp_offset;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   assert_is_interpreted_and_frame_type_mixed();
   if (derelativize(frame::interpreter_frame_locals_offset) + 1 >= _end) {
@@ -95,7 +95,7 @@ inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   assert_is_interpreted_and_frame_type_mixed();
 
@@ -104,14 +104,14 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   return (int)(bottom - top);
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   assert_is_interpreted_and_frame_type_mixed();
   int diff = (int)(derelativize(frame::interpreter_frame_locals_offset) - derelativize(frame::interpreter_frame_sender_sp_offset) + 1);
   return diff;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   assert_is_interpreted_and_frame_type_mixed();
   ResourceMark rm;
@@ -126,7 +126,7 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
     frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::sender_sp_offset
                                                           : (intptr_t**)(_sp - frame::sender_sp_offset));
@@ -135,14 +135,14 @@ inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(Regist
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
     frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::sender_sp_offset
                                                           : (intptr_t**)(_sp - frame::sender_sp_offset));
   }
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/cpu/zero/stackChunkFrameStream_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/stackChunkFrameStream_zero.inline.hpp
@@ -30,67 +30,67 @@
 #include "runtime/registerMap.hpp"
 
 #ifdef ASSERT
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   Unimplemented();
   return true;
 }
 #endif
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
   Unimplemented();
   return frame();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline address StackChunkFrameStream<frame_kind>::get_pc() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
   Unimplemented();
   return NULL;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
   Unimplemented();
   return 0;
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
   Unimplemented();
   return 0;
@@ -98,17 +98,17 @@ inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::MIXED>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
 template<>
 template<>
-inline void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::update_reg_map_pd(RegisterMap* map) {
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   Unimplemented();
 }
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 template <typename RegisterMapT>
 inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -133,13 +133,6 @@
     <Field type="ushort" name="size" label="Stack size in bytes" />
   </Event>
 
-  <Event name="ContinuationIterateOops" experimental="true" category="Java Virtual Machine" label="Continuation Iterate OOPs" thread="true" stackTrace="false" startTime="false">
-    <Field type="ulong" name="id" label="Continuation ID" />
-    <Field type="boolean" name="safepoint" label="Safepoint" />
-    <Field type="ushort" name="numFrames" label="Frames" />
-    <Field type="ushort" name="numOops" label="Oops" />
-  </Event>
-
   <Event name="ContinuationFreezeYoung" experimental="true" category="Java Virtual Machine" label="Continuation Freeze Young" thread="true" stackTrace="false" startTime="false">
     <Field type="ulong" name="id" label="Continuation ID" />
     <Field type="uint" name="size" label="Size" />

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -106,7 +106,8 @@ public:
       // The do_nmethod function takes care of having the right synchronization
       // when keeping the nmethod alive during concurrent execution.
       _closure->do_nmethod(nm);
-      // there's no need to mark the Method, as class redefinition will walk the CodeCache, noting their Methods
+      // There is no need to mark the Method, as class redefinition will walk the
+      // CodeCache, noting their Methods
     }
     return true;
   }
@@ -203,7 +204,8 @@ public:
   bool do_frame(const StackChunkFrameStream<frame_kind>& fs, const RegisterMapT* map) {
     frame f = fs.to_frame();
     _st->print_cr("-- frame sp: " INTPTR_FORMAT " interpreted: %d size: %d argsize: %d",
-      p2i(fs.sp()), fs.is_interpreted(), f.frame_size(), fs.is_interpreted() ? 0 : f.compiled_frame_stack_argsize());
+                  p2i(fs.sp()), fs.is_interpreted(), f.frame_size(),
+                  fs.is_interpreted() ? 0 : f.compiled_frame_stack_argsize());
     f.print_on(_st);
     const ImmutableOopMap* oopmap = fs.oopmap();
     if (oopmap != nullptr) {
@@ -221,12 +223,12 @@ void InstanceStackChunkKlass::print_chunk(const stackChunkOop c, bool verbose, o
   }
 
   st->print_cr("CHUNK " INTPTR_FORMAT " " INTPTR_FORMAT " - " INTPTR_FORMAT " :: " INTPTR_FORMAT,
-    p2i((oopDesc*)c), p2i(c->start_address()), p2i(c->end_address()), c->identity_hash());
+               p2i((oopDesc*)c), p2i(c->start_address()), p2i(c->end_address()), c->identity_hash());
   st->print_cr("       barriers: %d gc_mode: %d bitmap: %d parent: " INTPTR_FORMAT,
-    c->requires_barriers(), c->is_gc_mode(), c->has_bitmap(), p2i((oopDesc*)c->parent()));
+               c->requires_barriers(), c->is_gc_mode(), c->has_bitmap(), p2i((oopDesc*)c->parent()));
   st->print_cr("       flags mixed: %d", c->has_mixed_frames());
   st->print_cr("       size: %d argsize: %d max_size: %d sp: %d pc: " INTPTR_FORMAT,
-    c->stack_size(), c->argsize(), c->max_size(), c->sp(), p2i(c->pc()));
+               c->stack_size(), c->argsize(), c->max_size(), c->sp(), p2i(c->pc()));
 
   if (verbose) {
     st->cr();

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -96,7 +96,7 @@ class DoMethodsStackChunkFrameClosure {
 public:
   DoMethodsStackChunkFrameClosure(OopIterateClosure* cl) : _closure(cl) {}
 
-  template <chunk_frames frame_kind, typename RegisterMapT>
+  template <ChunkFrames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
     if (f.is_interpreted()) {
       Method* m = f.to_frame().interpreter_frame_method();
@@ -131,7 +131,7 @@ public:
     assert(_closure != nullptr, "must be set");
   }
 
-  template <chunk_frames frame_kind, typename RegisterMapT>
+  template <ChunkFrames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
     if (_do_metadata) {
       DoMethodsStackChunkFrameClosure(_closure).do_frame(f, map);
@@ -166,7 +166,7 @@ public:
   const RegisterMap* get_map(const RegisterMap* map,      intptr_t* sp) { return map; }
   const RegisterMap* get_map(const SmallRegisterMap* map, intptr_t* sp) { return map->copy_to_RegisterMap(&_map, sp); }
 
-  template <chunk_frames frame_kind, typename RegisterMapT>
+  template <ChunkFrames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
     ResetNoHandleMark rnhm;
     HandleMark hm(Thread::current());
@@ -200,7 +200,7 @@ class PrintStackChunkClosure {
 public:
   PrintStackChunkClosure(outputStream* st) : _st(st) {}
 
-  template <chunk_frames frame_kind, typename RegisterMapT>
+  template <ChunkFrames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& fs, const RegisterMapT* map) {
     frame f = fs.to_frame();
     _st->print_cr("-- frame sp: " INTPTR_FORMAT " interpreted: %d size: %d argsize: %d",

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -34,8 +34,9 @@
 class ClassFileParser;
 
 // An InstanceStackChunkKlass is a specialization of the InstanceKlass.
-// It has a header containing metadata, and a blob containing a stack segment
-// (some integral number of stack frames)
+//
+// The stackChunkOops have a header containing metadata, and a blob containing a
+// stack segment (some integral number of stack frames).
 //
 // A chunk is said to be "mixed" if it contains interpreter frames or stubs
 // (which can only be a safepoint stub as the topmost frame). Otherwise, it
@@ -135,7 +136,7 @@ public:
 
   // Oop fields (and metadata) iterators
   //
-  // The InstanceClassLoaderKlass iterators also visit the CLD pointer (or mirror of anonymous klasses.)
+  // The InstanceClassLoaderKlass iterators also visit the CLD pointer (or mirror of anonymous klasses).
 
   // Forward iteration
   // Iterate over the oop fields and metadata.

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -117,7 +117,8 @@ public:
 
   inline size_t instance_size(size_t stack_size_in_words) const;
 
-  static inline size_t bitmap_size(size_t stack_size_in_words); // in words
+  static inline size_t bitmap_size_in_bits(size_t stack_size_in_words); // In bits
+  static inline size_t bitmap_size(size_t stack_size_in_words); // In words
 
   // Returns the size of the instance including the stack data.
   virtual size_t oop_size(oop obj) const override;

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -55,7 +55,7 @@ inline size_t InstanceStackChunkKlass::instance_size(size_t stack_size_in_words)
 }
 
 inline size_t InstanceStackChunkKlass::bitmap_size(size_t stack_size_in_words) {
-  // One bit per potential narrowOop* or oop* address
+  // One bit per potential narrowOop* or oop* address.
   size_t size_in_bits = stack_size_in_words << (UseCompressedOops ? 1 : 0);
 
   return align_up(size_in_bits, BitsPerWord) >> LogBitsPerWord;
@@ -113,7 +113,7 @@ void InstanceStackChunkKlass::oop_oop_iterate_header_bounded(stackChunkOop chunk
 
 template <typename T, class OopClosureType>
 void InstanceStackChunkKlass::oop_oop_iterate_stack_bounded(stackChunkOop chunk, OopClosureType* closure, MemRegion mr) {
-  if (chunk->has_bitmap()) { // LIKELY
+  if (chunk->has_bitmap()) {
     intptr_t* start = chunk->sp_address() - frame::metadata_words;
     intptr_t* end = chunk->end_address();
     // mr.end() can actually be less than start. In that case, we only walk the metadata
@@ -131,7 +131,7 @@ void InstanceStackChunkKlass::oop_oop_iterate_stack_bounded(stackChunkOop chunk,
 
 template <typename T, class OopClosureType>
 void InstanceStackChunkKlass::oop_oop_iterate_stack(stackChunkOop chunk, OopClosureType* closure) {
-  if (chunk->has_bitmap()) { // LIKELY
+  if (chunk->has_bitmap()) {
     oop_oop_iterate_stack_with_bitmap<T>(chunk, closure, chunk->sp_address() - frame::metadata_words, chunk->end_address());
   } else {
     oop_oop_iterate_stack_slow(chunk, closure, chunk->range());

--- a/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.inline.hpp
@@ -54,11 +54,15 @@ inline size_t InstanceStackChunkKlass::instance_size(size_t stack_size_in_words)
   return align_object_size(size_helper() + stack_size_in_words + bitmap_size(stack_size_in_words));
 }
 
-inline size_t InstanceStackChunkKlass::bitmap_size(size_t stack_size_in_words) {
-  // One bit per potential narrowOop* or oop* address.
-  size_t size_in_bits = stack_size_in_words << (UseCompressedOops ? 1 : 0);
+inline size_t InstanceStackChunkKlass::bitmap_size_in_bits(size_t stack_size_in_words) {
+  // Need one bit per potential narrowOop* or oop* address.
+  size_t size_in_bits = stack_size_in_words << (LogBitsPerWord - LogBitsPerHeapOop);
 
-  return align_up(size_in_bits, BitsPerWord) >> LogBitsPerWord;
+  return align_up(size_in_bits, BitsPerWord);
+}
+
+inline size_t InstanceStackChunkKlass::bitmap_size(size_t stack_size_in_words) {
+  return bitmap_size_in_bits(stack_size_in_words) >> LogBitsPerWord;
 }
 
 template <typename T, class OopClosureType>

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -110,7 +110,7 @@ int stackChunkOopDesc::num_java_frames() const {
   return n;
 }
 
-template <stackChunkOopDesc::barrier_type barrier>
+template <stackChunkOopDesc::BarrierType barrier>
 class DoBarriersStackClosure {
   const stackChunkOop _chunk;
 
@@ -124,14 +124,14 @@ public:
   }
 };
 
-template <stackChunkOopDesc::barrier_type barrier>
+template <stackChunkOopDesc::BarrierType barrier>
 void stackChunkOopDesc::do_barriers() {
   DoBarriersStackClosure<barrier> closure(this);
   iterate_stack(&closure);
 }
 
-template void stackChunkOopDesc::do_barriers<stackChunkOopDesc::barrier_type::LOAD> ();
-template void stackChunkOopDesc::do_barriers<stackChunkOopDesc::barrier_type::STORE>();
+template void stackChunkOopDesc::do_barriers<stackChunkOopDesc::BarrierType::Load> ();
+template void stackChunkOopDesc::do_barriers<stackChunkOopDesc::BarrierType::Store>();
 
 // We replace derived oops with offsets; the converse is done in DerelativizeDerivedOopClosure
 class RelativizeDerivedOopClosure : public DerivedOopClosure {
@@ -324,7 +324,7 @@ void stackChunkOopDesc::transform() {
   }
 }
 
-template <stackChunkOopDesc::barrier_type barrier, bool compressedOopsWithBitmap>
+template <stackChunkOopDesc::BarrierType barrier, bool compressedOopsWithBitmap>
 class BarrierClosure: public OopClosure {
   NOT_PRODUCT(intptr_t* _sp;)
 
@@ -336,13 +336,13 @@ public:
 
   template <class T> inline void do_oop_work(T* p) {
     oop value = (oop)HeapAccess<>::oop_load(p);
-    if (barrier == stackChunkOopDesc::barrier_type::STORE) {
+    if (barrier == stackChunkOopDesc::BarrierType::Store) {
       HeapAccess<>::oop_store(p, value);
     }
   }
 };
 
-template <stackChunkOopDesc::barrier_type barrier, chunk_frames frame_kind, typename RegisterMapT>
+template <stackChunkOopDesc::BarrierType barrier, chunk_frames frame_kind, typename RegisterMapT>
 void stackChunkOopDesc::do_barriers0(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
   // We need to invoke the write barriers so as not to miss oops in old chunks that haven't yet been concurrently scanned
   if (f.is_done()) {
@@ -377,14 +377,14 @@ void stackChunkOopDesc::do_barriers0(const StackChunkFrameStream<frame_kind>& f,
   }
 }
 
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::LOAD> (const StackChunkFrameStream<chunk_frames::MIXED>& f, const RegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::STORE>(const StackChunkFrameStream<chunk_frames::MIXED>& f, const RegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::LOAD> (const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const RegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::STORE>(const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const RegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::LOAD> (const StackChunkFrameStream<chunk_frames::MIXED>& f, const SmallRegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::STORE>(const StackChunkFrameStream<chunk_frames::MIXED>& f, const SmallRegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::LOAD> (const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const SmallRegisterMap* map);
-template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::barrier_type::STORE>(const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const SmallRegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Load> (const StackChunkFrameStream<chunk_frames::MIXED>& f, const RegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Store>(const StackChunkFrameStream<chunk_frames::MIXED>& f, const RegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Load> (const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const RegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Store>(const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const RegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Load> (const StackChunkFrameStream<chunk_frames::MIXED>& f, const SmallRegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Store>(const StackChunkFrameStream<chunk_frames::MIXED>& f, const SmallRegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Load> (const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const SmallRegisterMap* map);
+template void stackChunkOopDesc::do_barriers0<stackChunkOopDesc::BarrierType::Store>(const StackChunkFrameStream<chunk_frames::COMPILED_ONLY>& f, const SmallRegisterMap* map);
 
 class DerelativizeDerivedOopClosure : public DerivedOopClosure {
 public:

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -344,7 +344,7 @@ public:
 
 template <stackChunkOopDesc::barrier_type barrier, chunk_frames frame_kind, typename RegisterMapT>
 void stackChunkOopDesc::do_barriers0(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
-  // we need to invoke the write barriers so as not to miss oops in old chunks that haven't yet been concurrently scanned
+  // We need to invoke the write barriers so as not to miss oops in old chunks that haven't yet been concurrently scanned
   if (f.is_done()) {
     return;
   }
@@ -357,7 +357,8 @@ void stackChunkOopDesc::do_barriers0(const StackChunkFrameStream<frame_kind>& f,
     // The entry barrier takes care of having the right synchronization
     // when keeping the nmethod alive during concurrent execution.
     nm->run_nmethod_entry_barrier();
-    // there's no need to mark the Method, as class redefinition will walk the CodeCache, noting their Methods
+    // There is no need to mark the Method, as class redefinition will walk the
+    // CodeCache, noting their Methods
   }
 
   relativize_derived_oops_in_frame(f, map);
@@ -587,8 +588,8 @@ public:
       f.print_on(&ls);
     }
     assert(f.pc() != nullptr,
-      "young: %d num_frames: %d sp: " INTPTR_FORMAT " start: " INTPTR_FORMAT " end: " INTPTR_FORMAT,
-      !_chunk->requires_barriers(), _num_frames, p2i(f.sp()), p2i(_chunk->start_address()), p2i(_chunk->bottom_address()));
+           "young: %d num_frames: %d sp: " INTPTR_FORMAT " start: " INTPTR_FORMAT " end: " INTPTR_FORMAT,
+           !_chunk->requires_barriers(), _num_frames, p2i(f.sp()), p2i(_chunk->start_address()), p2i(_chunk->bottom_address()));
 
     if (_num_frames == 0) {
       assert(f.pc() == _chunk->pc(), "");
@@ -652,8 +653,8 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
 
   const bool concurrent = !Thread::current()->is_Java_thread();
 
-  // if argsize == 0 and the chunk isn't mixed, the chunk contains the metadata (pc, fp -- frame::sender_sp_offset)
-  // for the top frame (below sp), and *not* for the bottom frame
+  // If argsize == 0 and the chunk isn't mixed, the chunk contains the metadata (pc, fp -- frame::sender_sp_offset)
+  // for the top frame (below sp), and *not* for the bottom frame.
   int size = stack_size() - argsize() - sp();
   assert(size >= 0, "");
   assert((size == 0) == is_empty(), "");
@@ -662,8 +663,8 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
   const bool has_safepoint_stub_frame = first.is_stub();
 
   VerifyStackChunkFrameClosure closure(this,
-    has_safepoint_stub_frame ? 1 : 0, // iterate_stack skips the safepoint stub
-    has_safepoint_stub_frame ? first.frame_size() : 0);
+                                       has_safepoint_stub_frame ? 1 : 0, // Iterate_stack skips the safepoint stub
+                                       has_safepoint_stub_frame ? first.frame_size() : 0);
   iterate_stack(&closure);
 
   assert(!is_empty() || closure._cb == nullptr, "");
@@ -678,16 +679,16 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
 
   if (!concurrent) {
     assert(closure._size <= size + argsize() + frame::metadata_words,
-      "size: %d argsize: %d closure.size: %d end sp: " PTR_FORMAT " start sp: %d chunk size: %d",
-      size, argsize(), closure._size, closure._sp - start_address(), sp(), stack_size());
+           "size: %d argsize: %d closure.size: %d end sp: " PTR_FORMAT " start sp: %d chunk size: %d",
+           size, argsize(), closure._size, closure._sp - start_address(), sp(), stack_size());
     assert(argsize() == closure._argsize,
-      "argsize(): %d closure.argsize: %d closure.callee_interpreted: %d",
-      argsize(), closure._argsize, closure._callee_interpreted);
+           "argsize(): %d closure.argsize: %d closure.callee_interpreted: %d",
+           argsize(), closure._argsize, closure._callee_interpreted);
 
     int calculated_max_size = closure._size + closure._num_i2c * frame::align_wiggle;
     assert(max_size() == calculated_max_size,
-      "max_size(): %d calculated_max_size: %d argsize: %d num_i2c: %d",
-      max_size(), calculated_max_size, closure._argsize, closure._num_i2c);
+           "max_size(): %d calculated_max_size: %d argsize: %d num_i2c: %d",
+           max_size(), calculated_max_size, closure._argsize, closure._num_i2c);
 
     if (out_size   != nullptr) *out_size   += size;
     if (out_oops   != nullptr) *out_oops   += closure._num_oops;
@@ -704,22 +705,23 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
     assert(bitmap().size() == align_up((size_t)(stack_size() << (UseCompressedOops ? 1 : 0)), BitsPerWord),
       "bitmap().size(): %zu stack_size: %d",
       bitmap().size(), stack_size());
+
     int oop_count;
     if (UseCompressedOops) {
       StackChunkVerifyBitmapClosure<narrowOop> bitmap_closure(this);
       bitmap().iterate(&bitmap_closure,
-        bit_index_for((narrowOop*)(sp_address() - frame::metadata_words)),
-        bit_index_for((narrowOop*)end_address()));
+                       bit_index_for((narrowOop*)(sp_address() - frame::metadata_words)),
+                       bit_index_for((narrowOop*)end_address()));
       oop_count = bitmap_closure._count;
     } else {
       StackChunkVerifyBitmapClosure<oop> bitmap_closure(this);
       bitmap().iterate(&bitmap_closure,
-        bit_index_for((oop*)(sp_address() - frame::metadata_words)),
-        bit_index_for((oop*)end_address()));
+                       bit_index_for((oop*)(sp_address() - frame::metadata_words)),
+                       bit_index_for((oop*)end_address()));
       oop_count = bitmap_closure._count;
     }
     assert(oop_count == closure._num_oops,
-      "bitmap_closure._count: %d closure._num_oops: %d", oop_count, closure._num_oops);
+           "bitmap_closure._count: %d closure._num_oops: %d", oop_count, closure._num_oops);
   }
 
   return true;

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -702,9 +702,9 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
   }
 
   if (has_bitmap()) {
-    assert(bitmap().size() == align_up((size_t)(stack_size() << (UseCompressedOops ? 1 : 0)), BitsPerWord),
-      "bitmap().size(): %zu stack_size: %d",
-      bitmap().size(), stack_size());
+    assert(bitmap().size() == InstanceStackChunkKlass::bitmap_size_in_bits(stack_size()),
+           "bitmap().size(): %zu stack_size: %d",
+           bitmap().size(), stack_size());
 
     int oop_count;
     if (UseCompressedOops) {

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -651,9 +651,6 @@ bool stackChunkOopDesc::verify(size_t* out_size, int* out_oops, int* out_frames,
   assert(oopDesc::is_oop_or_null(parent()), "");
 
   const bool concurrent = !Thread::current()->is_Java_thread();
-  const bool gc_mode = is_gc_mode();
-  const bool is_last = parent() == nullptr;
-  const bool mixed = has_mixed_frames();
 
   // if argsize == 0 and the chunk isn't mixed, the chunk contains the metadata (pc, fp -- frame::sender_sp_offset)
   // for the top frame (below sp), and *not* for the bottom frame

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -45,10 +45,10 @@ typedef VMRegImpl* VMReg;
 // max_size is the maximum space a thawed chunk would take up on the stack, *not* including top-most frame's metadata
 class stackChunkOopDesc : public instanceOopDesc {
 public:
-  enum class barrier_type { LOAD, STORE };
+  enum class BarrierType { Load, Store };
 
 private:
-  template <barrier_type barrier> friend class DoBarriersStackClosure;
+  template <BarrierType barrier> friend class DoBarriersStackClosure;
 
   // Chunk flags.
   static const uint8_t FLAG_HAS_INTERPRETED_FRAMES = 1;
@@ -122,10 +122,10 @@ public:
 
   inline bool requires_barriers();
 
-  template <barrier_type>
+  template <BarrierType>
   void do_barriers();
 
-  template <barrier_type, chunk_frames frames, typename RegisterMapT>
+  template <BarrierType, chunk_frames frames, typename RegisterMapT>
   inline void do_barriers(const StackChunkFrameStream<frames>& f, const RegisterMapT* map);
 
   template <typename RegisterMapT>
@@ -178,7 +178,7 @@ public:
               int* out_frames = NULL, int* out_interpreted_frames = NULL) NOT_DEBUG({ return true; });
 
 private:
-  template <barrier_type barrier, chunk_frames frames = chunk_frames::MIXED, typename RegisterMapT>
+  template <BarrierType barrier, chunk_frames frames = chunk_frames::MIXED, typename RegisterMapT>
   void do_barriers0(const StackChunkFrameStream<frames>& f, const RegisterMapT* map);
 
   template <chunk_frames frames, class StackChunkFrameClosureType>

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -125,7 +125,7 @@ public:
   template <BarrierType>
   void do_barriers();
 
-  template <BarrierType, chunk_frames frames, typename RegisterMapT>
+  template <BarrierType, ChunkFrames frames, typename RegisterMapT>
   inline void do_barriers(const StackChunkFrameStream<frames>& f, const RegisterMapT* map);
 
   template <typename RegisterMapT>
@@ -178,10 +178,10 @@ public:
               int* out_frames = NULL, int* out_interpreted_frames = NULL) NOT_DEBUG({ return true; });
 
 private:
-  template <BarrierType barrier, chunk_frames frames = chunk_frames::MIXED, typename RegisterMapT>
+  template <BarrierType barrier, ChunkFrames frames = ChunkFrames::Mixed, typename RegisterMapT>
   void do_barriers0(const StackChunkFrameStream<frames>& f, const RegisterMapT* map);
 
-  template <chunk_frames frames, class StackChunkFrameClosureType>
+  template <ChunkFrames frames, class StackChunkFrameClosureType>
   inline void iterate_stack(StackChunkFrameClosureType* closure);
 
   inline intptr_t* relative_base() const;

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -52,8 +52,8 @@ private:
 
   // Chunk flags.
   static const uint8_t FLAG_HAS_INTERPRETED_FRAMES = 1;
-  static const uint8_t FLAG_GC_MODE = 1 << 2; // once true it and FLAG_HAS_INTERPRETED_FRAMES can't change
-  static const uint8_t FLAG_HAS_BITMAP = 1 << 3; // can only be true if FLAG_GC_MODE is true
+  static const uint8_t FLAG_GC_MODE = 1 << 2; // Once true it and FLAG_HAS_INTERPRETED_FRAMES can't change
+  static const uint8_t FLAG_HAS_BITMAP = 1 << 3; // Can only be true if FLAG_GC_MODE is true
 
 public:
   static inline stackChunkOop cast(oop obj);

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -150,7 +150,7 @@ inline bool stackChunkOopDesc::requires_barriers() {
   return Universe::heap()->requires_barriers(this);
 }
 
-template <stackChunkOopDesc::barrier_type barrier, chunk_frames frame_kind, typename RegisterMapT>
+template <stackChunkOopDesc::BarrierType barrier, chunk_frames frame_kind, typename RegisterMapT>
 void stackChunkOopDesc::do_barriers(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
   if (frame_kind == chunk_frames::MIXED) {
     // we could freeze deopted frames in slow mode.

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -150,9 +150,9 @@ inline bool stackChunkOopDesc::requires_barriers() {
   return Universe::heap()->requires_barriers(this);
 }
 
-template <stackChunkOopDesc::BarrierType barrier, chunk_frames frame_kind, typename RegisterMapT>
+template <stackChunkOopDesc::BarrierType barrier, ChunkFrames frame_kind, typename RegisterMapT>
 void stackChunkOopDesc::do_barriers(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
-  if (frame_kind == chunk_frames::MIXED) {
+  if (frame_kind == ChunkFrames::Mixed) {
     // we could freeze deopted frames in slow mode.
     f.handle_deopted();
   }
@@ -161,11 +161,11 @@ void stackChunkOopDesc::do_barriers(const StackChunkFrameStream<frame_kind>& f, 
 
 template <class StackChunkFrameClosureType>
 inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure) {
-  has_mixed_frames() ? iterate_stack<chunk_frames::MIXED>(closure)
-                     : iterate_stack<chunk_frames::COMPILED_ONLY>(closure);
+  has_mixed_frames() ? iterate_stack<ChunkFrames::Mixed>(closure)
+                     : iterate_stack<ChunkFrames::CompiledOnly>(closure);
 }
 
-template <chunk_frames frame_kind, class StackChunkFrameClosureType>
+template <ChunkFrames frame_kind, class StackChunkFrameClosureType>
 inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure) {
   const SmallRegisterMap* map = SmallRegisterMap::instance;
   assert(!map->in_cont(), "");
@@ -189,7 +189,7 @@ inline void stackChunkOopDesc::iterate_stack(StackChunkFrameClosureType* closure
   assert(!f.is_stub(), "");
 
   for(; should_continue && !f.is_done(); f.next(map)) {
-    if (frame_kind == chunk_frames::MIXED) {
+    if (frame_kind == ChunkFrames::Mixed) {
       // in slow mode we might freeze deoptimized frames
       f.handle_deopted();
     }

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -203,10 +203,9 @@ inline frame stackChunkOopDesc::derelativize(frame fr) const { derelativize_fram
 inline BitMapView stackChunkOopDesc::bitmap() const {
   int stack_sz = stack_size();
 
-  // The bitmap is located after the stack
+  // The bitmap is located after the stack.
   HeapWord* bitmap_addr = start_of_stack() + stack_sz;
-  size_t bitmap_size = InstanceStackChunkKlass::bitmap_size(stack_sz);
-  size_t bitmap_size_in_bits = bitmap_size << LogBitsPerWord;
+  size_t bitmap_size_in_bits = InstanceStackChunkKlass::bitmap_size_in_bits(stack_sz);
 
   BitMapView bitmap((BitMap::bm_word_t*)bitmap_addr, bitmap_size_in_bits);
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -469,7 +469,7 @@ const frame ContinuationWrapper::last_frame() {
   if (chunk == nullptr) {
     return frame();
   }
-  return StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame();
+  return StackChunkFrameStream<ChunkFrames::Mixed>(chunk).to_frame();
 }
 
 inline stackChunkOop ContinuationWrapper::nonempty_chunk(stackChunkOop chunk) const {
@@ -1436,7 +1436,7 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
       bool top_interpreted = Interpreter::contains(chunk->pc());
       unextended_sp = chunk->sp();
       if (top_interpreted) {
-        StackChunkFrameStream<chunk_frames::MIXED> last(chunk);
+        StackChunkFrameStream<ChunkFrames::Mixed> last(chunk);
         unextended_sp += last.unextended_sp() - last.sp(); // can be negative (-1), often with lambda forms
       }
       if (callee.is_interpreted_frame() == top_interpreted) {
@@ -1451,7 +1451,7 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
   assert(_size >= 0, "");
 
   assert(chunk == nullptr || chunk->is_empty()
-          || unextended_sp == chunk->to_offset(StackChunkFrameStream<chunk_frames::MIXED>(chunk).unextended_sp()), "");
+          || unextended_sp == chunk->to_offset(StackChunkFrameStream<ChunkFrames::Mixed>(chunk).unextended_sp()), "");
   assert(chunk != nullptr || unextended_sp < _size, "");
 
     // _barriers can be set to true by an allocation in freeze_fast, in which case the chunk is available
@@ -1501,8 +1501,8 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
   assert(!_barriers || chunk->is_empty(), "");
 
   assert(!chunk->has_bitmap(), "");
-  assert(!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).is_done(), "");
-  assert(!chunk->is_empty() || StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame().is_empty(), "");
+  assert(!chunk->is_empty() || StackChunkFrameStream<ChunkFrames::Mixed>(chunk).is_done(), "");
+  assert(!chunk->is_empty() || StackChunkFrameStream<ChunkFrames::Mixed>(chunk).to_frame().is_empty(), "");
 
   // We unwind frames after the last safepoint so that the GC will have found the oops in the frames, but before
   // writing into the chunk. This is so that an asynchronous stack walk (not at a safepoint) that suspends us here
@@ -1517,7 +1517,7 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
     chunk->print_on(&ls);
   }
 
-  caller = StackChunkFrameStream<chunk_frames::MIXED>(chunk).to_frame();
+  caller = StackChunkFrameStream<ChunkFrames::Mixed>(chunk).to_frame();
 
   DEBUG_ONLY(_last_write = caller.unextended_sp() + (empty_chunk ? argsize : overlap);)
   assert(chunk->is_in_chunk(_last_write - _size),
@@ -2121,7 +2121,7 @@ protected:
   intptr_t* _top_unextended_sp;
   int _align_size;
 
-  StackChunkFrameStream<chunk_frames::MIXED> _stream;
+  StackChunkFrameStream<ChunkFrames::Mixed> _stream;
 
   NOT_PRODUCT(int _frames;)
 
@@ -2252,7 +2252,7 @@ NOINLINE intptr_t* Thaw<ConfigT>::thaw_fast(stackChunkOop chunk) {
   } else { // thaw a single frame
     partial = true;
 
-    StackChunkFrameStream<chunk_frames::COMPILED_ONLY> f(chunk);
+    StackChunkFrameStream<ChunkFrames::CompiledOnly> f(chunk);
     assert(chunk_sp == f.sp(), "");
     assert(chunk_sp == f.unextended_sp(), "");
 
@@ -2367,7 +2367,7 @@ NOINLINE intptr_t* ThawBase::thaw_slow(stackChunkOop chunk, bool return_barrier)
   int num_frames = (return_barrier ? 1 : 2);
   bool last_interpreted = chunk->has_mixed_frames() && Interpreter::contains(chunk->pc());
 
-  _stream = StackChunkFrameStream<chunk_frames::MIXED>(chunk);
+  _stream = StackChunkFrameStream<ChunkFrames::Mixed>(chunk);
   _top_unextended_sp = _stream.unextended_sp();
 
   frame hf = _stream.to_frame();

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -882,17 +882,6 @@ void Continuation::describe(FrameValues &values) {
 }
 #endif
 
-void Continuation::emit_chunk_iterate_event(oop chunk, int num_frames, int num_oops) {
-  EventContinuationIterateOops e;
-  if (e.should_commit()) {
-    e.set_id(cast_from_oop<u8>(chunk));
-    e.set_safepoint(SafepointSynchronize::is_at_safepoint());
-    e.set_numFrames((u2)num_frames);
-    e.set_numOops((u2)num_oops);
-    e.commit();
-  }
-}
-
 #ifdef ASSERT
 void Continuation::debug_verify_continuation(oop contOop) {
   if (!VerifyContinuations) {

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -1743,7 +1743,7 @@ NOINLINE void FreezeBase::finish_freeze(const frame& f, const frame& top) {
 
   if (UNLIKELY(_barriers)) {
     log_develop_trace(continuations)("do barriers on old chunk");
-    _cont.tail()->do_barriers<stackChunkOopDesc::barrier_type::STORE>();
+    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>();
   }
 
   log_develop_trace(continuations)("finish_freeze: has_mixed_frames: %d", chunk->has_mixed_frames());
@@ -2525,7 +2525,7 @@ NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& c
   assert(hf.is_interpreted_frame(), "");
 
   if (UNLIKELY(_barriers)) {
-    _cont.tail()->do_barriers<stackChunkOopDesc::barrier_type::STORE>(_stream, SmallRegisterMap::instance);
+    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance);
   }
 
   const bool bottom = recurse_thaw_java_frame<ContinuationHelper::InterpretedFrame>(caller, num_frames);
@@ -2591,7 +2591,7 @@ void ThawBase::recurse_thaw_compiled_frame(const frame& hf, frame& caller, int n
   assert(_cont.is_preempted() || !stub_caller, "stub caller not at preemption");
 
   if (!stub_caller && UNLIKELY(_barriers)) { // recurse_thaw_stub_frame already invoked our barriers with a full regmap
-    _cont.tail()->do_barriers<stackChunkOopDesc::barrier_type::STORE>(_stream, SmallRegisterMap::instance);
+    _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, SmallRegisterMap::instance);
   }
 
   const bool bottom = recurse_thaw_java_frame<ContinuationHelper::CompiledFrame>(caller, num_frames);
@@ -2664,7 +2664,7 @@ void ThawBase::recurse_thaw_stub_frame(const frame& hf, frame& caller, int num_f
     _stream.next(&map);
     assert(!_stream.is_done(), "");
     if (UNLIKELY(_barriers)) { // we're now doing this on the stub's caller
-      _cont.tail()->do_barriers<stackChunkOopDesc::barrier_type::STORE>(_stream, &map);
+      _cont.tail()->do_barriers<stackChunkOopDesc::BarrierType::Store>(_stream, &map);
     }
     assert(!_stream.is_done(), "");
   }

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -3076,7 +3076,7 @@ private:
 
     freeze_entry = (address)freeze<SelectedConfigT>;
 
-    // if we want, we could templatize by king and have three different that entries
+    // If we wanted, we could templatize by kind and have three different thaw entries
     thaw_entry   = (address)thaw<SelectedConfigT>;
   }
 };

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -103,7 +103,6 @@ public:
 
 private:
   friend class InstanceStackChunkKlass;
-  static void emit_chunk_iterate_event(oop chunk, int num_frames, int num_oops);
 
 #ifdef ASSERT
 public:

--- a/src/hotspot/share/runtime/stackChunkFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.cpp
@@ -27,13 +27,13 @@
 #include "utilities/ostream.hpp"
 
 #ifndef PRODUCT
-template void StackChunkFrameStream<chunk_frames::MIXED>::print_on(outputStream* st) const;
-template void StackChunkFrameStream<chunk_frames::COMPILED_ONLY>::print_on(outputStream* st) const;
+template void StackChunkFrameStream<ChunkFrames::Mixed>::print_on(outputStream* st) const;
+template void StackChunkFrameStream<ChunkFrames::CompiledOnly>::print_on(outputStream* st) const;
 
-template <chunk_frames frames>
+template <ChunkFrames frames>
 void StackChunkFrameStream<frames>::print_on(outputStream* st) const {
   st->print_cr("chunk: " INTPTR_FORMAT " index: %d sp offset: %d stack size: %d",
-    p2i(_chunk), _index, _chunk->to_offset(_sp), _chunk->stack_size());
+               p2i(_chunk), _index, _chunk->to_offset(_sp), _chunk->stack_size());
   to_frame().print_on(st);
 }
 #endif

--- a/src/hotspot/share/runtime/stackChunkFrameStream.hpp
+++ b/src/hotspot/share/runtime/stackChunkFrameStream.hpp
@@ -36,9 +36,9 @@ class ImmutableOopMap;
 class VMRegImpl;
 typedef VMRegImpl* VMReg;
 
-enum chunk_frames { COMPILED_ONLY, MIXED };
+enum ChunkFrames { CompiledOnly, Mixed };
 
-template <chunk_frames frame_kind>
+template <ChunkFrames frame_kind>
 class StackChunkFrameStream : public StackObj {
 private:
   intptr_t* _end;
@@ -73,7 +73,7 @@ public:
   intptr_t*        sp() const  { return _sp; }
   inline address   pc() const  { return get_pc(); }
   inline intptr_t* fp() const;
-  inline intptr_t* unextended_sp() const { return frame_kind == chunk_frames::MIXED ? _unextended_sp : _sp; }
+  inline intptr_t* unextended_sp() const { return frame_kind == ChunkFrames::Mixed ? _unextended_sp : _sp; }
   NOT_PRODUCT(int index() { return _index; })
   inline address orig_pc() const;
 

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -128,10 +128,6 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
-    <event name="jdk.ContinuationIterateOops">
-      <setting name="enabled">true</setting>
-    </event>
-
     <event name="jdk.ContinuationFreezeYoung">
       <setting name="enabled">true</setting>
     </event>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -128,10 +128,6 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
-    <event name="jdk.ContinuationIterateOops">
-      <setting name="enabled">true</setting>
-    </event>
-
     <event name="jdk.ContinuationFreezeYoung">
       <setting name="enabled">true</setting>
     </event>


### PR DESCRIPTION
Hi all,

  please review these minor cleanups containing (I tried to separate these into distinct commits)
- more removal of dead code, including removal of the `ContinuationIterateOops` JFR event: alone, it does not give any actionable information (only triggers for stack chunk iteration), in a very bloated way (one event per stackchunk iteration), where it's data potentially has overflow issues (only 32k stack frames, only 32k oops within a chunk).
- some cleanup of comments (punctuation, initial casing)
- improved `instanceStackChunkKlass::bitmap_size` using some available constants instead of the check
- named (enum) classes according to style guide (CamelCase)

Testing: loom-tier1-3, no new issue (there is some JVMTI related crash in kitchensink, but that may already been fixed).

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.java.net/loom pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/137.diff">https://git.openjdk.java.net/loom/pull/137.diff</a>

</details>
