### PR TITLE
Some more descriptive names, removed redundant asserts.  Request for comments.

### DIFF
--- a/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuationHelper_aarch64.inline.hpp
@@ -97,12 +97,12 @@ void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, Continu
   anchor->set_last_Java_fp(entry->entry_fp());
 }
 
+#ifdef ASSERT
 void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   intptr_t* fp = *(intptr_t**)(sp - frame::sender_sp_offset);
   anchor->set_last_Java_fp(fp);
 }
 
-#ifdef ASSERT
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());

--- a/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/continuation_aarch64.inline.hpp
@@ -86,9 +86,8 @@ frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
     *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + locals - 1;
     return hf;
   } else {
-    // we need to re-read fp because it may be an oop and we might have had a safepoint in finalize_freeze,
-    // after constructing f.
-    // This comment doesn't make sense since we don't reread fp
+    // We need to re-read fp out of the frame because it may be an oop and we might have
+    // had a safepoint in finalize_freeze, after constructing f.
     fp = *(intptr_t**)(f.sp() - frame::sender_sp_offset);
 
     int fsize = FKind::size(f);

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -239,12 +239,6 @@ inline int frame::frame_size() const {
     : cb()->frame_size();
 }
 
-inline int frame::num_oops() const {
-  assert(!is_interpreted_frame(), "interpreted");
-  assert(oop_map() != NULL, "");
-  return oop_map()->num_oops() ;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   assert(cb()->is_compiled(), "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;

--- a/src/hotspot/cpu/arm/continuationHelper_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuationHelper_arm.inline.hpp
@@ -33,6 +33,20 @@
 
 // TODO: Implement
 
+frame ContinuationEntry::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+intptr_t* ContinuationEntry::entry_fp() const {
+  Unimplemented();
+  return nullptr;
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
+  Unimplemented();
+}
+
 template<typename FKind>
 static inline intptr_t** link_address(const frame& f) {
   Unimplemented();
@@ -62,8 +76,15 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
 
 #ifdef ASSERT
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   Unimplemented();
   return false;

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -29,23 +29,6 @@
 #include "runtime/frame.hpp"
 #include "runtime/frame.inline.hpp"
 
-frame ContinuationEntry::to_frame() const {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  Unimplemented();
-}
-
 inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
@@ -59,6 +42,10 @@ inline frame FreezeBase::sender(const frame& f) {
 template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
+}
+
+void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
+  Unimplemented();
 }
 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
@@ -98,11 +85,6 @@ inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& cal
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
-}
-
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
-  Unimplemented();
-  return NULL;
 }
 
 void ThawBase::patch_chunk_pd(intptr_t* sp) {

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -69,7 +69,7 @@ inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void FreezeBase::patch_chunk_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
   Unimplemented();
 }
 
@@ -91,7 +91,7 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/cpu/arm/continuation_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/continuation_arm.inline.hpp
@@ -56,7 +56,7 @@ inline frame FreezeBase::sender(const frame& f) {
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
@@ -78,7 +78,7 @@ inline frame ThawBase::new_entry_frame() {
   return frame();
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
   Unimplemented();
   return frame();
 }

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -54,7 +54,11 @@
     interpreter_frame_monitor_block_bottom_offset    = interpreter_frame_initial_sp_offset,
 
     // Entry frames
-    entry_frame_call_wrapper_offset                  =  0
+    entry_frame_call_wrapper_offset                  =  0,
+    metadata_words                                   = sender_sp_offset,
+    frame_alignment                                  = 16,
+    // size, in words, of maximum shift in frame position due to alignment
+    align_wiggle                                     =  1
   };
 
   intptr_t ptr_at(int offset) const {

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -40,6 +40,7 @@ inline frame::frame() {
   _cb = NULL;
   _deopt_state = unknown;
   _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 }
 
 inline frame::frame(intptr_t* sp) {
@@ -54,6 +55,7 @@ inline void frame::init(intptr_t* sp, intptr_t* fp, address pc) {
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
+  DEBUG_ONLY(_frame_index = -1;)
 
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
@@ -77,6 +79,7 @@ inline frame::frame(intptr_t* sp, intptr_t* unextended_sp, intptr_t* fp, address
   assert(pc != NULL, "no pc?");
   _cb = CodeCache::find_blob(pc);
   adjust_unextended_sp();
+  DEBUG_ONLY(_frame_index = -1;)
 
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
@@ -100,6 +103,7 @@ inline frame::frame(intptr_t* sp, intptr_t* fp) {
   // assert(_pc != NULL, "no pc?"); // see comments in x86
   _cb = CodeCache::find_blob(_pc);
   adjust_unextended_sp();
+  DEBUG_ONLY(_frame_index = -1;)
 
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {

--- a/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuationHelper_ppc.inline.hpp
@@ -33,6 +33,20 @@
 
 // TODO: Implement
 
+frame ContinuationEntry::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+intptr_t* ContinuationEntry::entry_fp() const {
+  Unimplemented();
+  return nullptr;
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
+  Unimplemented();
+}
+
 template<typename FKind>
 static inline intptr_t** link_address(const frame& f) {
   Unimplemented();
@@ -63,7 +77,15 @@ inline void ContinuationHelper::push_pd(const frame& f) {
 }
 
 
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
 #ifdef ASSERT
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   Unimplemented();
   return false;

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -29,22 +29,6 @@
 #include "runtime/frame.hpp"
 #include "runtime/frame.inline.hpp"
 
-frame ContinuationEntry::to_frame() const {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  Unimplemented();
-}
 
 inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
@@ -59,6 +43,10 @@ inline frame FreezeBase::sender(const frame& f) {
 template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
+}
+
+void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
+  Unimplemented();
 }
 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
@@ -98,11 +86,6 @@ inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& cal
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
-}
-
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
-  Unimplemented();
-  return NULL;
 }
 
 void ThawBase::patch_chunk_pd(intptr_t* sp) {

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -69,7 +69,7 @@ inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void FreezeBase::patch_chunk_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
   Unimplemented();
 }
 
@@ -91,7 +91,7 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/continuation_ppc.inline.hpp
@@ -56,7 +56,7 @@ inline frame FreezeBase::sender(const frame& f) {
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
@@ -78,7 +78,7 @@ inline frame ThawBase::new_entry_frame() {
   return frame();
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
   Unimplemented();
   return frame();
 }

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -419,7 +419,11 @@
 
   enum {
     // normal return address is 1 bundle past PC
-    pc_return_offset = 0
+    pc_return_offset = 0,
+    metadata_words   = 0,
+    frame_alignment  = 16,
+    // size, in words, of maximum shift in frame position due to alignment
+    align_wiggle     =  1
   };
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -56,17 +56,31 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
 inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL),  _deopt_state(unknown), _on_heap(false),
+#ifdef ASSERT
+                        _frame_index(-1),
+#endif
                         _unextended_sp(NULL), _fp(NULL) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                        _frame_index(-1),
+#endif
+                        _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->lr); // also sets _fp and adjusts _unextended_sp
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                         _frame_index(-1),
+#endif
+                        _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }
 
 inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                    _frame_index(-1),
+#endif
                     _unextended_sp(unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // also sets _fp and adjusts _unextended_sp
 }

--- a/src/hotspot/cpu/s390/continuationHelper_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuationHelper_s390.inline.hpp
@@ -33,6 +33,20 @@
 
 // TODO: Implement
 
+frame ContinuationEntry::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+intptr_t* ContinuationEntry::entry_fp() const {
+  Unimplemented();
+  return nullptr;
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
+  Unimplemented();
+}
+
 template<typename FKind>
 static inline intptr_t** link_address(const frame& f) {
   Unimplemented();
@@ -62,8 +76,15 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
 
 #ifdef ASSERT
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   Unimplemented();
   return false;

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -29,23 +29,6 @@
 #include "runtime/frame.hpp"
 #include "runtime/frame.inline.hpp"
 
-frame ContinuationEntry::to_frame() const {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  Unimplemented();
-}
-
 inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
@@ -59,6 +42,10 @@ inline frame FreezeBase::sender(const frame& f) {
 template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
+}
+
+void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
+  Unimplemented();
 }
 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
@@ -98,11 +85,6 @@ inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& cal
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
-}
-
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
-  Unimplemented();
-  return NULL;
 }
 
 void ThawBase::patch_chunk_pd(intptr_t* sp) {

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -69,7 +69,7 @@ inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void FreezeBase::patch_chunk_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
   Unimplemented();
 }
 
@@ -91,7 +91,7 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/cpu/s390/continuation_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/continuation_s390.inline.hpp
@@ -56,7 +56,7 @@ inline frame FreezeBase::sender(const frame& f) {
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
@@ -78,7 +78,7 @@ inline frame ThawBase::new_entry_frame() {
   return frame();
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
   Unimplemented();
   return frame();
 }

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -554,6 +554,10 @@
     //
     // Normal return address is the instruction following the branch.
     pc_return_offset =  0,
+    metadata_words   = 0,
+    frame_alignment  = 16,
+    // size, in words, of maximum shift in frame position due to alignment
+    align_wiggle     =  1
   };
 
   static jint interpreter_frame_expression_stack_direction() { return -1; }

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -55,17 +55,31 @@ inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
 inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _on_heap(false),
+#ifdef ASSERT
+                        _frame_index(-1),
+#endif
                         _unextended_sp(NULL), _fp(NULL) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                        _frame_index(-1),
+#endif
+                        _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->return_pc);
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false), _unextended_sp(sp) {
+inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                        _frame_index(-1),
+#endif
+                        _unextended_sp(sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
 
 inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _on_heap(false),
+#ifdef ASSERT
+                                                                         _frame_index(-1),
+#endif
                                                                          _unextended_sp(unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
 }
@@ -74,6 +88,9 @@ inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp)
 #ifndef PRODUCT
 inline frame::frame(void* sp, void* pc, void* unextended_sp) :
   _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _on_heap(false),
+#ifdef ASSERT
+  _frame_index(-1),
+#endif
   _unextended_sp((intptr_t*)unextended_sp) {
   find_codeblob_and_set_pc_and_deopt_state((address)pc); // Also sets _fp and adjusts _unextended_sp.
 }

--- a/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuationHelper_x86.inline.hpp
@@ -80,12 +80,12 @@ void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, Continu
   anchor->set_last_Java_fp(entry->entry_fp());
 }
 
+#ifdef ASSERT
 void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
   intptr_t* fp = *(intptr_t**)(sp - frame::sender_sp_offset);
   anchor->set_last_Java_fp(fp);
 }
 
-#ifdef ASSERT
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -77,7 +77,7 @@ inline frame FreezeBase::sender(const frame& f) {
 }
 
 template<typename FKind>
-frame FreezeBase::new_hframe(frame& f, frame& caller) {
+frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   assert(FKind::is_instance(f), "");
   assert(!caller.is_interpreted_frame()
     || caller.unextended_sp() == (intptr_t*)caller.at(frame::interpreter_frame_last_sp_offset), "");
@@ -88,7 +88,7 @@ frame FreezeBase::new_hframe(frame& f, frame& caller) {
       || f.unextended_sp() == (intptr_t*)f.at(frame::interpreter_frame_last_sp_offset), "");
     int locals = f.interpreter_frame_method()->max_locals();
     bool overlap_caller = caller.is_interpreted_frame() || caller.is_empty();
-    fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ? ContinuationHelper::InterpretedFrame::stack_argsize(f) : 0);
+    fp = caller.unextended_sp() - (locals + frame::sender_sp_offset) + (overlap_caller ?  ContinuationHelper::InterpretedFrame::stack_argsize(f) : 0);
     sp = fp - (f.fp() - f.unextended_sp());
     assert(sp <= fp, "");
     assert(fp <= caller.unextended_sp(), "");
@@ -100,7 +100,11 @@ frame FreezeBase::new_hframe(frame& f, frame& caller) {
     *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + locals - 1;
     return hf;
   } else {
-    fp = *(intptr_t**)(f.sp() - frame::sender_sp_offset); // we need to re-read fp because it may be an oop and we might have had a safepoint in finalize_freeze, after constructing f.
+    // we need to re-read fp because it may be an oop and we might have had a safepoint in
+    // finalize_freeze, after constructing f.
+    // This comment doesn't make sense since we don't reread fp
+    fp = *(intptr_t**)(f.sp() - frame::sender_sp_offset);
+
     int fsize = FKind::size(f);
     sp = caller.unextended_sp() - fsize;
     if (caller.is_interpreted_frame()) {
@@ -200,7 +204,7 @@ inline frame ThawBase::new_entry_frame() {
   return frame(sp, sp, _cont.entryFP(), _cont.entryPC()); // TODO PERF: This finds code blob and computes deopt state
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
   assert(FKind::is_instance(hf), "");
 
   if (FKind::interpreted) {

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -100,9 +100,8 @@ frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
     *hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + locals - 1;
     return hf;
   } else {
-    // we need to re-read fp because it may be an oop and we might have had a safepoint in
-    // finalize_freeze, after constructing f.
-    // This comment doesn't make sense since we don't reread fp
+    // We need to re-read fp out of the frame because it may be an oop and we might have
+    // had a safepoint in finalize_freeze, after constructing f.
     fp = *(intptr_t**)(f.sp() - frame::sender_sp_offset);
 
     int fsize = FKind::size(f);

--- a/src/hotspot/cpu/x86/continuation_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/continuation_x86.inline.hpp
@@ -49,9 +49,9 @@ frame ContinuationEntry::to_frame() const {
 
 // Fast path
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void FreezeBase::patch_chunk_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
   // copy the spilled rbp from the heap to the stack
-  *(vsp - frame::sender_sp_offset) = *(hsp - frame::sender_sp_offset);
+  *(frame_sp - frame::sender_sp_offset) = *(heap_sp - frame::sender_sp_offset);
 }
 
 // Slow path
@@ -207,15 +207,15 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
   assert(FKind::is_instance(hf), "");
 
   if (FKind::interpreted) {
-    intptr_t* hsp = hf.unextended_sp();
+    intptr_t* heap_sp = hf.unextended_sp();
     const int fsize = ContinuationHelper::InterpretedFrame::frame_bottom(hf) - hf.unextended_sp();
     const int locals = hf.interpreter_frame_method()->max_locals();
-    intptr_t* vsp = caller.unextended_sp() - fsize;
-    intptr_t* fp = vsp + (hf.fp() - hsp);
+    intptr_t* frame_sp = caller.unextended_sp() - fsize;
+    intptr_t* fp = frame_sp + (hf.fp() - heap_sp);
     DEBUG_ONLY(intptr_t* unextended_sp = fp + *hf.addr_at(frame::interpreter_frame_last_sp_offset);)
-    assert(vsp == unextended_sp, "");
+    assert(frame_sp == unextended_sp, "");
     caller.set_sp(fp + frame::sender_sp_offset);
-    frame f(vsp, vsp, fp, hf.pc());
+    frame f(frame_sp, frame_sp, fp, hf.pc());
     // it's set again later in derelativize_interpreted_frame_metadata, but we need to set the locals now so that we'll have the frame's bottom
     intptr_t offset = *hf.addr_at(frame::interpreter_frame_locals_offset);
     assert((int)offset == locals + frame::sender_sp_offset - 1, "");
@@ -223,16 +223,16 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
     return f;
   } else {
     int fsize = FKind::size(hf);
-    intptr_t* vsp = caller.unextended_sp() - fsize;
+    intptr_t* frame_sp = caller.unextended_sp() - fsize;
     if (bottom || caller.is_interpreted_frame()) {
       int argsize = hf.compiled_frame_stack_argsize();
 
       fsize += argsize;
-      vsp   -= argsize;
+      frame_sp   -= argsize;
       caller.set_sp(caller.sp() - argsize);
-      assert(caller.sp() == vsp + (fsize-argsize), "");
+      assert(caller.sp() == frame_sp + (fsize-argsize), "");
 
-      vsp = align(hf, vsp, caller, bottom);
+      frame_sp = align(hf, frame_sp, caller, bottom);
     }
 
     assert(hf.cb() != nullptr, "");
@@ -240,26 +240,26 @@ template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame&
     intptr_t* fp;
     if (PreserveFramePointer) {
       // we need to recreate a "real" frame pointer, pointing into the stack
-      fp = vsp + FKind::size(hf) - frame::sender_sp_offset;
+      fp = frame_sp + FKind::size(hf) - frame::sender_sp_offset;
     } else {
        // we need to re-read fp because it may be an oop and we might have fixed the frame.
       fp = *(intptr_t**)(hf.sp() - frame::sender_sp_offset);
     }
-    return frame(vsp, vsp, fp, hf.pc(), hf.cb(), hf.oop_map(), false); // TODO PERF : this computes deopt state; is it necessary?
+    return frame(frame_sp, frame_sp, fp, hf.pc(), hf.cb(), hf.oop_map(), false); // TODO PERF : this computes deopt state; is it necessary?
   }
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
 #ifdef _LP64
-  if (((intptr_t)vsp & 0xf) != 0) {
+  if (((intptr_t)frame_sp & 0xf) != 0) {
     assert(caller.is_interpreted_frame() || (bottom && hf.compiled_frame_stack_argsize() % 2 != 0), "");
-    vsp--;
+    frame_sp--;
     caller.set_sp(caller.sp() - 1);
   }
-  assert(is_aligned(vsp, frame::frame_alignment), "");
+  assert(is_aligned(frame_sp, frame::frame_alignment), "");
 #endif
 
-  return vsp;
+  return frame_sp;
 }
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -228,12 +228,6 @@ inline int frame::frame_size() const {
     : cb()->frame_size();
 }
 
-inline int frame::num_oops() const {
-  assert(!is_interpreted_frame(), "interpreted");
-  assert(oop_map() != NULL, "");
-  return oop_map()->num_oops() ;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   assert(cb()->is_compiled(), "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;

--- a/src/hotspot/cpu/zero/continuationHelper_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuationHelper_zero.inline.hpp
@@ -33,6 +33,20 @@
 
 // TODO: Implement
 
+frame ContinuationEntry::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+intptr_t* ContinuationEntry::entry_fp() const {
+  Unimplemented();
+  return nullptr;
+}
+
+void ContinuationEntry::update_register_map(RegisterMap* map) const {
+  Unimplemented();
+}
+
 template<typename FKind> // TODO: maybe do the same CRTP trick with Interpreted and Compiled as with hframe
 static inline intptr_t** link_address(const frame& f) {
   Unimplemented();
@@ -62,7 +76,15 @@ inline void ContinuationHelper::push_pd(const frame& f) {
   Unimplemented();
 }
 
+void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
 #ifdef ASSERT
+void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   Unimplemented();
   return false;

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -29,23 +29,6 @@
 #include "runtime/frame.hpp"
 #include "runtime/frame.inline.hpp"
 
-frame ContinuationEntry::to_frame() const {
-  Unimplemented();
-  return frame();
-}
-
-void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
-  Unimplemented();
-}
-
-void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  Unimplemented();
-}
-
 inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
   Unimplemented();
 }
@@ -59,6 +42,10 @@ inline frame FreezeBase::sender(const frame& f) {
 template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
+}
+
+void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
+  Unimplemented();
 }
 
 inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
@@ -98,11 +85,6 @@ inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& cal
 
 inline void ThawBase::patch_pd(frame& f, const frame& caller) {
   Unimplemented();
-}
-
-intptr_t* ThawBase::push_interpreter_return_frame(intptr_t* sp) {
-  Unimplemented();
-  return NULL;
 }
 
 void ThawBase::patch_chunk_pd(intptr_t* sp) {

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -69,7 +69,7 @@ inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
   Unimplemented();
 }
 
-inline void FreezeBase::patch_chunk_pd(intptr_t* vsp, intptr_t* hsp) {
+inline void FreezeBase::patch_chunk_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
   Unimplemented();
 }
 
@@ -91,7 +91,7 @@ inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, c
   Unimplemented();
 }
 
-inline intptr_t* ThawBase::align(const frame& hf, intptr_t* vsp, frame& caller, bool bottom) {
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/cpu/zero/continuation_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/continuation_zero.inline.hpp
@@ -56,7 +56,7 @@ inline frame FreezeBase::sender(const frame& f) {
   return frame();
 }
 
-template<typename FKind> frame FreezeBase::new_hframe(frame& f, frame& caller) {
+template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
   Unimplemented();
   return frame();
 }
@@ -78,7 +78,7 @@ inline frame ThawBase::new_entry_frame() {
   return frame();
 }
 
-template<typename FKind> frame ThawBase::new_frame(const frame& hf, frame& caller, bool bottom) {
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
   Unimplemented();
   return frame();
 }

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -30,7 +30,11 @@
 
  public:
   enum {
-    pc_return_offset = 0
+    pc_return_offset = 0,
+    metadata_words   = 0,
+    frame_alignment  = 16,
+    // size, in words, of maximum shift in frame position due to alignment
+    align_wiggle     =  1
   };
 
  const ImmutableOopMap* get_oop_map() const;

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -37,6 +37,7 @@ inline frame::frame() {
   _cb = NULL;
   _deopt_state = unknown;
   _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 }
 
 inline address  frame::sender_pc()           const { ShouldNotCallThis(); return NULL; }
@@ -49,6 +50,7 @@ inline frame::frame(ZeroFrame* zf, intptr_t* sp) {
   _zeroframe = zf;
   _sp = sp;
   _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
   switch (zeroframe()->type()) {
   case ZeroFrame::ENTRY_FRAME:
     _pc = StubRoutines::call_stub_return_pc();

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -104,4 +104,11 @@ inline CodeBlob* frame::get_cb() const {
   return _cb;
 }
 
+inline int frame::num_oops() const {
+  assert(!is_interpreted_frame(), "interpreted");
+  assert(oop_map() != NULL, "");
+  return oop_map()->num_oops() ;
+}
+
+
 #endif // SHARE_RUNTIME_FRAME_INLINE_HPP

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1047,8 +1047,8 @@ JavaThread::JavaThread() :
   _in_deopt_handler(0),
   _doing_unsafe_access(false),
   _do_not_unlock_if_synchronized(false),
-  _carrier_thread_suspended(false),
 #if INCLUDE_JVMTI
+  _carrier_thread_suspended(false),
   _is_in_VTMT(false),
 #ifdef ASSERT
   _is_VTMT_disabler(false),


### PR DESCRIPTION
Also, there's an if statement already for chunk_available which the compiler shouldn't have trouble optimizing.  Otherwise we should refactor freeze_fast.
Tested locally with make test TEST=jdk/jdk/internal/vm/Continuation since only names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/loom pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/139.diff">https://git.openjdk.java.net/loom/pull/139.diff</a>

</details>
