### PR TITLE
Use one future

### DIFF
--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -800,10 +800,10 @@ public class StructuredTaskScope<T> implements AutoCloseable {
 
     private static int stateToInt(Future.State s) {
         return switch (s) {
-            case RUNNING -> 0;
+            case RUNNING   -> 0;
             case CANCELLED -> 1;
-            case FAILED -> 2;
-            case SUCCESS -> 3;
+            case FAILED    -> 2;
+            case SUCCESS   -> 3;
         };
     }
 
@@ -946,10 +946,10 @@ public class StructuredTaskScope<T> implements AutoCloseable {
                 throw new IllegalStateException("No completed tasks");
             }
             return switch (f.state()) {
-                case SUCCESS -> f.resultNow();
-                case FAILED -> throw new ExecutionException(f.exceptionNow());
+                case SUCCESS   -> f.resultNow();
+                case FAILED    -> throw new ExecutionException(f.exceptionNow());
                 case CANCELLED -> throw new CancellationException();
-                default -> throw new InternalError("Unexpected value: " + f.state());
+                default        -> throw new InternalError("Unexpected value: " + f.state());
             };
         }
 

--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -798,7 +798,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
         }
     }
 
-    private static int stateToId(Future.State s) {
+    private static int stateToInt(Future.State s) {
         return switch (s) {
             case RUNNING -> 0;
             case CANCELLED -> 1;
@@ -809,7 +809,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
 
     // RUNNING < CANCELLED < FAILED < SUCCESS
     static final Comparator<Future.State> FUTURE_STATE_COMPARATOR =
-            Comparator.comparingInt(StructuredTaskScope::stateToId);
+            Comparator.comparingInt(StructuredTaskScope::stateToInt);
 
     /**
      * A StructuredTaskScope that captures the result of the first task to complete


### PR DESCRIPTION
Here's an example of changing the structured task scope impls, using one `Future` field and comparing future states. In effect the state can only increase monotonically (as per the order determined by the comparator).

The single future field could be made non-volatile, using the `VarHandle` for the volatile read in `handleComplete` since the happens-before edge should ensure the future is visible to the reading thread after `join`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.java.net/loom pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/144.diff">https://git.openjdk.java.net/loom/pull/144.diff</a>

</details>
