### PR TITLE
Loom: RISCV stubs

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -301,6 +301,10 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
   monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
 }
 
+void LIRGenerator::do_continuation_doYield(Intrinsic* x) {
+  fatal("Continuation.doYield intrinsic is not implemented on this platform");
+}
+
 // neg
 void LIRGenerator::do_NegateOp(NegateOp* x) {
   LIRItem from(x->x(), this);

--- a/src/hotspot/cpu/riscv/continuationEntry_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationEntry_riscv.inline.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +22,25 @@
  *
  */
 
-#include "precompiled.hpp"
-#include "runtime/registerMap.hpp"
-#include "vmreg_riscv.inline.hpp"
+#ifndef CPU_RISCV_CONTINUATIONENTRY_RISCV_INLINE_HPP
+#define CPU_RISCV_CONTINUATIONENTRY_RISCV_INLINE_HPP
 
-address RegisterMap::pd_location(VMReg base_reg, int slot_idx) const {
-  if (base_reg->is_VectorRegister()) {
-    assert(base_reg->is_concrete(), "must pass base reg");
-    int base_reg_enc = (base_reg->value() - ConcreteRegisterImpl::max_fpr) /
-                       VectorRegisterImpl::max_slots_per_register;
-    intptr_t offset_in_bytes = slot_idx * VMRegImpl::stack_slot_size;
-    address base_location = location(base_reg, nullptr);
-    if (base_location != NULL) {
-      return base_location + offset_in_bytes;
-    } else {
-      return NULL;
-    }
-  } else {
-    return location(base_reg->next(slot_idx), nullptr);
-  }
+#include "runtime/continuationEntry.hpp"
+
+// TODO: Implement
+
+inline frame ContinuationEntry::to_frame() const {
+  Unimplemented();
+  return frame();
 }
+
+inline intptr_t* ContinuationEntry::entry_fp() const {
+  Unimplemented();
+  return nullptr;
+}
+
+inline void ContinuationEntry::update_register_map(RegisterMap* map) const {
+  Unimplemented();
+}
+
+#endif // CPU_RISCV_CONTINUATIONENTRY_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_CONTINUATIONFREEZETHAW_RISCV_INLINE_HPP
+#define CPU_RISCV_CONTINUATIONFREEZETHAW_RISCV_INLINE_HPP
+
+#include "oops/stackChunkOop.inline.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/frame.inline.hpp"
+
+
+inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {
+  Unimplemented();
+}
+
+template<typename FKind>
+inline frame FreezeBase::sender(const frame& f) {
+  Unimplemented();
+  return frame();
+}
+
+template<typename FKind> frame FreezeBase::new_heap_frame(frame& f, frame& caller) {
+  Unimplemented();
+  return frame();
+}
+
+void FreezeBase::adjust_interpreted_frame_unextended_sp(frame& f) {
+  Unimplemented();
+}
+
+inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, const frame& hf) {
+  Unimplemented();
+}
+
+inline void FreezeBase::patch_pd(frame& hf, const frame& caller) {
+  Unimplemented();
+}
+
+inline void FreezeBase::patch_stack_pd(intptr_t* frame_sp, intptr_t* heap_sp) {
+  Unimplemented();
+}
+
+inline frame ThawBase::new_entry_frame() {
+  Unimplemented();
+  return frame();
+}
+
+template<typename FKind> frame ThawBase::new_stack_frame(const frame& hf, frame& caller, bool bottom) {
+  Unimplemented();
+  return frame();
+}
+
+inline void ThawBase::set_interpreter_frame_bottom(const frame& f, intptr_t* bottom) {
+  Unimplemented();
+}
+
+inline void ThawBase::derelativize_interpreted_frame_metadata(const frame& hf, const frame& f) {
+  Unimplemented();
+}
+
+inline intptr_t* ThawBase::align(const frame& hf, intptr_t* frame_sp, frame& caller, bool bottom) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void ThawBase::patch_pd(frame& f, const frame& caller) {
+  Unimplemented();
+}
+
+void ThawBase::patch_chunk_pd(intptr_t* sp) {
+  Unimplemented();
+}
+
+inline void ThawBase::prefetch_chunk_pd(void* start, int size) {
+  Unimplemented();
+}
+
+#endif // CPU_RISCV_CONTINUATIONFREEZETHAW_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_CONTINUATIONHELPER_RISCV_INLINE_HPP
+#define CPU_RISCV_CONTINUATIONHELPER_RISCV_INLINE_HPP
+
+#include "runtime/continuationHelper.hpp"
+
+template<typename FKind>
+static inline intptr_t** link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline int ContinuationHelper::frame_align_words(int size) {
+  Unimplemented();
+  return 0;
+}
+
+inline intptr_t* ContinuationHelper::frame_align_pointer(intptr_t* sp) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+inline void ContinuationHelper::update_register_map(const frame& f, RegisterMap* map) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::update_register_map_with_callee(const frame& f, RegisterMap* map) {
+  Unimplemented();
+}
+
+inline void ContinuationHelper::push_pd(const frame& f) {
+  Unimplemented();
+}
+
+
+inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* cont) {
+  Unimplemented();
+}
+
+#ifdef ASSERT
+inline void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
+  Unimplemented();
+  return false;
+}
+#endif
+
+inline intptr_t** ContinuationHelper::Frame::callee_link_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+template<typename FKind>
+static inline intptr_t* real_fp(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address* ContinuationHelper::InterpretedFrame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void ContinuationHelper::InterpretedFrame::patch_sender_sp(frame& f, intptr_t* sp) {
+  Unimplemented();
+}
+
+inline address* ContinuationHelper::Frame::return_pc_address(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline address ContinuationHelper::Frame::real_pc(const frame& f) {
+  Unimplemented();
+  return NULL;
+}
+
+inline void ContinuationHelper::Frame::patch_pc(const frame& f, address pc) {
+  Unimplemented();
+}
+
+inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f, InterpreterOopMap* mask) { // inclusive; this will be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* ContinuationHelper::InterpretedFrame::frame_bottom(const frame& f) { // exclusive; this will not be copied with the frame
+  Unimplemented();
+  return NULL;
+}
+
+inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f, int callee_argsize, bool callee_interpreted) {
+  Unimplemented();
+  return NULL;
+}
+
+#endif // CPU_RISCV_CONTINUATIONFRAMEHELPERS_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -135,7 +135,14 @@
     entry_frame_call_wrapper_offset                  = -10,
 
     // we don't need a save area
-    arg_reg_save_area_bytes                          =  0
+    arg_reg_save_area_bytes                          =  0,
+
+    // size, in words, of frame metadata (e.g. pc and link)
+    metadata_words                                   = sender_sp_offset,
+    // in bytes
+    frame_alignment                                  = 16,
+    // size, in words, of maximum shift in frame position due to alignment
+    align_wiggle                                     =  1
   };
 
   intptr_t ptr_at(int offset) const {
@@ -168,6 +175,8 @@
   static void verify_deopt_original_pc(   CompiledMethod* nm, intptr_t* unextended_sp);
 #endif
 
+  const ImmutableOopMap* get_oop_map() const;
+
  public:
   // Constructors
 
@@ -181,15 +190,15 @@
 
   // accessors for the instance variables
   // Note: not necessarily the real 'frame pointer' (see real_fp)
-  intptr_t*   fp() const { return _fp; }
+  intptr_t* fp() const { return _fp; }
 
   inline address* sender_pc_addr() const;
 
   // expression stack tos if we are nested in a java call
   intptr_t* interpreter_frame_last_sp() const;
 
-  // helper to update a map with callee-saved RBP
-  static void update_map_with_saved_link(RegisterMap* map, intptr_t** link_addr);
+  template <typename RegisterMapT>
+  static void update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr);
 
   // deoptimization support
   void interpreter_frame_set_last_sp(intptr_t* last_sp);
@@ -197,6 +206,6 @@
   static jint interpreter_frame_expression_stack_direction() { return -1; }
 
   // returns the sending frame, without applying any barriers
-  frame sender_raw(RegisterMap* map) const;
+  inline frame sender_raw(RegisterMap* map) const;
 
 #endif // CPU_RISCV_FRAME_RISCV_HPP

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -41,6 +41,8 @@ inline frame::frame() {
   _fp = NULL;
   _cb = NULL;
   _deopt_state = unknown;
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 }
 
 static int spin;
@@ -63,6 +65,9 @@ inline void frame::init(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
   } else {
     _deopt_state = not_deoptimized;
   }
+
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 }
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp, address pc) {
@@ -89,6 +94,13 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   } else {
     _deopt_state = not_deoptimized;
   }
+
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
+}
+
+inline frame::frame(intptr_t* ptr_sp) {
+  Unimplemented();
 }
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
@@ -119,6 +131,9 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   } else {
     _deopt_state = not_deoptimized;
   }
+
+  _on_heap = false;
+  DEBUG_ONLY(_frame_index = -1;)
 }
 
 // Accessors
@@ -150,6 +165,38 @@ inline intptr_t* frame::link_or_null() const {
 
 inline intptr_t* frame::unextended_sp() const     { return _unextended_sp; }
 
+inline void frame::set_unextended_sp(intptr_t* value) {
+  Unimplemented();
+}
+
+inline int frame::offset_unextended_sp() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::set_offset_unextended_sp(int value) {
+  Unimplemented();
+}
+
+inline intptr_t* frame::real_fp() const {
+  if (_cb != NULL) {
+    // use the frame size if valid
+    int size = _cb->frame_size();
+    if (size > 0) {
+      return unextended_sp() + size;
+    }
+  }
+  // else rely on fp()
+  assert(!is_compiled_frame(), "unknown compiled frame size");
+  return fp();
+}
+
+inline int frame::frame_size() const {
+  return is_interpreted_frame()
+    ? sender_sp() - sp()
+    : cb()->frame_size();
+}
+
 // Return address
 inline address* frame::sender_pc_addr() const     { return (address*) addr_at(return_addr_offset); }
 inline address  frame::sender_pc() const          { return *sender_pc_addr(); }
@@ -160,7 +207,7 @@ inline intptr_t** frame::interpreter_frame_locals_addr() const {
 }
 
 inline intptr_t* frame::interpreter_frame_last_sp() const {
-  return *(intptr_t**)addr_at(interpreter_frame_last_sp_offset);
+  return (intptr_t*)at(interpreter_frame_last_sp_offset);
 }
 
 inline intptr_t* frame::interpreter_frame_bcp_addr() const {
@@ -233,16 +280,130 @@ inline JavaCallWrapper** frame::entry_frame_call_wrapper_addr() const {
 PRAGMA_DIAG_PUSH
 PRAGMA_NONNULL_IGNORED
 inline oop frame::saved_oop_result(RegisterMap* map) const {
-  oop* result_adr = (oop *)map->location(x10->as_VMReg());
+  oop* result_adr = (oop *)map->location(x10->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
   return (*result_adr);
 }
 
 inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
-  oop* result_adr = (oop *)map->location(x10->as_VMReg());
+  oop* result_adr = (oop *)map->location(x10->as_VMReg(), nullptr);
   guarantee(result_adr != NULL, "bad register save location");
   *result_adr = obj;
 }
 PRAGMA_DIAG_POP
+
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  Unimplemented();
+  return NULL;
+}
+
+inline int frame::compiled_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
+  Unimplemented();
+}
+
+inline int frame::sender_sp_ret_address_offset() {
+  Unimplemented();
+  return 0;
+}
+
+//------------------------------------------------------------------------------
+// frame::sender
+frame frame::sender(RegisterMap* map) const {
+  frame result = sender_raw(map);
+
+  if (map->process_frames()) {
+    StackWatermarkSet::on_iteration(map->thread(), result);
+  }
+
+  return result;
+}
+
+//------------------------------------------------------------------------------
+// frame::sender_raw
+frame frame::sender_raw(RegisterMap* map) const {
+  // Default is we done have to follow them. The sender_for_xxx will
+  // update it accordingly
+  assert(map != NULL, "map must be set");
+  map->set_include_argument_oops(false);
+
+  if (is_entry_frame()) {
+    return sender_for_entry_frame(map);
+  }
+  if (is_interpreted_frame()) {
+    return sender_for_interpreter_frame(map);
+  }
+  assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
+
+  // This test looks odd: why is it not is_compiled_frame() ?  That's
+  // because stubs also have OOP maps.
+  if (_cb != NULL) {
+    return sender_for_compiled_frame(map);
+  }
+
+  // Must be native-compiled frame, i.e. the marshaling code for native
+  // methods that exists in the core system.
+  return frame(sender_sp(), link(), sender_pc());
+}
+
+//------------------------------------------------------------------------------
+// frame::sender_for_compiled_frame
+frame frame::sender_for_compiled_frame(RegisterMap* map) const {
+  // we cannot rely upon the last fp having been saved to the thread
+  // in C2 code but it will have been pushed onto the stack. so we
+  // have to find it relative to the unextended sp
+
+  assert(_cb->frame_size() >= 0, "must have non-zero frame size");
+  intptr_t* l_sender_sp = unextended_sp() + _cb->frame_size();
+  intptr_t* unextended_sp = l_sender_sp;
+
+  // the return_address is always the word on the stack
+  address sender_pc = (address) *(l_sender_sp + frame::return_addr_offset);
+
+  intptr_t** saved_fp_addr = (intptr_t**) (l_sender_sp + frame::link_offset);
+
+  assert(map != NULL, "map must be set");
+  if (map->update_map()) {
+    // Tell GC to use argument oopmaps for some runtime stubs that need it.
+    // For C1, the runtime stub might not have oop maps, so set this flag
+    // outside of update_register_map.
+    map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
+    if (_cb->oop_maps() != NULL) {
+      OopMapSet::update_register_map(this, map);
+    }
+
+    // Since the prolog does the save and restore of FP there is no
+    // oopmap for it so we must fill in its location as if there was
+    // an oopmap entry since if our caller was compiled code there
+    // could be live jvm state in it.
+    update_map_with_saved_link(map, saved_fp_addr);
+  }
+
+  return frame(l_sender_sp, unextended_sp, *saved_fp_addr, sender_pc);
+}
+
+//------------------------------------------------------------------------------
+// frame::update_map_with_saved_link
+template <typename RegisterMapT>
+void frame::update_map_with_saved_link(RegisterMapT* map, intptr_t** link_addr) {
+  // The interpreter and compiler(s) always save fp in a known
+  // location on entry. We must record where that location is
+  // so that if fp was live on callout from c2 we can find
+  // the saved copy no matter what it called.
+
+  // Since the interpreter always saves fp if we record where it is then
+  // we don't have to always save fp on entry and exit to c2 compiled
+  // code, on entry will be enough.
+  assert(map != NULL, "map must be set");
+  map->set_location(::fp->as_VMReg(), (address) link_addr);
+  // this is weird "H" ought to be at a higher address however the
+  // oopMaps seems to have the "H" regs at the same address and the
+  // vanilla register.
+  map->set_location(::fp->as_VMReg()->next(), (address) link_addr);
+}
 
 #endif // CPU_RISCV_FRAME_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "gc/shared/barrierSetNMethod.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/frame.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/registerMap.hpp"
 #include "runtime/thread.hpp"
@@ -159,6 +160,10 @@ void BarrierSetNMethod::disarm(nmethod* nm) {
   NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
 
   barrier->set_value(disarmed_value());
+}
+
+void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
+  Unimplemented();
 }
 
 bool BarrierSetNMethod::is_armed(nmethod* nm) {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -569,4 +569,35 @@ public:
   }
 };
 
+class NativePostCallNop: public NativeInstruction {
+public:
+  bool check() const { Unimplemented(); return false; }
+  int displacement() const { Unimplemented(); return 0; }
+  void patch(jint diff) { Unimplemented(); }
+  void make_deopt() { Unimplemented(); }
+};
+
+inline NativePostCallNop* nativePostCallNop_at(address address) {
+  Unimplemented();
+  return NULL;
+}
+
+class NativeDeoptInstruction: public NativeInstruction {
+public:
+  address instruction_address() const       { Unimplemented(); return NULL; }
+  address next_instruction_address() const  { Unimplemented(); return NULL; }
+
+  void  verify() { Unimplemented(); }
+
+  static bool is_deopt_at(address instr) {
+    Unimplemented();
+    return false;
+  }
+
+  // MT-safe patching
+  static void insert(address code_pos) {
+    Unimplemented();
+  }
+};
+
 #endif // CPU_RISCV_NATIVEINST_RISCV_HPP

--- a/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_SMALLREGISTERMAP_RISCV_INLINE_HPP
+#define CPU_RISCV_SMALLREGISTERMAP_RISCV_INLINE_HPP
+
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+// Java frames don't have callee saved registers (except for rfp), so we can use a smaller RegisterMap
+class SmallRegisterMap {
+public:
+  static constexpr SmallRegisterMap* instance = nullptr;
+private:
+  static void assert_is_rfp(VMReg r) PRODUCT_RETURN
+                                     DEBUG_ONLY({ Unimplemented(); })
+public:
+  // as_RegisterMap is used when we didn't want to templatize and abstract over RegisterMap type to support SmallRegisterMap
+  // Consider enhancing SmallRegisterMap to support those cases
+  const RegisterMap* as_RegisterMap() const { return nullptr; }
+  RegisterMap* as_RegisterMap() { return nullptr; }
+
+  RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
+    Unimplemented();
+    return map;
+  }
+
+  SmallRegisterMap() {}
+
+  SmallRegisterMap(const RegisterMap* map) {
+    Unimplemented();
+  }
+
+  inline address location(VMReg reg, intptr_t* sp) const {
+    Unimplemented();
+    return NULL;
+  }
+
+  inline void set_location(VMReg reg, address loc) { assert_is_rfp(reg); }
+
+  JavaThread* thread() const {
+  #ifndef ASSERT
+    guarantee (false, "");
+  #endif
+    return nullptr;
+  }
+
+  bool update_map()    const { return false; }
+  bool walk_cont()     const { return false; }
+  bool include_argument_oops() const { return false; }
+  void set_include_argument_oops(bool f)  {}
+  bool in_cont()       const { return false; }
+  stackChunkHandle stack_chunk() const { return stackChunkHandle(); }
+
+#ifdef ASSERT
+  bool should_skip_missing() const  { return false; }
+  VMReg find_register_spilled_here(void* p, intptr_t* sp) {
+    Unimplemented();
+    return NULL;
+  }
+  void print() const { print_on(tty); }
+  void print_on(outputStream* st) const { st->print_cr("Small register map"); }
+#endif
+};
+
+#endif // CPU_RISCV_SMALLREGISTERMAP_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_STACKCHUNKFRAMESTREAM_RISCV_INLINE_HPP
+#define CPU_RISCV_STACKCHUNKFRAMESTREAM_RISCV_INLINE_HPP
+
+#include "interpreter/oopMapCache.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/registerMap.hpp"
+
+#ifdef ASSERT
+template <ChunkFrames frame_kind>
+inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
+  Unimplemented();
+  return true;
+}
+#endif
+
+template <ChunkFrames frame_kind>
+inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
+  Unimplemented();
+  return frame();
+}
+
+template <ChunkFrames frame_kind>
+inline address StackChunkFrameStream<frame_kind>::get_pc() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <ChunkFrames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <ChunkFrames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::derelativize(int offset) const {
+  Unimplemented();
+  return NULL;
+}
+
+template <ChunkFrames frame_kind>
+inline intptr_t* StackChunkFrameStream<frame_kind>::unextended_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <ChunkFrames frame_kind>
+intptr_t* StackChunkFrameStream<frame_kind>::next_sp_for_interpreter_frame() const {
+  Unimplemented();
+  return NULL;
+}
+
+template <ChunkFrames frame_kind>
+inline void StackChunkFrameStream<frame_kind>::next_for_interpreter_frame() {
+  Unimplemented();
+}
+
+template <ChunkFrames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_size() const {
+  Unimplemented();
+  return 0;
+}
+
+template <ChunkFrames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_stack_argsize() const {
+  Unimplemented();
+  return 0;
+}
+
+template <ChunkFrames frame_kind>
+inline int StackChunkFrameStream<frame_kind>::interpreter_frame_num_oops() const {
+  Unimplemented();
+  return 0;
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template<>
+template<>
+inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
+  Unimplemented();
+}
+
+template <ChunkFrames frame_kind>
+template <typename RegisterMapT>
+inline void StackChunkFrameStream<frame_kind>::update_reg_map_pd(RegisterMapT* map) {}
+
+#endif // CPU_RISCV_STACKCHUNKFRAMESTREAM_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/stackChunkOop_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/stackChunkOop_riscv.inline.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,23 +22,15 @@
  *
  */
 
-#include "precompiled.hpp"
-#include "runtime/registerMap.hpp"
-#include "vmreg_riscv.inline.hpp"
+#ifndef CPU_RISCV_STACKCHUNKOOP_RISCV_INLINE_HPP
+#define CPU_RISCV_STACKCHUNKOOP_RISCV_INLINE_HPP
 
-address RegisterMap::pd_location(VMReg base_reg, int slot_idx) const {
-  if (base_reg->is_VectorRegister()) {
-    assert(base_reg->is_concrete(), "must pass base reg");
-    int base_reg_enc = (base_reg->value() - ConcreteRegisterImpl::max_fpr) /
-                       VectorRegisterImpl::max_slots_per_register;
-    intptr_t offset_in_bytes = slot_idx * VMRegImpl::stack_slot_size;
-    address base_location = location(base_reg, nullptr);
-    if (base_location != NULL) {
-      return base_location + offset_in_bytes;
-    } else {
-      return NULL;
-    }
-  } else {
-    return location(base_reg->next(slot_idx), nullptr);
-  }
+inline void stackChunkOopDesc::relativize_frame_pd(frame& fr) const {
+  Unimplemented();
 }
+
+inline void stackChunkOopDesc::derelativize_frame_pd(frame& fr) const {
+  Unimplemented();
+}
+
+#endif // CPU_RISCV_STACKCHUNKOOP_RISCV_INLINE_HPP

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3855,10 +3855,10 @@ class StubGenerator: public StubCodeGenerator {
 }; // end class declaration
 
 #define UCM_TABLE_MAX_ENTRIES 8
-void StubGenerator_generate(CodeBuffer* code, bool all) {
+void StubGenerator_generate(CodeBuffer* code, int phase) {
   if (UnsafeCopyMemory::_table == NULL) {
     UnsafeCopyMemory::create_table(UCM_TABLE_MAX_ENTRIES);
   }
 
-  StubGenerator g(code, all);
+  StubGenerator g(code, phase);
 }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -797,6 +797,11 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
 
 // End of helpers
 
+address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  Unimplemented();
+  return NULL;
+}
+
 // Various method entries
 //------------------------------------------------------------------------------------------------------------------------
 //


### PR DESCRIPTION
RISCV64 port has been upstreamed recently. This makes compile on Linux RISCV64 platform.
Note current patch does not implement Loom on this platform, but merely provides the absolute basic build capabilities.

Additional testing:
Linux RISCV64 cross-compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.java.net/loom pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/150.diff">https://git.openjdk.java.net/loom/pull/150.diff</a>

</details>
