### PR TITLE
use a staic final for "old-m-a-i-n" thread name

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -150,10 +150,10 @@ public class monitor001 extends JdbTest {
 
         grep = new Paragrep(reply);
 
-        // check 'threads', searching for java.lang.Thread main or old-m-a-i-n
+        // check 'threads', searching for "java.lang.Thread" followed by the main thread name.
         v.add("java.lang.Thread");
         if (System.getProperty("main.wrapper") != null) {
-            v.add("old-m-a-i-n");
+            v.add(nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME);
         } else {
             v.add("main");
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -184,10 +184,10 @@ public class unmonitor001 extends JdbTest {
             result = false;
         }
 
-        // check 'threads', searching for java.lang.Thread main or old-m-a-i-n
+        // check 'threads', searching for "java.lang.Thread" followed by the main thread name.
         v.add("java.lang.Thread");
         if (System.getProperty("main.wrapper") != null) {
-            v.add("old-m-a-i-n");
+            v.add(nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME);
         } else {
             v.add("main");
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadGroupReference/threads/threads001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadGroupReference/threads/threads001.java
@@ -247,10 +247,10 @@ public class threads001 {
 
                 /*
                  * This test initially expected group1 to have 2 Threads: "main" and "Thread2".
-                 * With the added wrapper support, it will also contain "old-m-a-i-n". However,
-                 * when run with vthread wrapper, it will only have "Thread2" since "main" and
-                 * "old-m-a-i-n" will be vthreads, which are always considered to be in the
-                 * "VirtualThreads" ThreadGroup, and threfore do not show up in group1.
+                 * With the added wrapper support, it will also contain the original main thread.
+                 * However, when run with vthread wrapper, it will only have "Thread2" since "main"
+                 * and original main thread will be vthreads, which are always considered to be in
+                 * the "VirtualThreads" ThreadGroup, and threfore do not show up in group1.
                  */
                 int expectedNumThreads;
                 if (usingVThreadWrapper) {
@@ -272,7 +272,7 @@ public class threads001 {
                     String s1 = ( (ThreadReference) li.next()).name();
                     if (s1.equals("main"))
                         nMain += 1;
-                    if (s1.equals("old-m-a-i-n"))
+                    if (s1.equals(nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME))
                         nOldMain += 1;
                     if (s1.equals("Thread2"))
                         nThread2 += 1;
@@ -283,12 +283,14 @@ public class threads001 {
                 }
                 if (expectedNumThreads == 3) {
                     if (nOldMain != 1) {
-                        log3("ERROR: # of 'old-m-a-i-n' threads != 1  : " + nOldMain);
+                        log3("ERROR: # of '" + nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME +
+                             "' threads != 1  : " + nOldMain);
                         expresult = 1;
                     }
                 } else {
                     if (nOldMain != 0) {
-                        log3("ERROR: # of 'old-m-a-i-n' threads != 0  : " + nOldMain);
+                        log3("ERROR: # of '" + nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME +
+                             "n' threads != 0  : " + nOldMain);
                         expresult = 1;
                     }
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
@@ -246,9 +246,9 @@ public class thread001 {
                                   if (checkedThreads[i][1].equals("0")) {
                                       checkedThreads[i][1] = "1";
                                   } else {
-                                      // When using the jtreg wrapper, the main thread is renamed to old-m-a-i-n,
-                                      // and a new "main" vthread is created. However, the rename happens after
-                                      // the debug agent has already generated the THREAD_START event for the
+                                      // When using the jtreg wrapper, the main thread is renamed, and a new
+                                      // "main" vthread is created. However, the rename happens after the
+                                      // debug agent has already generated the THREAD_START event for the
                                       // original "main", so we end up with two THREAD_START events for "main".
                                       // We need to allow for this.
                                       if ((System.getProperty("main.wrapper") != null) &&

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 
 public final class MainWrapper {
+    public static final String OLD_MAIN_THREAD_NAME = "old-m-a-i-n";
 
     static AtomicReference<Throwable> ue = new AtomicReference<>();
     public MainWrapper() {
@@ -68,7 +69,7 @@ public final class MainWrapper {
             t = new Thread(task);
         }
         t.setName("main");
-        Thread.currentThread().setName("old-m-a-i-n");
+        Thread.currentThread().setName(OLD_MAIN_THREAD_NAME);
         t.start();
         t.join();
         if (ue.get() != null) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - no project role)
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.java.net/loom pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/151.diff">https://git.openjdk.java.net/loom/pull/151.diff</a>

</details>
