### PR TITLE
Cleanup ProcessTool.createJavaProcessBuilder()

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -338,25 +338,10 @@ public final class ProcessTools {
                     if (cmd.equals(dWArg)) {
                         skipNext = true;
                         args.add(cmd);
-                        continue;
+                        break;
                     }
                 }
                 if (skipNext) {
-                    continue;
-                }
-                if (cmd.startsWith("-cp")) {
-                    skipNext = true;
-                    args.add(cmd);
-                    continue;
-                }
-                if (cmd.startsWith("--add-exports")) {
-                    skipNext = true;
-                    args.add(cmd);
-                    continue;
-                }
-                if (cmd.startsWith("--patch-module")) {
-                    skipNext = true;
-                    args.add(cmd);
                     continue;
                 }
                 if (cmd.startsWith("-")) {

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -308,6 +308,7 @@ public final class ProcessTools {
         for (String cmd: command) {
             if (cmd.equals("-m")) {
                 noModule = false;
+                break;
             }
         }
 


### PR DESCRIPTION
Two issues (discovered by Alex):

1. A number of the "if" blocks are already covered by the `doubleWordArgs` loop.
2. The `doubleWordArgs` loop should exit with a `break` instead of a `continue`
3. Break out of loop once noModule is set false

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer) ⚠️ Review applies to 4a5aeca67fd3070d4d7011e995e004197f826883


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.java.net/loom pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/152.diff">https://git.openjdk.java.net/loom/pull/152.diff</a>

</details>
