### PR TITLE
dcubed - cleanup2 changes (JVM/TI, JDI, JDWP)

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -873,7 +873,7 @@ public:
   jvmtiError result() { return _result; }
 };
 
-// HandshakeClosure to set frame pop for a virtual thread..
+// HandshakeClosure to set frame pop for a virtual thread.
 class VirtualThreadSetFramePopClosure : public JvmtiHandshakeClosure {
 private:
   JvmtiEnv *_env;

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -380,7 +380,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
       }
   }
   if (Continuations::enabled()) {
-    // Virtual threads support. There is a performance impact of VTMT transitions enabled.
+    // Virtual threads support. There is a performance impact when VTMT transitions are enabled.
     java_lang_VirtualThread::set_notify_jvmti_events(true);
   }
 

--- a/src/jdk.jdi/share/classes/com/sun/jdi/OpaqueFrameException.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/OpaqueFrameException.java
@@ -44,7 +44,7 @@ public sealed class OpaqueFrameException
     /**
      * Constructs a OpaqueFrameException with the given detail message.
      *
-     * @param message the detail messag, can be {@code null}
+     * @param message the detail message, can be {@code null}
      */
     public OpaqueFrameException(String message) {
         super(message);

--- a/src/jdk.jdi/share/classes/com/sun/jdi/ThreadGroupReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ThreadGroupReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -43,8 +43,8 @@ import com.sun.jdi.request.MonitorContendedEnterRequest;
 import com.sun.jdi.request.MonitorContendedEnteredRequest;
 import com.sun.jdi.request.MonitorWaitRequest;
 import com.sun.jdi.request.MonitorWaitedRequest;
-import com.sun.jdi.request.ThreadStartRequest;
 import com.sun.jdi.request.ThreadDeathRequest;
+import com.sun.jdi.request.ThreadStartRequest;
 import com.sun.jdi.request.VMDeathRequest;
 
 /**
@@ -792,7 +792,7 @@ public interface VirtualMachine extends Mirror {
     }
 
     /**
-     * Determine if the target VM support virtual threads.
+     * Determine if the target VM supports virtual threads.
      *
      * @return {@code true} if the feature is supported, {@code false} otherwise
      *

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -119,8 +119,8 @@ public class EventHandler implements Runnable {
             }
             // If we added it, we need to make sure it eventually gets removed. Usually
             // this happens when the ThreadDeathEvent comes in, but if !trackVthreads,
-            // then the ThreadDeathReqest was setup to filter out vthreads. So we'll need
-            // to create a special ThreadDeathReqest just to detect when this vthread dies.
+            // then the ThreadDeathRequest was setup to filter out vthreads. So we'll need
+            // to create a special ThreadDeathRequest just to detect when this vthread dies.
             if (added && !trackVthreads) {
                 EventRequestManager erm = Env.vm().eventRequestManager();
                 ThreadDeathRequest tdr = erm.createThreadDeathRequest();

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/StackFrameImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libjdwp/EventRequestImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/EventRequestImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdwp.agent/share/native/libjdwp/standardHandlers.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/standardHandlers.c
@@ -156,7 +156,7 @@ standardHandlers_defaultHandler(EventIndex ei)
         /* These events should have been converted to THREAD_START and THREAD_END already. */
         case EI_VIRTUAL_THREAD_START:
         case EI_VIRTUAL_THREAD_END:
-            /* This NULL will trigger a AGENT_ERROR_INVALID_EVENT_TYPE */
+            /* This NULL will trigger an AGENT_ERROR_INVALID_EVENT_TYPE */
             return NULL;
 
         case EI_CLASS_PREPARE:

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -410,7 +410,7 @@ insertThread(JNIEnv *env, ThreadList *list, jthread thread)
             jint vthread_state = 0;
             jvmtiError error = threadState(node->thread, &vthread_state);
             if (error != JVMTI_ERROR_NONE) {
-                EXIT_ERROR(error, "getting thread state");
+                EXIT_ERROR(error, "getting vthread state");
             }
             if (suspendAllCount > 0) {
                 // Assume the suspendAllCount, just like the regular thread case above.
@@ -1596,7 +1596,7 @@ threadControl_suspendCount(jthread thread, jint *count)
             jint vthread_state = 0;
             jvmtiError error = threadState(thread, &vthread_state);
             if (error != JVMTI_ERROR_NONE) {
-                EXIT_ERROR(error, "getting thread state");
+                EXIT_ERROR(error, "getting vthread state");
             }
             if (vthread_state == 0) {
                 // If state == 0, then this is a new vthread that has not been started yet.
@@ -1693,7 +1693,7 @@ threadControl_suspendAll(void)
 
             /*
              * Increment suspendCount of each virtual thread that we are tracking. Note the
-             * compliment to this that happens during the resumeAll() is handled by
+             * complement to this that happens during the resumeAll() is handled by
              * commonResumeList(), so it's a bit orthogonal to how we handle incrementing
              * the suspendCount.
              */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -84,8 +84,8 @@ typedef struct {
     volatile jboolean vmDead; /* Once VM is dead it stays that way - don't put in init */
     jboolean assertOn;
     jboolean assertFatal;
-    jboolean vthreadsSupported; /* If true, debugging support for vthreads is enabled.*/
-    jboolean enumerateVThreads; /* If true, JDWP APIs returns vthreads in thread lists. */
+    jboolean vthreadsSupported; /* If true, debugging support for vthreads is enabled. */
+    jboolean enumerateVThreads; /* If true, JDWP APIs return vthreads in thread lists. */
     jboolean doerrorexit;
     jboolean modifiedUtf8;
     jboolean quiet;


### PR DESCRIPTION
Trivial cleanup changes to JVM/TI, JDI and JDWP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - Committer)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.java.net/loom pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/153.diff">https://git.openjdk.java.net/loom/pull/153.diff</a>

</details>
