### PR TITLE
Remove is_owning_locks() call from freeze slow path 

### DIFF
--- a/src/hotspot/share/runtime/continuationEntry.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.hpp
@@ -78,6 +78,7 @@ public:
   static size_t size() { return align_up((int)sizeof(ContinuationEntry), 2*wordSize); }
 
   ContinuationEntry* parent() const { return _parent; }
+  int parent_held_monitor_count() const { return _parent_held_monitor_count; }
 
   static address entry_pc() { return return_pc; }
   intptr_t* entry_sp() const { return (intptr_t*)this; }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1275,8 +1275,8 @@ static bool monitors_on_stack(JavaThread* thread) {
   RegisterMap map(thread, true, false, false);
   map.set_include_argument_oops(false);
   for (frame f = thread->last_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
-    if (f.is_interpreted_frame() && ContinuationHelper::InterpretedFrame::is_owning_locks(f) ||
-        f.is_compiled_frame() && ContinuationHelper::CompiledFrame::is_owning_locks(map.thread(), &map, f)) {
+    if ((f.is_interpreted_frame() && ContinuationHelper::InterpretedFrame::is_owning_locks(f)) ||
+        (f.is_compiled_frame() && ContinuationHelper::CompiledFrame::is_owning_locks(map.thread(), &map, f))) {
       return true;
     }
   }
@@ -1414,7 +1414,7 @@ static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoi
   }
 
   while (true) {
-    if (f.is_interpreted_frame() && f.interpreter_frame_method()->is_native() || f.is_native_frame()) {
+    if ((f.is_interpreted_frame() && f.interpreter_frame_method()->is_native()) || f.is_native_frame()) {
       return freeze_pinned_native;
     }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -752,16 +752,9 @@ NOINLINE freeze_result FreezeBase::freeze(frame& f, frame& caller, int callee_ar
       // special native frame
       return freeze_pinned_native;
     }
-    if (UNLIKELY(ContinuationHelper::CompiledFrame::is_owning_locks(_cont.thread(), SmallRegisterMap::instance, f))) {
-      return freeze_pinned_monitor;
-    }
-
     return recurse_freeze_compiled_frame(f, caller, callee_argsize, callee_interpreted);
   } else if (f.is_interpreted_frame()) {
     assert((_preempt && top) || !f.interpreter_frame_method()->is_native(), "");
-    if (ContinuationHelper::InterpretedFrame::is_owning_locks(f)) {
-      return freeze_pinned_monitor;
-    }
     if (_preempt && top && f.interpreter_frame_method()->is_native()) {
       // int native entry
       return freeze_pinned_native;
@@ -1109,9 +1102,6 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_stub_frame(frame& f, frame& ca
     // native frame
     return freeze_pinned_native;
   }
-  if (UNLIKELY(ContinuationHelper::CompiledFrame::is_owning_locks(_cont.thread(), &map, senderf))) {
-    return freeze_pinned_monitor;
-  }
 
   freeze_result result = recurse_freeze_compiled_frame(senderf, caller, 0, 0); // This might be deoptimized
   if (UNLIKELY(result > freeze_ok_bottom)) {
@@ -1323,19 +1313,6 @@ static bool interpreted_native_or_deoptimized_on_stack(JavaThread* thread) {
 }
 #endif // ASSERT
 
-static inline bool can_freeze_fast(JavaThread* thread) {
-  // There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c adapter or called Deoptimization::unpack_frames
-  // Calls from native frames also go through the interpreter (see JavaCalls::call_helper)
-  assert(!thread->cont_fastpath()
-         || (thread->cont_fastpath_thread_state() && !interpreted_native_or_deoptimized_on_stack(thread)), "");
-
-  // We also clear thread->cont_fastpath on deoptimization (notify_deopt) and when we thaw interpreted frames
-  bool fast = thread->cont_fastpath() && UseContinuationFastPath;
-  assert(!fast || monitors_on_stack(thread) == (thread->held_monitor_count() > 0), "");
-  fast = fast && thread->held_monitor_count() == 0;
-  return fast;
-}
-
 static inline int freeze_epilog(JavaThread* thread, ContinuationWrapper& cont) {
   verify_continuation(cont.continuation());
   assert(!cont.is_empty(), "");
@@ -1379,16 +1356,24 @@ static inline int freeze_internal(JavaThread* current, intptr_t* const sp) {
 
   assert(entry->is_virtual_thread() == (entry->scope() == java_lang_VirtualThread::vthread_scope()), "");
 
-  if (entry->is_pinned()) {
-    log_develop_debug(continuations)("PINNED due to critical section");
+  assert(monitors_on_stack(current) == (current->held_monitor_count() > 0), "");
+
+  if (entry->is_pinned() || current->held_monitor_count() > 0) {
+    log_develop_debug(continuations)("PINNED due to critical section/hold monitor");
     verify_continuation(cont.continuation());
-    log_develop_trace(continuations)("=== end of freeze (fail %d)", freeze_pinned_cs);
-    return freeze_pinned_cs;
+    freeze_result res = entry->is_pinned() ? freeze_pinned_cs : freeze_pinned_monitor;
+    log_develop_trace(continuations)("=== end of freeze (fail %d)", res);
+    return res;
   }
 
   Freeze<ConfigT> fr(current, cont, false);
 
-  bool fast = can_freeze_fast(current);
+  // There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c
+  // adapter or called Deoptimization::unpack_frames. Calls from native frames also go through the interpreter
+  // (see JavaCalls::call_helper).
+  assert(!current->cont_fastpath()
+         || (current->cont_fastpath_thread_state() && !interpreted_native_or_deoptimized_on_stack(current)), "");
+  bool fast = UseContinuationFastPath && current->cont_fastpath();
   if (fast && fr.is_chunk_available_for_fast_freeze(sp)) {
     freeze_result res = fr.template try_freeze_fast<true>(sp);
     assert(res == freeze_ok, "");

--- a/src/hotspot/share/runtime/continuationHelper.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.hpp
@@ -100,7 +100,10 @@ public:
   static int size(const frame& f, InterpreterOopMap* mask);
   static int size(const frame& f);
   static inline int expression_stack_size(const frame &f, InterpreterOopMap* mask);
+
+#ifdef ASSERT
   static bool is_owning_locks(const frame& f);
+#endif
 
   static bool is_instance(const frame& f);
 
@@ -129,8 +132,10 @@ public:
 
   static bool is_instance(const frame& f);
 
+#ifdef ASSERT
   template <typename RegisterMapT>
   static bool is_owning_locks(JavaThread* thread, RegisterMapT* map, const frame& f);
+#endif
 };
 
 class ContinuationHelper::StubFrame : public ContinuationHelper::NonInterpretedFrame {

--- a/src/hotspot/share/runtime/continuationHelper.inline.hpp
+++ b/src/hotspot/share/runtime/continuationHelper.inline.hpp
@@ -106,6 +106,7 @@ inline int ContinuationHelper::InterpretedFrame::expression_stack_size(const fra
   return size;
 }
 
+#ifdef ASSERT
 inline bool ContinuationHelper::InterpretedFrame::is_owning_locks(const frame& f) {
   assert(f.interpreter_frame_monitor_end() <= f.interpreter_frame_monitor_begin(), "must be");
   if (f.interpreter_frame_monitor_end() == f.interpreter_frame_monitor_begin()) {
@@ -123,6 +124,7 @@ inline bool ContinuationHelper::InterpretedFrame::is_owning_locks(const frame& f
   }
   return false;
 }
+#endif
 
 inline intptr_t* ContinuationHelper::InterpretedFrame::frame_top(const frame& f) { // inclusive; this will be copied with the frame
   return f.unextended_sp();
@@ -167,6 +169,7 @@ inline int ContinuationHelper::CompiledFrame::num_oops(const frame& f) {
   return f.num_oops() + 1;
 }
 
+#ifdef ASSERT
 template<typename RegisterMapT>
 bool ContinuationHelper::CompiledFrame::is_owning_locks(JavaThread* thread, RegisterMapT* map, const frame& f) {
   assert(!f.is_interpreted_frame(), "");
@@ -203,6 +206,7 @@ bool ContinuationHelper::CompiledFrame::is_owning_locks(JavaThread* thread, Regi
   }
   return false;
 }
+#endif
 
 inline bool ContinuationHelper::StubFrame::is_instance(const frame& f) {
   return !f.is_interpreted_frame() && is_stub(f.cb());


### PR DESCRIPTION
The call to is_owning_locks() on each frame when we recurse on freeze can be removed. Instead we can check _held_monitor_count once at the beginning on freeze_internal().

Tested locally by running all tests in test/jdk/java/lang/Thread/virtual/ and jdk/jdk/internal/vm/Continuation/, and in mach5 tiers loom-tier1, loom-tier2 and loom-tier3.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**) ⚠️ Review applies to 47e960b134d3e71d355ca02dd9f676e2b96db887
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.java.net/loom pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/155.diff">https://git.openjdk.java.net/loom/pull/155.diff</a>

</details>
