### PR TITLE
No caching of can fast result

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1388,8 +1388,7 @@ static inline int freeze_internal(JavaThread* current, intptr_t* const sp) {
 
   Freeze<ConfigT> fr(current, cont, false);
 
-  bool fast = can_freeze_fast(current);
-  if (fast && fr.is_chunk_available_for_fast_freeze(sp)) {
+  if (can_freeze_fast(current) && fr.is_chunk_available_for_fast_freeze(sp)) {
     freeze_result res = fr.template try_freeze_fast<true>(sp);
     assert(res == freeze_ok, "");
     CONT_JFR_ONLY(fr.jfr_info().post_jfr_event(&event, oopCont, current);)
@@ -1405,8 +1404,8 @@ static inline int freeze_internal(JavaThread* current, intptr_t* const sp) {
     JvmtiSampledObjectAllocEventCollector jsoaec(false);
     fr.set_jvmti_event_collector(&jsoaec);
 
-    freeze_result res = fast ? fr.template try_freeze_fast<false>(sp)
-                             : fr.freeze_slow();
+    freeze_result res = can_freeze_fast(current) ? fr.template try_freeze_fast<false>(sp)
+                                                 : fr.freeze_slow();
     CONT_JFR_ONLY(fr.jfr_info().post_jfr_event(&event, oopCont, current);)
     freeze_epilog(current, cont, res);
     cont.done(); // allow safepoint in the transition back to Java


### PR DESCRIPTION
can_freeze_fast() result could be changed byt JRT_BLOCK.
Let's not cache it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.java.net/loom pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/157.diff">https://git.openjdk.java.net/loom/pull/157.diff</a>

</details>
