### PR TITLE
Fix location of transform call in oop_promotion_failed

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -337,14 +337,14 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
 
     _promotion_failed_info.register_copy_failure(obj->size());
 
+    ContinuationGCSupport::transform_stack_chunk(obj);
+
     push_contents(obj);
 
     // Save the markWord of promotion-failed objs in _preserved_marks for later
     // restoration. This way we don't have to walk the young-gen to locate
     // these promotion-failed objs.
     _preserved_marks->push_always(obj, obj_mark);
-
-    ContinuationGCSupport::transform_stack_chunk(obj);
   }  else {
     // We lost, someone else "owns" this object
     guarantee(obj->is_forwarded(), "Object must be forwarded if the cas failed.");


### PR DESCRIPTION
Manual inspection of the ParallelGC code showed that we transform the chunk *after* the oops are pushed and published to other threads. I couldn't reproduce a crash with this, but this looks wrong and should be fixed. Just move the transform to *before* the push.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)
 * [Thomas Schatzl](https://openjdk.java.net/census#tschatzl) (@tschatzl - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.java.net/loom pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/159.diff">https://git.openjdk.java.net/loom/pull/159.diff</a>

</details>
