### PR TITLE
StackChunk only special in null loader.

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -164,6 +164,12 @@ static inline bool is_class_loader(const Symbol* class_name,
   return false;
 }
 
+static inline bool is_stack_chunk_class(const Symbol* class_name,
+                                        const ClassLoaderData* loader_data) {
+  return (class_name == vmSymbols::jdk_internal_vm_StackChunk() &&
+          loader_data->is_the_null_class_loader_data());
+}
+
 // private: called to verify that k is a static member of this nest.
 // We know that k is an instance class in the same package and hence the
 // same classloader.
@@ -443,7 +449,7 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
     if (class_name == vmSymbols::java_lang_Class()) {
       // mirror - java.lang.Class
       ik = new (loader_data, size, THREAD) InstanceMirrorKlass(parser);
-    } else if (class_name == vmSymbols::jdk_internal_vm_StackChunk()) {
+    } else if (is_stack_chunk_class(class_name, loader_data)) {
       // stack chunk
       ik = new (loader_data, size, THREAD) InstanceStackChunkKlass(parser);
     } else if (is_class_loader(class_name, parser)) {

--- a/test/hotspot/jtreg/runtime/vthread/StackChunk.java
+++ b/test/hotspot/jtreg/runtime/vthread/StackChunk.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm;
+
+public class StackChunk {
+    int i;
+    int j;
+    String myName;
+    public StackChunk() {
+        System.out.println("Constructor called");
+        myName = "StackChunk";
+        i = 55;
+        j = 66;
+    }
+    public void print() {
+        System.out.println("My name is " + myName);
+    }
+    public int getI() { return i; }
+}

--- a/test/hotspot/jtreg/runtime/vthread/StackChunkClassLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/vthread/StackChunkClassLoaderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test StackChunkClassLoaderTest
+ * @summary Test that a different jdk.internal.vm.StackChunk can be loaded by non-null class loader
+ * @library /test/lib
+ * @compile StackChunk.java
+ * @run main/othervm StackChunkClassLoaderTest
+ */
+
+import java.lang.reflect.Method;
+import java.io.FileInputStream;
+import java.io.File;
+
+public class StackChunkClassLoaderTest extends ClassLoader {
+
+    public String loaderName;
+
+    StackChunkClassLoaderTest(String name) {
+        this.loaderName = name;
+    }
+
+    // Get data for pre-compiled class file to load.
+    public byte[] getClassData(String name) {
+        try {
+            String classDir = System.getProperty("test.classes");
+            String tempName = name.replaceAll("\\.", "/");
+            return new FileInputStream(classDir + File.separator + tempName + ".class").readAllBytes();
+        } catch (Exception e) {
+              return null;
+        }
+    }
+
+    public Class loadClass(String name) throws ClassNotFoundException {
+        if (!name.contains("StackChunk")) {
+            return super.loadClass(name);
+        }
+
+        byte[] data = getClassData(name);
+        System.out.println("name is " + name);
+        return defineClass(name, data, 0, data.length);
+    }
+
+  public static void main(java.lang.String[] unused) throws Exception {
+      ClassLoader cl = new StackChunkClassLoaderTest("StackChunkClassLoaderTest");
+      Class<?> c = Class.forName("jdk.internal.vm.StackChunk", true, cl);
+      Object obj = c.getDeclaredConstructor().newInstance();
+      System.gc();
+      java.lang.reflect.Method m = c.getMethod("print");
+      m.invoke(obj);
+      Method mi = c.getMethod("getI");
+      Object val = mi.invoke(obj);
+      if (((Integer)val).intValue() != 55) {
+          throw new RuntimeException("Test failed, StackChunk object corrupt");
+      }
+  }
+}


### PR DESCRIPTION
This adds a check and a test so that only the real StackChunk is treated as StackChunk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.java.net/census#stefank) (@stefank - no project role)
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.java.net/loom pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/163.diff">https://git.openjdk.java.net/loom/pull/163.diff</a>

</details>
