### PR TITLE
8284402: serviceability/jvmti/events/MonitorContendedEntered/mcontent…

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
@@ -89,9 +89,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
@@ -121,10 +121,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
@@ -93,10 +93,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
@@ -95,10 +95,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 


### PR DESCRIPTION
The following tests fail in Loom:
  serviceability/jvmti/events/MonitorContendedEnter/mcontenter01
  serviceability/jvmti/events/MonitorContendedEntered/mcontentered01
  serviceability/jvmti/events/MonitorWait/monitorwait01
  serviceability/jvmti/events/MonitorWaited/monitorwaited01

with the error:
```
# Internal Error (/opt/mach5/mesos/work_dir/slaves/779adf21-f3e5-4e6a-a889-8cc0f9bc6fbb-S14747/frameworks/1735e8a2-a1db-478c-8104-60c8b0af87dd-0196/executors/4ceff4c0-ff1e-4329-9c88-90f77211fe28/runs/480df0be-42f1-45f1-add5-989e159fadb3/workspace/open/src/hotspot/share/runtime/jniHandles.inline.hpp:64), pid=15533, tid=15535
# assert(external_guard || result != __null) failed: Invalid JNI handle 
```

The problem is that the agent thread has this code without synchronization:
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);

So, the expected_object and expected_thread can be destroyed when an event callback is still executed.
The simplest way to fix it to remove this fragment.
Also, these Loom tests were originated/converted from the nsk.jvmti tests which do not have this fragment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.java.net/loom pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/165.diff">https://git.openjdk.java.net/loom/pull/165.diff</a>

</details>
