### PR TITLE
Support yield on virtual thread on EPollSelector select()

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -48,6 +48,7 @@ public abstract class Poller {
     private static final Poller[] WRITE_POLLERS;
     private static final int READ_MASK, WRITE_MASK;
     private static final boolean USE_DIRECT_REGISTER;
+    private static final boolean USE_RECURSIVE_POLL;
 
     // true if this is a poller for reading, false for writing
     private final boolean read;
@@ -388,6 +389,12 @@ public abstract class Poller {
         } else {
             USE_DIRECT_REGISTER = "".equals(s) || Boolean.parseBoolean(s);
         }
+        s = GetPropertyAction.privilegedGetProperty("jdk.useRecursivePoll");
+        if (s == null) {
+            USE_RECURSIVE_POLL = provider.useRecursivePoll();
+        } else {
+            USE_RECURSIVE_POLL = "".equals(s) || Boolean.parseBoolean(s);
+        }
         try {
             Poller[] readPollers = createReadPollers(provider);
             READ_POLLERS = readPollers;
@@ -465,5 +472,9 @@ public abstract class Poller {
 
     private Stream<Thread> registeredThreads() {
         return map.values().stream();
+    }
+
+    static boolean useRecursivePoll() {
+        return USE_RECURSIVE_POLL;
     }
 }

--- a/src/java.base/share/classes/sun/nio/ch/PollerProvider.java
+++ b/src/java.base/share/classes/sun/nio/ch/PollerProvider.java
@@ -41,6 +41,10 @@ abstract class PollerProvider {
         return false;
     }
 
+    boolean useRecursivePoll() {
+        return false;
+    }
+
     /**
      * Creates a Poller for read ops.
      */

--- a/test/jdk/java/lang/Thread/virtual/Selectors.java
+++ b/test/jdk/java/lang/Thread/virtual/Selectors.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Basic tests for virtual threads doing blocking Selector select
+ * @requires (os.family == "linux")
+ * @compile --enable-preview --add-exports=java.base/sun.nio.ch=ALL-UNNAMED  -source ${jdk.version} Selectors.java
+ * @run testng/othervm/timeout=300 --enable-preview --add-exports=java.base/sun.nio.ch=ALL-UNNAMED  Selectors
+ * @run testng/othervm/timeout=300 --enable-preview --add-exports=java.base/sun.nio.ch=ALL-UNNAMED -Djdk.useRecursivePoll=true Selectors
+ * @run testng/othervm/timeout=300 --enable-preview --add-exports=java.base/sun.nio.ch=ALL-UNNAMED -Djdk.useRecursivePoll=true -Djdk.useDirectRegister Selectors
+ */
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import sun.nio.ch.Poller;
+import static org.testng.Assert.*;
+
+
+public class Selectors {
+    @Test
+    public void testSelectorMounted() throws Exception {
+        var selectorThread =  Thread.ofVirtual().start(() -> {
+            try {
+                Selector selector = Selector.open();
+                selector.select();
+            } catch (Exception ignored) {
+            }
+        });
+        Thread.sleep(200);
+        assertEquals(selectorThread.getState(),
+                (Boolean.parseBoolean(System.getProperty("jdk.useRecursivePoll"))? Thread.State.WAITING : Thread.State.RUNNABLE));
+        selectorThread.interrupt();
+        selectorThread.join();
+    }
+
+    @Test
+    public void testSelectorWakeup() throws Exception {
+        var selectorSet = new CountDownLatch(1);
+        var wakened = new CountDownLatch(1);
+        var selector = new AtomicReference<Selector>();
+        var selectorThread =  Thread.ofVirtual().start(() -> {
+            try {
+                selector.set(Selector.open());
+                selectorSet.countDown();
+                selector.get().select();
+                wakened.countDown();
+            } catch (Exception ignored) {
+            }
+        });
+        selectorSet.await();
+        selector.get().wakeup();
+        wakened.await();
+        selectorThread.join();
+    }
+
+    @Test
+    public void testSelectorInterrupt() throws Exception {
+        var wakened = new CountDownLatch(1);
+        var selector = new AtomicReference<Selector>();
+        var exception = new AtomicReference<Exception>();
+        var selectorThread =  Thread.ofVirtual().start(() -> {
+            try {
+                selector.set(Selector.open());
+                selector.get().select();
+                assertTrue(Thread.currentThread().isInterrupted());
+                wakened.countDown();
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        });
+        Thread.sleep(100);  // give time for thread to block
+        selectorThread.interrupt();
+        wakened.await();
+        assertTrue(exception.get() == null);
+        selectorThread.join();
+    }
+
+    @Test
+    public void testSelectNow() throws Exception {
+        var selector = Selector.open();
+        var p = SelectorProvider.provider().openPipe();
+        var sink = p.sink();
+        var source = p.source();
+        source.configureBlocking(false);
+        sink.configureBlocking(false);
+        var selectResult = new AtomicReference<Integer>();
+        var exception = new AtomicReference<Exception>();
+
+        // selectNow return expected result
+        Thread.ofVirtual().start(() -> {
+            try {
+                selectResult.set(selector.selectNow());
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        }).join();
+
+        assertTrue(exception.get() == null);
+        assertTrue(selectResult.get() == 0);
+
+        var readKey = source.register(selector, SelectionKey.OP_READ);
+        var writeBuffer = ByteBuffer.allocateDirect(128);
+        writeBuffer.put("helloworld".getBytes());
+        sink.write(writeBuffer);
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                selectResult.set(selector.selectNow());
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        }).join();
+
+        assertTrue(exception.get() == null);
+        assertTrue(selectResult.get() == 1);
+    }
+
+    @Test
+    public void testSelectWithTimeout() throws Exception {
+        // timed select wakeup eventually
+        var exception = new AtomicReference<Exception>();
+        Thread.ofVirtual().start(() -> {
+            try {
+                Selector.open().select(1000);
+            } catch (Exception e) {
+                exception.set(e);
+            }
+        }).join();
+    }
+
+}

--- a/test/jdk/java/net/vthread/HttpALot.java
+++ b/test/jdk/java/net/vthread/HttpALot.java
@@ -31,6 +31,12 @@
  *     -Dsun.net.client.defaultConnectTimeout=5000
  *     -Dsun.net.client.defaultReadTimeout=5000
  *     HttpALot
+ * @run main/othervm/timeout=600
+ *     --enable-preview
+ *     -Dsun.net.client.defaultConnectTimeout=5000
+ *     -Dsun.net.client.defaultReadTimeout=5000
+ *     -Djdk.useRecursivePoll=true
+ *     HttpALot
  */
 
 import java.io.IOException;

--- a/test/jdk/java/nio/channels/Selector/RegisterDuringSelect.java
+++ b/test/jdk/java/nio/channels/Selector/RegisterDuringSelect.java
@@ -24,7 +24,7 @@
 /* @test
  * @bug 8201315
  * @build SelectorUtils
- * @run main RegisterDuringSelect
+ * @run main/othervm --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED  RegisterDuringSelect
  * @summary Test that channels can be registered, interest ops can changed,
  *          and keys cancelled while a selection operation is in progress.
  */

--- a/test/jdk/java/nio/channels/Selector/SelectAndClose.java
+++ b/test/jdk/java/nio/channels/Selector/SelectAndClose.java
@@ -24,7 +24,7 @@
 /* @test
  * @bug 5004077 8203765
  * @build SelectorUtils
- * @run main SelectAndClose
+ * @run main/othervm --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED SelectAndClose
  * @summary Check blocking of select and close
  */
 

--- a/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
+++ b/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
@@ -24,7 +24,7 @@
 /* @test
  * @summary Unit test for Selector.select/selectNow(Consumer)
  * @bug 8199433 8208780
- * @run testng SelectWithConsumer
+ * @run testng/othervm --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED SelectWithConsumer
  */
 
 /* @test
@@ -518,25 +518,22 @@ public class SelectWithConsumer {
             // select(Consumer)
             sel.select(k -> {
                 assertTrue(k == key);
-                assertTrue(Thread.holdsLock(sel));
-                assertFalse(Thread.holdsLock(sel.keys()));
-                assertTrue(Thread.holdsLock(sel.selectedKeys()));
+                assertTrue(SelectorUtils.mightHoldKeysLock(Thread.currentThread(), sel));
+                assertTrue(SelectorUtils.mightHoldSelectorLock(Thread.currentThread(), sel));
             });
 
             // select(Consumer, timeout)
             sel.select(k -> {
                 assertTrue(k == key);
-                assertTrue(Thread.holdsLock(sel));
-                assertFalse(Thread.holdsLock(sel.keys()));
-                assertTrue(Thread.holdsLock(sel.selectedKeys()));
+                assertTrue(SelectorUtils.mightHoldKeysLock(Thread.currentThread(), sel));
+                assertTrue(SelectorUtils.mightHoldSelectorLock(Thread.currentThread(), sel));
             }, 1000L);
 
             // selectNow(Consumer)
             sel.selectNow(k -> {
                 assertTrue(k == key);
-                assertTrue(Thread.holdsLock(sel));
-                assertFalse(Thread.holdsLock(sel.keys()));
-                assertTrue(Thread.holdsLock(sel.selectedKeys()));
+                assertTrue(SelectorUtils.mightHoldKeysLock(Thread.currentThread(), sel));
+                assertTrue(SelectorUtils.mightHoldSelectorLock(Thread.currentThread(), sel));
             });
         } finally {
             closePipe(p);


### PR DESCRIPTION
Proposal: suport selector poll in loom
Hi, supporting selector poll in loom could enhance compatibility and improve performance based on my experiments with spring  benchmarks.
Many frameworks are using reactor-based networking, for those blocking `Selector.select()` calls currently loom's implementation is blocking the current ForkJoin worker until these calls are returned. For two reasons current virtual threads can't yield out, first is Selector is using synchronized, second is epoll_wait must fall into the kernel. By replacing synchronized with java locks and delegating blocking `Selector.select()` to background threads, this patch supports yielding on `EpollSelector's epoll_wait`. (Similar solutions for coroutine's `Selector.select()` have been widely verified on the production environment in Alibaba).
Hopefully, my benchmarks could be easily reproduced and modified for verification, for spring I have to hack the Thread.start() to start those bundled workers as virtual threads.

In summary, my observations are supporting coroutine yield on virtual threads `Selector.select()` could boost performance when
1. Selector threads(in charge of Selector.select()) are likely to block
2. there are a large number of selector threads 

Numbers:
What did each column mean?
● spring(no suffix) -> the default platform thread mode
● spring-virtualbiz -> all executor threads are converted to virtual threads
● spring-virtual -> all IO threads and executor threads are converted to virtual threads
● spring-virtualoptimized -> all IO threads and executor threads are converted to virtual threads and enable this patch


Spring: 

Configuration:
1. CPU number of Selector threads, each request's handler will be submitted to an executor pool. 
2. Using "wrk" to add pressure, measure latencyAvg and totalRequests each run.
3. Skipped database-related workloads for spring, currently,  they might introduce frequent pinning due to synchronized block.

Summary: 
Converting all executor threads to virtual threads gains more performance than the default, but degradation happens when all threads including IO threads are converted to virtual threads. 

For total requests(throughput) in fixed time, this patch brings **3-7%** improvement on plaintext and **6-14%** improvement on JSON. For average latency, optimize **4-8%** on the plaintext and about 15% on JSON. 

1. We are measuring requests and latency at the same time, so for each run latency and throughput both improved.
2. The percentage is computed via comparing optimized version with current optimal mode(virtualBiz)
```
+------------------------------------------------------------------------------------+
|                       Type: plaintext, Result: totalRequests                       |
+----------+---------+-------------------+-----------------+-------------------------+
| pipeline |  spring | spring-virtualbiz | spring-virtual  | spring-virtualoptimized |
+----------+---------+-------------------+-----------------+-------------------------+
|    4     | 1105401 |      1146776      |     1219481     |         1233398         |
|    8     | 1304546 |      1313621      |     1234331     |         1406274         |
|    16    | 1465894 |      1474328      |     1245648     |         1520790         |
+----------+---------+-------------------+-----------------+-------------------------+
+--------------------------------------------------------------------------------------------+
|                             Type: json, Result: totalRequests                              |
+------------------+---------+-------------------+-----------------+-------------------------+
| concurrencyLevel |  spring | spring-virtualbiz | spring-virtual  | spring-virtualoptimized |
+------------------+---------+-------------------+-----------------+-------------------------+
|        4         |  592597 |       655380      |      698312     |          622674         |
|        8         |  906588 |      1014115      |     1060094     |         1016332         |
|        16        | 1051602 |      1050818      |     1079971     |         1140643         |
|        32        | 1116081 |      1088898      |     1109657     |         1280262         |
|        64        | 1184019 |      1148817      |     1096397     |         1360887         |
|       128        | 1293541 |      1358471      |     1119223     |         1440368         |
+------------------+---------+-------------------+-----------------+-------------------------+
```


How to reproduce:
Environment
Two 4C8G ECS machines on the cloud serve as the java application while the other is in charge of the wrk pressure client.
Based on the [upstream](https://github.com/TechEmpower/FrameworkBenchmarks) Frameworkbenchmark I did some work to adapt this to the loom, now on [the loom](https://github.com/joeyleeeeeee97/FrameworkBenchmarks/) branch we could easily set up a benchmark run to verify this.
● Quickstart( runs on a docker-machine)

```
git clone https://github.com/joeyleeeeeee97/FrameworkBenchmarks.git
cd FrameworkBenchmarks
./tfb --test spring-optimized --duration 60
```

Notice
● if there are socket errors in wrk, then maybe current stress level is too much
● I was using separate machines as client and server following this [guide](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Benchmarking-Getting-Started)
● Use configuration to adjust test duration and concurrency level
--concurrency-levels=[4, 8, 16, 32, 64, 128] --pipeline-concurrency-levels=[128, 256, 512, 1024] --duration 30
Modifications
● Most of my modifications are open now except for the process of building docker image and the hacking part to run spring on loom

Tests
● jtreg java/nio/channels/Selector/ to make sure refactoring Selector synchronized didn't break tests
● jtreg test/jdk/java/lang/Thread/virtual/Selectors.java to verify Selector behavior on virtual threads

```
    @Test
    public void testSelectorMounted() throws Exception {
        var selectorThread =  Thread.ofVirtual().start(() -> {
            try {
                Selector selector = Selector.open();
                selector.select();
            } catch (Exception ignored) {
            }
        });
        Thread.sleep(200);
        // virtual threads are waiting now :)
        assertEquals(selectorThread.getState(),
                (Boolean.parseBoolean(System.getProperty("jdk.useRecursivePoll"))? Thread.State.WAITING : Thread.State.RUNNABLE));
        selectorThread.interrupt();
        selectorThread.join();
    }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.java.net/loom pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/166.diff">https://git.openjdk.java.net/loom/pull/166.diff</a>

</details>
