### PR TITLE
8284233: serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java failing in loom repo

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEnter/mcontenter01/libmcontenter01.cpp
@@ -89,9 +89,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorContendedEntered/mcontentered01/libmcontentered01.cpp
@@ -121,10 +121,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWait/monitorwait01/libmonitorwait01.cpp
@@ -93,10 +93,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
@@ -95,10 +95,6 @@ static int clean() {
   if (err != JVMTI_ERROR_NONE) {
     set_agent_fail_status();
   }
-
-  jni->DeleteGlobalRef(expected_object);
-  jni->DeleteGlobalRef(expected_thread);
-
   return NSK_TRUE;
 }
 


### PR DESCRIPTION
The test has a lack of synchronization.
The fix is to wait for target virtual thread reaching the desired state of execution.
The fix was tested with 100 of mach5 runs on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.java.net/loom pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/167.diff">https://git.openjdk.java.net/loom/pull/167.diff</a>

</details>
