### PR TITLE
284233: serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java failing in loom repo

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -37,13 +37,15 @@ public class InterruptThreadTest {
 
     native boolean testJvmtiFunctionsInJNICall(Thread vthread);
 
+    volatile private boolean target_is_ready = false;
     private boolean iterrupted = false;
 
     final Runnable pinnedTask = () -> {
         synchronized (lock) {
             do {
                 try {
-                    lock.wait(1);
+                    target_is_ready = true;
+                    lock.wait();
                 } catch (InterruptedException ie) {
                     System.err.println("Virtual thread was interrupted as expected");
                     iterrupted = true;
@@ -54,6 +56,12 @@ public class InterruptThreadTest {
 
     void runTest() throws Exception {
         Thread vthread = Thread.ofVirtual().name("VThread").start(pinnedTask);
+        // wait for target virtual thread to reach the expected waiting state
+        synchronized (lock) {
+            while (!target_is_ready || vthread.getState() != Thread.State.WAITING) {
+              lock.wait(1);
+            }
+        }
         testJvmtiFunctionsInJNICall(vthread);
         isJNITestingCompleted.set(true);
         vthread.join();


### PR DESCRIPTION
The test has a lack of synchronization.
The fix is to wait for target virtual thread reaching the desired state of execution.
The fix was tested with 100 of mach5 test runs on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.java.net/loom pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/168.diff">https://git.openjdk.java.net/loom/pull/168.diff</a>

</details>
