### PR TITLE
8284233: serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java failing in loom repo

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -47,7 +47,8 @@ public class InterruptThreadTest {
                     target_is_ready = true;
                     lock.wait();
                 } catch (InterruptedException ie) {
-                    iterrupted = true;
+                     System.err.println("Virtual thread was interrupted as expected");
+                     iterrupted = true;
                 }
             } while (!isJNITestingCompleted.get());
         }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class InterruptThreadTest {
     private static final String AGENT_LIB = "InterruptThreadTest";
     final Object lock = new Object();
-    final AtomicBoolean isJNITestingCompleted = new AtomicBoolean(false);
 
     native boolean testJvmtiFunctionsInJNICall(Thread vthread);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -37,15 +37,16 @@ public class InterruptThreadTest {
 
     native boolean testJvmtiFunctionsInJNICall(Thread vthread);
 
+    volatile private boolean target_is_ready = false;
     private boolean iterrupted = false;
 
     final Runnable pinnedTask = () -> {
         synchronized (lock) {
             do {
                 try {
-                    lock.wait(1);
+                    target_is_ready = true; 
+                    lock.wait();
                 } catch (InterruptedException ie) {
-                    System.err.println("Virtual thread was interrupted as expected");
                     iterrupted = true;
                 }
             } while (!isJNITestingCompleted.get());
@@ -54,6 +55,13 @@ public class InterruptThreadTest {
 
     void runTest() throws Exception {
         Thread vthread = Thread.ofVirtual().name("VThread").start(pinnedTask);
+
+        // wait for target virtual thread to reach the expected waiting state
+        while (!target_is_ready) {
+           synchronized (lock) {
+              lock.wait(1);
+            }
+        }
         testJvmtiFunctionsInJNICall(vthread);
         isJNITestingCompleted.set(true);
         vthread.join();

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -42,15 +42,13 @@ public class InterruptThreadTest {
 
     final Runnable pinnedTask = () -> {
         synchronized (lock) {
-            do {
-                try {
-                    target_is_ready = true;
-                    lock.wait();
-                } catch (InterruptedException ie) {
-                     System.err.println("Virtual thread was interrupted as expected");
-                     iterrupted = true;
-                }
-            } while (!isJNITestingCompleted.get());
+            try {
+                target_is_ready = true;
+                lock.wait();
+            } catch (InterruptedException ie) {
+                 System.err.println("Virtual thread was interrupted as expected");
+                 iterrupted = true;
+            }
         }
     };
 
@@ -64,7 +62,6 @@ public class InterruptThreadTest {
             }
         }
         testJvmtiFunctionsInJNICall(vthread);
-        isJNITestingCompleted.set(true);
         vthread.join();
         if (!iterrupted) {
             throw new RuntimeException("Failed: Virtual thread was not interrupted!");

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/InterruptThreadTest/InterruptThreadTest.java
@@ -44,7 +44,7 @@ public class InterruptThreadTest {
         synchronized (lock) {
             do {
                 try {
-                    target_is_ready = true; 
+                    target_is_ready = true;
                     lock.wait();
                 } catch (InterruptedException ie) {
                     iterrupted = true;


### PR DESCRIPTION
The test has a lack of synchronization.
The fix is to wait for target virtual thread reaching the desired state of execution.
The fix is being tested with 100 of mach5 test runs on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.java.net/loom pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/169.diff">https://git.openjdk.java.net/loom/pull/169.diff</a>

</details>
