### PR TITLE
Don't check access during vmerror reporting.

### DIFF
--- a/src/hotspot/share/oops/accessBackend.cpp
+++ b/src/hotspot/share/oops/accessBackend.cpp
@@ -30,6 +30,7 @@
 #include "runtime/thread.inline.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/vmError.hpp"
 
 namespace AccessInternal {
   // VM_Version::supports_cx8() is a surrogate for 'supports atomic long memory ops'.
@@ -207,11 +208,13 @@ namespace AccessInternal {
 
 #ifdef ASSERT
   void check_access_thread_state() {
+    if (VMError::is_error_reported()) {
+      return;
+    }
     Thread* thread = Thread::current();
     if (!thread->is_Java_thread()) {
       return;
     }
-
     JavaThread* java_thread = JavaThread::cast(thread);
     JavaThreadState state = java_thread->thread_state();
     assert(state == _thread_in_vm || state == _thread_in_Java || state == _thread_new,

--- a/src/hotspot/share/oops/accessBackend.cpp
+++ b/src/hotspot/share/oops/accessBackend.cpp
@@ -211,10 +211,12 @@ namespace AccessInternal {
     if (VMError::is_error_reported()) {
       return;
     }
+
     Thread* thread = Thread::current();
     if (!thread->is_Java_thread()) {
       return;
     }
+
     JavaThread* java_thread = JavaThread::cast(thread);
     JavaThreadState state = java_thread->thread_state();
     assert(state == _thread_in_vm || state == _thread_in_Java || state == _thread_new,


### PR DESCRIPTION
Don't check access during vmerror reporting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.java.net/loom pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/172.diff">https://git.openjdk.java.net/loom/pull/172.diff</a>

</details>
