### PR TITLE
8285196: Deadlock reporting prints carrier thread when virtual thread is in deadlock cycle 

### DIFF
--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -370,6 +370,9 @@ void ThreadService::reset_contention_time_stat(JavaThread* thread) {
 
 // Find deadlocks involving raw monitors, object monitors and concurrent locks
 // if concurrent_locks is true.
+// We skip virtual thread carriers under the assumption that the current scheduler, ForkJoinPool,
+// doesn't hold any locks while mounting a virtual thread, so any owned monitor (or j.u.c., lock for that matter)
+// on that JavaThread must be owned by the virtual thread, and we don't support deadlock detection for virtual threads.
 DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, bool concurrent_locks) {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
 
@@ -385,6 +388,7 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
   // Initialize the depth-first-number for each JavaThread.
   JavaThreadIterator jti(t_list);
   for (JavaThread* jt = jti.first(); jt != NULL; jt = jti.next()) {
+    if (jt->is_vthread_mounted()) continue;
     jt->set_depth_first_number(-1);
   }
 
@@ -392,6 +396,7 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
   DeadlockCycle* last = NULL;
   DeadlockCycle* cycle = new DeadlockCycle();
   for (JavaThread* jt = jti.first(); jt != NULL; jt = jti.next()) {
+    if (jt->is_vthread_mounted()) continue;
     if (jt->depth_first_number() >= 0) {
       // this thread was already visited
       continue;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -471,7 +471,7 @@ DeadlockCycle* ThreadService::find_deadlocks_at_safepoint(ThreadsList * t_list, 
         }
       }
 
-      if (currentThread == NULL) {
+      if (currentThread == NULL || currentThread->is_vthread_mounted()) {
         // No dependency on another thread
         break;
       }


### PR DESCRIPTION
Do not detect deadlock cycles, be it for monitors only or j.u.c `OwnableSynchronizer`s, when virtual threads are involved in the cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - Committer)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.java.net/loom pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/173.diff">https://git.openjdk.java.net/loom/pull/173.diff</a>

</details>
