### PR TITLE
thaw_kind cleanup

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -42,6 +42,7 @@
 #include "oops/oop.inline.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"
@@ -6599,9 +6600,9 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     // If we want, we can templatize thaw by kind, and have three different entries
-    if (exception)           __ movw(c_rarg1, (uint32_t)2);
-    else if (return_barrier) __ movw(c_rarg1, (uint32_t)1);
-    else                     __ movw(c_rarg1, (uint32_t)0);
+    if (exception)           __ movw(c_rarg1, (uint32_t)Continuation::thaw_exception);
+    else if (return_barrier) __ movw(c_rarg1, (uint32_t)Continuation::thaw_return_barrier);
+    else                     __ movw(c_rarg1, (uint32_t)Continuation::thaw_top);
 
     __ call_VM_leaf(Continuation::thaw_entry(), rthread, c_rarg1);
     __ mov(rscratch2, r0); // r0 is the sp of the yielding frame

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -7531,9 +7531,9 @@ address generate_avx_ghash_processBlocks() {
     }
 
     // If we want, we can templatize thaw by kind, and have three different entries
-    if (exception)           __ movl(c_rarg1, (int32_t)2);
-    else if (return_barrier) __ movl(c_rarg1, (int32_t)1);
-    else                     __ movl(c_rarg1, (int32_t)0);
+    if (exception)           __ movl(c_rarg1, (int32_t)Continuation::thaw_exception);
+    else if (return_barrier) __ movl(c_rarg1, (int32_t)Continuation::thaw_return_barrier);
+    else                     __ movl(c_rarg1, (int32_t)Continuation::thaw_top);
 
     __ call_VM_leaf(Continuation::thaw_entry(), r15_thread, c_rarg1);
     __ movptr(rbx, rax); // rax is the sp of the yielding frame

--- a/src/hotspot/share/runtime/continuation.hpp
+++ b/src/hotspot/share/runtime/continuation.hpp
@@ -58,6 +58,13 @@ class JavaThread;
 
 class Continuation : AllStatic {
 public:
+
+  enum thaw_kind {
+    thaw_top = 0,
+    thaw_return_barrier = 1,
+    thaw_exception = 2,
+  };
+
   static void init();
 
   static address freeze_entry();

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -45,6 +45,7 @@
 #include "oops/stackChunkOop.inline.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
 #include "runtime/continuationHelper.inline.hpp"
 #include "runtime/continuationWrapper.inline.hpp"
@@ -211,14 +212,8 @@ const char* freeze_result_names[6] = {
 static freeze_result is_pinned0(JavaThread* thread, oop cont_scope, bool safepoint);
 template<typename ConfigT> static inline int freeze_internal(JavaThread* current, intptr_t* const sp);
 
-enum thaw_kind {
-  thaw_top = 0,
-  thaw_return_barrier = 1,
-  thaw_exception = 2,
-};
-
 static inline int prepare_thaw_internal(JavaThread* thread, bool return_barrier);
-template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thread, const thaw_kind kind);
+template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::thaw_kind kind);
 
 
 // Entry point to freeze. Transitions are handled manually
@@ -245,7 +240,7 @@ static JRT_LEAF(intptr_t*, thaw(JavaThread* thread, int kind))
   // JRT_ENTRY instead?
   ResetNoHandleMark rnhm;
 
-  return ConfigT::thaw(thread, (thaw_kind)kind);
+  return ConfigT::thaw(thread, (Continuation::thaw_kind)kind);
 JRT_END
 
 JVM_ENTRY(jint, CONT_isPinned0(JNIEnv* env, jobject cont_scope)) {
@@ -267,7 +262,7 @@ public:
     return freeze_internal<SelfT>(thread, sp);
   }
 
-  static intptr_t* thaw(JavaThread* thread, thaw_kind kind) {
+  static intptr_t* thaw(JavaThread* thread, Continuation::thaw_kind kind) {
     return thaw_internal<SelfT>(thread, kind);
   }
 };
@@ -1637,12 +1632,12 @@ public:
            && !PreserveFramePointer;
   }
 
-  inline intptr_t* thaw(thaw_kind kind);
+  inline intptr_t* thaw(Continuation::thaw_kind kind);
   NOINLINE intptr_t* thaw_fast(stackChunkOop chunk);
 };
 
 template <typename ConfigT>
-inline intptr_t* Thaw<ConfigT>::thaw(thaw_kind kind) {
+inline intptr_t* Thaw<ConfigT>::thaw(Continuation::thaw_kind kind) {
   verify_continuation(_cont.continuation());
   assert(!jdk_internal_vm_Continuation::done(_cont.continuation()), "");
   assert(!_cont.is_empty(), "");
@@ -1653,7 +1648,7 @@ inline intptr_t* Thaw<ConfigT>::thaw(thaw_kind kind) {
 
   _barriers = chunk->requires_barriers();
   return (LIKELY(can_thaw_fast(chunk))) ? thaw_fast(chunk)
-                                        : thaw_slow(chunk, kind != thaw_top);
+                                        : thaw_slow(chunk, kind != Continuation::thaw_top);
 }
 
 class ReconstructedStack : public StackObj {
@@ -2212,7 +2207,7 @@ void ThawBase::push_return_frame(frame& f) { // see generate_cont_thaw
 // returns new top sp
 // called after preparations (stack overflow check and making room)
 template<typename ConfigT>
-static inline intptr_t* thaw_internal(JavaThread* thread, const thaw_kind kind) {
+static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::thaw_kind kind) {
   assert(thread == JavaThread::current(), "Must be current thread");
 
   CONT_JFR_ONLY(EventContinuationThaw event;)


### PR DESCRIPTION
In continuationFreezeThaw.cpp, the following enum is declared:
enum thaw_kind {
  thaw_top = 0,
  thaw_return_barrier = 1,
  thaw_exception = 2,
};

thaw_kind being declared in a .cpp file, it cannot be exported to other files. The consequence of that is that in the assembly code preparing the argument for the thaw() method, hard coded values are used instead of values from the enum:
    if (exception)           __ movl(c_rarg1, (int32_t)2);
    else if (return_barrier) __ movl(c_rarg1, (int32_t)1);
    else                     __ movl(c_rarg1, (int32_t)0);

The fix is to move the declaration of thaw_kind to continuation.hpp and use it everywhere instead of using hard coded values.

Tested with Loom test, tier 1 to 5.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.java.net/loom pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/174.diff">https://git.openjdk.java.net/loom/pull/174.diff</a>

</details>
