### PR TITLE
8276713

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -180,10 +180,6 @@ vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEa
 
 # Loom
 
-# stratum mismatch, test running with the wrong class path
-vmTestbase/vm/mlvm/indy/func/jdi/breakpointOtherStratum/Test.java            8276713 generic-all
-vmTestbase/vm/mlvm/meth/func/jdi/breakpointOtherStratum/Test.java            8276713 generic-all
-
 # obsolete test using Thread.stop
 runtime/Thread/StopAtExit.java                                               8283610 generic-all
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -190,7 +190,7 @@ public class Binder extends DebugeeBinder {
         Debugee debugee = null;
 
         String classPath = null;
-        classPath = System.getProperty("java.class.path");
+//        classPath = System.getProperty("java.class.path");
 
         prepareForPipeConnection(argumentHandler);
 
@@ -687,7 +687,6 @@ public class Binder extends DebugeeBinder {
     private Map<String,? extends Argument> setupLaunchingConnector(LaunchingConnector connector,
                                                 String classToExecute,
                                                 String classPath) {
-        display("ClassPath: " + classPath);
         display("LaunchingConnector:");
         display("    name: " + connector.name());
         display("    description: " + connector.description());
@@ -758,9 +757,11 @@ public class Binder extends DebugeeBinder {
             vmArgs += " --enable-preview";
         }
 
+/*
         if (classPath != null) {
             vmArgs += " -classpath " + quote + classPath + quote;
         }
+ */
 
         if (vmArgs.length() > 0) {
             arg = (Connector.StringArgument) arguments.get("options");


### PR DESCRIPTION
I removed some classpath changes that were causing some JVMTI to fail to find the .smap file for a couple of stratum tests. The changes appear to be unecessary.

I restored the commented out of the code to what it looks like in jdk. I did this to minimize diff with jdk, but if you wish I could either completely remove the commented code, or at least improve the formatting.

Tested with loom-tier1-5 on fibers branch and tier1-5 on jep-vt branch.