### PR TITLE
frame::describe: fix stack parameter location.

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1441,8 +1441,9 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
         }
         assert(sig_index == sizeargs, "");
       }
-      int out_preserve = SharedRuntime::java_calling_convention(sig_bt, regs, sizeargs);
-      assert(out_preserve ==  m->num_stack_arg_slots(), "");
+      int stack_arg_slots = SharedRuntime::java_calling_convention(sig_bt, regs, sizeargs);
+      assert(stack_arg_slots ==  m->num_stack_arg_slots(), "");
+      int out_preserve = SharedRuntime::out_preserve_stack_slots();
       int sig_index = 0;
       int arg_index = (m->is_static() ? 0 : -1);
       for (SignatureStream ss(m->signature()); !ss.at_return_type(); ) {
@@ -1453,7 +1454,7 @@ void frame::describe(FrameValues& values, int frame_no, const RegisterMap* reg_m
         VMReg fst = regs[sig_index].first();
         if (fst->is_stack()) {
           assert(((int)fst->reg2stack()) >= 0, "reg2stack: " INTPTR_FORMAT, fst->reg2stack());
-          int offset = fst->reg2stack() * VMRegImpl::stack_slot_size + stack_slot_offset;
+          int offset = (fst->reg2stack() + out_preserve) * VMRegImpl::stack_slot_size + stack_slot_offset;
           intptr_t* stack_address = (intptr_t*)((address)unextended_sp() + offset);
           if (at_this) {
             values.describe(frame_no, stack_address, err_msg("this for #%d", frame_no), 1);


### PR DESCRIPTION
Hi,

I'd like to contribute a small fix for a bug in `frame::describe()` I noticed while working on the ppc64le port.

Symptom: wrong location of stack parameters in compiled java calls on ppc64:

```
[6.223s][trace][continuations ]  0x00007fffb53bd660: 0x00007fffb53bd830 #6 nmethod 0x00007fffa5026890 for method J BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_12_dontinline(JJJJJJJJJJJJJ)J
[6.223s][trace][continuations ]                                         - #0 scope BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_12_dontinline(JJJJJJJJJJJJJ)J @ 28
[6.223s][trace][continuations ]                                         param 7 long for #6
[6.223s][trace][continuations ]                                         unextended_sp for #7
[6.223s][trace][continuations ]                                         sp for #7
[6.223s][trace][continuations ]  0x00007fffb53bd658: 0x00007fffa10077b0
[6.223s][trace][continuations ]  0x00007fffb53bd650: 0x00007fffb53bd7c8
[6.223s][trace][continuations ]  0x00007fffb53bd648: 0x00007fffb7c90c20
[6.223s][trace][continuations ]  0x00007fffb53bd640: 0x000000000000000d
[6.223s][trace][continuations ]  0x00007fffb53bd638: 0x000000000000000c
[6.223s][trace][continuations ]  0x00007fffb53bd630: 0x000000000000000b
[6.223s][trace][continuations ]  0x00007fffb53bd628: 0x000000000000000a
[6.223s][trace][continuations ]  0x00007fffb53bd620: 0x0000000000000009 param 13 long for #5
[6.223s][trace][continuations ]  0x00007fffb53bd618: 0x0000000000000008 param 12 long for #5
[6.223s][trace][continuations ]  0x00007fffb53bd610: 0x0000000000000007 param 11 long for #5
[6.223s][trace][continuations ]  0x00007fffb53bd608: 0x00007fffb53bd5c0 param 10 long for #5
[6.224s][trace][continuations ]  0x00007fffb53bd600: 0x00007fffa5026ba8 param 9 long for #5
[6.224s][trace][continuations ]                                         return address for #6
[6.224s][trace][continuations ]  0x00007fffb53bd5f8: 0x00007fffa0e3a220 param 8 long for #5
[6.224s][trace][continuations ]  0x00007fffb53bd5f0: 0x00007fffb53bd660 #5 nmethod 0x00007fffa5026190 for method J BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_13_dontinline(JJJJJJJJJJJJJJ)J
```

You can see that the locations of the stack parameters are wrong, because value for param N is (long)N.

Trace with the fix:

```
[8.273s][trace][continuations ]  0x00007fffb53bd660: 0x00007fffb53bd830 #6 nmethod 0x00007fffa5026890 for method J BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_12_dontinline(JJJJJJJJJJJJJ)J
[8.273s][trace][continuations ]                                         - #0 scope BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_12_dontinline(JJJJJJJJJJJJJ)J @ 28
[8.273s][trace][continuations ]                                         unextended_sp for #7
[8.273s][trace][continuations ]                                         sp for #7
[8.273s][trace][continuations ]  0x00007fffb53bd658: 0x00007fffa10077b0
[8.273s][trace][continuations ]  0x00007fffb53bd650: 0x00007fffb53bd7c8
[8.273s][trace][continuations ]  0x00007fffb53bd648: 0x00007fffb7c90c20
[8.273s][trace][continuations ]  0x00007fffb53bd640: 0x000000000000000d param 13 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd638: 0x000000000000000c param 12 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd630: 0x000000000000000b param 11 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd628: 0x000000000000000a param 10 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd620: 0x0000000000000009 param 9 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd618: 0x0000000000000008 param 8 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd610: 0x0000000000000007 param 7 long for #5
[8.273s][trace][continuations ]  0x00007fffb53bd608: 0x00007fffb53bd5c0
[8.273s][trace][continuations ]  0x00007fffb53bd600: 0x00007fffa5026ba8 return address for #6
[8.273s][trace][continuations ]  0x00007fffb53bd5f8: 0x00007fffa0e3a220
[8.273s][trace][continuations ]  0x00007fffb53bd5f0: 0x00007fffb53bd660 #5 nmethod 0x00007fffa5026190 for method J BasicExpWIP$ContinuationCompiledFrameWithStackArgs.testMethod_13_dontinline(JJJJJJJJJJJJJJ)J
```

See also [`reg2offset()`](https://github.com/openjdk/jdk/blob/3d07b3c7f01b60ff4dc38f62407c212b48883dbf/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp#L573-L575)

I've done only manual testing.

The change has no effect on x86_64/aarch64 because there [`SharedRuntime::out_preserve_stack_slots()`](https://github.com/openjdk/jdk/blob/3d07b3c7f01b60ff4dc38f62407c212b48883dbf/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp#L2259-L2261) returns 0.

Thanks, Richard.
