### PR TITLE
Don't assert for getting the name of thread->threadObj() if debugging.

### DIFF
--- a/src/hotspot/share/oops/accessBackend.cpp
+++ b/src/hotspot/share/oops/accessBackend.cpp
@@ -30,6 +30,7 @@
 #include "runtime/thread.inline.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/copy.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/vmError.hpp"
 
 namespace AccessInternal {
@@ -208,7 +209,7 @@ namespace AccessInternal {
 
 #ifdef ASSERT
   void check_access_thread_state() {
-    if (VMError::is_error_reported()) {
+    if (VMError::is_error_reported() || Debugging) {
       return;
     }
 


### PR DESCRIPTION
I keep hitting this assert using ps() from the debugger.  This builds without any error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Ron Pressler](https://openjdk.java.net/census#rpressler) (@pron - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/loom pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.java.net/loom pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/loom/pull/181.diff">https://git.openjdk.java.net/loom/pull/181.diff</a>

</details>
