### PR TITLE
ProblemList failing JMX tests that fail with the wrapper.

### DIFF
--- a/test/hotspot/jtreg/ProblemList-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-vthread.txt
@@ -492,3 +492,26 @@ compiler/jvmci/compilerToVM/DebugOutputTest.java 0000000 generic-all
 compiler/jvmci/compilerToVM/MaterializeVirtualObjectTest.java 0000000 generic-all
 compiler/jvmci/compilerToVM/MaterializeVirtualObjectTest.java 0000000 generic-all
 compiler/jvmci/compilerToVM/MaterializeVirtualObjectTest.java 0000000 generic-all
+
+
+####
+## NSK JMX Tests
+
+####
+## Unsupported functionality
+
+vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/baseBehaviorTest_server_default/TestDescription.java 8285419 generic-all
+vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/baseBehaviorTest_server_custom/TestDescription.java 8285419 generic-all
+vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/baseBehaviorTest_directly/TestDescription.java 8285419 generic-all
+vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/baseBehaviorTest_proxy_custom/TestDescription.java 8285419 generic-all
+vmTestbase/nsk/monitoring/ThreadMXBean/GetThreadAllocatedBytes/baseBehaviorTest_proxy_default/TestDescription.java 8285419 generic-all
+
+
+####
+## No ThreadInfo for vthreads
+
+vmTestbase/nsk/monitoring/ThreadInfo/isInNative/isinnative001/TestDescription.java 8285420 generic-all
+vmTestbase/nsk/monitoring/ThreadInfo/getLockOwnerName/getlockownername001/TestDescription.java 8285420 generic-all
+vmTestbase/nsk/monitoring/ThreadInfo/getLockName/getlockname001/TestDescription.java 8285420 generic-all
+vmTestbase/nsk/monitoring/ThreadInfo/from_c/from_c001/TestDescription.java 8285420 generic-all
+vmTestbase/nsk/monitoring/MemoryUsage/from/from001/TestDescription.java 8285420 generic-all


### PR DESCRIPTION
In the jdk repo, the following is being pushed:

[JDK-8291578](https://bugs.openjdk.org/browse/JDK-8291578) Remove JMX related tests from ProblemList-svc-vthreads.txt

Eventually this will make it's way into loom, which would leave these tests no longer being problem listed. As described in [JDK-8291578](https://bugs.openjdk.org/browse/JDK-8291578), these tests should be problem listed on ProblemList-vthread.txt, and this PR is taking care of that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/loom pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/189.diff">https://git.openjdk.org/loom/pull/189.diff</a>

</details>
