### PR TITLE
Support Kona Fiber of jdk20

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -162,6 +162,10 @@ ifneq ($(call check-jvm-feature, jfr), true)
   JVM_EXCLUDE_FILES += compilerEvent.cpp
 endif
 
+ifneq ($(call check-jvm-feature, fiber), true)
+  JVM_CFLAGS_FEATURES += -DINCLUDE_KONA_FIBER=0
+endif
+
 ################################################################################
 
 ifeq ($(call check-jvm-feature, link-time-opt), true)

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -361,7 +361,7 @@ inline const ImmutableOopMap* frame::get_oop_map() const {
 inline frame frame::sender(RegisterMap* map) const {
   frame result = sender_raw(map);
 
-  if (map->process_frames() && !map->in_cont()) {
+  if (map->process_frames() && !map->in_cont() && !UseKonaFiber) {
     StackWatermarkSet::on_iteration(map->thread(), result);
   }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -670,6 +670,10 @@ public:
   // prints msg and continues
   void warn(const char* msg);
 
+//#if INCLUDE_KONA_FIBER
+  void CoroutineSwitch(Register old_coroutine, Register target_coroutine, Register thread);
+//#endif
+
   // dumps registers and other state
   void print_state();
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -60,6 +60,7 @@ class outputStream;
   LOG_TAG(container) \
   LOG_TAG(continuations) \
   LOG_TAG(coops) \
+  LOG_TAG(coroutine) \
   LOG_TAG(cpu) \
   LOG_TAG(cset) \
   LOG_TAG(data) \

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -129,6 +129,8 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
   f(mtMetaspace,      "Metaspace")                                                   \
   f(mtStringDedup,    "String Deduplication")                                        \
   f(mtObjectMonitor,  "Object Monitors")                                             \
+  f(mtCoroutineStack, "Fiber Coroutine Stack Space")                                 \
+  f(mtCoroutine,      "Fiber Coroutine Wrapper")                                     \
   f(mtNone,           "Unknown")                                                     \
   //end
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -37,6 +37,7 @@
 #include "runtime/osThread.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vframe_hp.hpp"
+#include "runtime/coroutine.hpp"
 
 // defined in continuationFreezeThaw.cpp
 extern "C" jint JNICALL CONT_isPinned0(JNIEnv* env, jobject cont_scope);
@@ -447,4 +448,7 @@ void CONT_RegisterNativeMethods(JNIEnv *env, jclass cls) {
     int status = env->RegisterNatives(cls, CONT_methods, sizeof(CONT_methods)/sizeof(JNINativeMethod));
     guarantee(status == JNI_OK, "register jdk.internal.vm.Continuation natives");
     guarantee(!env->ExceptionOccurred(), "register jdk.internal.vm.Continuation natives");
+    if (UseKonaFiber) {
+      Coroutine::Initialize();
+    }
 }

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -47,7 +47,9 @@ void ContinuationEntry::set_enter_code(CompiledMethod* cm, int interpreted_entry
   _interpreted_entry_offset = interpreted_entry_offset;
   assert(_enter_special->code_contains(compiled_entry()),    "entry not in enterSpecial");
   assert(_enter_special->code_contains(interpreted_entry()), "entry not in enterSpecial");
-  assert(interpreted_entry() < compiled_entry(), "unexpected code layout");
+  if (!UseKonaFiber) {
+    assert(interpreted_entry() < compiled_entry(), "unexpected code layout");
+  }
 }
 
 address ContinuationEntry::compiled_entry() {

--- a/src/hotspot/share/runtime/continuationJavaClasses.cpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.cpp
@@ -56,6 +56,7 @@ int jdk_internal_vm_Continuation::_yieldInfo_offset;
 int jdk_internal_vm_Continuation::_mounted_offset;
 int jdk_internal_vm_Continuation::_done_offset;
 int jdk_internal_vm_Continuation::_preempted_offset;
+int jdk_internal_vm_Continuation::_data_offset;
 
 #define CONTINUATION_FIELDS_DO(macro) \
   macro(_scope_offset,     k, vmSymbols::scope_name(),     continuationscope_signature, false); \
@@ -65,7 +66,8 @@ int jdk_internal_vm_Continuation::_preempted_offset;
   macro(_tail_offset,      k, vmSymbols::tail_name(),      stackchunk_signature,        false); \
   macro(_mounted_offset,   k, vmSymbols::mounted_name(),   bool_signature,              false); \
   macro(_done_offset,      k, vmSymbols::done_name(),      bool_signature,              false); \
-  macro(_preempted_offset, k, "preempted",                 bool_signature,              false);
+  macro(_preempted_offset, k, "preempted",                 bool_signature,              false); \
+  macro(_data_offset,      k, "data",                      long_signature,              false);
 
 void jdk_internal_vm_Continuation::compute_offsets() {
   InstanceKlass* k = vmClasses::Continuation_klass();

--- a/src/hotspot/share/runtime/continuationJavaClasses.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.hpp
@@ -57,6 +57,9 @@ class jdk_internal_vm_Continuation: AllStatic {
   static int _mounted_offset;
   static int _done_offset;
   static int _preempted_offset;
+#if INCLUDE_KONA_FIBER
+  static int _data_offset;
+#endif
 
   static void compute_offsets();
  public:
@@ -73,6 +76,21 @@ class jdk_internal_vm_Continuation: AllStatic {
   static inline bool done(oop continuation);
   static inline bool is_preempted(oop continuation);
   static inline void set_preempted(oop continuation, bool value);
+#if INCLUDE_KONA_FIBER
+  // Accessors for Kona Fiber
+  static jlong data(oop obj) {
+    return obj->long_field(_data_offset);
+  }
+  static void set_data(oop obj, jlong value) {
+    obj->long_field_put(_data_offset, value);
+  }
+  static int get_data_offset() {
+    return _data_offset;
+  }
+  static int get_done_offset() {
+    return _done_offset;
+  }
+#endif
 };
 
 // Interface to jdk.internal.vm.StackChunk objects

--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -1,0 +1,790 @@
+/*
+ * Copyright 2001-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#if INCLUDE_KONA_FIBER
+#include "runtime/coroutine.hpp"
+#ifdef TARGET_ARCH_x86
+# include "vmreg_x86.inline.hpp"
+#endif
+#ifdef TARGET_ARCH_aarch64
+# include "vmreg_aarch64.inline.hpp"
+#endif
+#include "services/threadService.hpp"
+//#include "gc/cms/concurrentMarkSweepThread.hpp"
+#include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
+//#include "gc/parallel/pcTasks.hpp"
+#include "gc/shared/barrierSetNMethod.hpp"
+#include "runtime/java.hpp"
+#include "runtime/javaCalls.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/stackFrameStream.inline.hpp"
+#include "runtime/thread.inline.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/os.inline.hpp"
+#include "runtime/globals_extension.hpp"
+#include "oops/method.inline.hpp"
+#if INCLUDE_ZGC
+#include "gc/z/zBarrierSet.inline.hpp"
+#endif
+
+JavaThread* Coroutine::_main_thread = NULL;
+Method* Coroutine::_continuation_start = NULL;
+Coroutine::ConcCoroStage Coroutine::_conc_stage = Coroutine::_Uninitialized;
+int Coroutine::_conc_claim_parity = 1;
+
+ContBucket* ContContainer::_buckets= NULL;
+
+Mutex* ContReservedStack::_lock = NULL;
+GrowableArray<address>* ContReservedStack::free_array = NULL;
+ContPreMappedStack* ContReservedStack::current_pre_mapped_stack = NULL;
+uintx ContReservedStack::stack_size = 0;
+int ContReservedStack::free_array_uncommit_index = 0;
+Method* Coroutine::_try_compensate_method = NULL;
+Method* Coroutine::_update_active_count_method = NULL;
+
+void ContReservedStack::init() {
+  _lock = new Mutex(Mutex::nosafepoint, "InitializedStack");
+
+  free_array = new (ResourceObj::C_HEAP, mtCoroutine)GrowableArray<address>(CONT_RESERVED_PHYSICAL_MEM_MAX, mtCoroutine);
+  stack_size = align_up(DefaultCoroutineStackSize +
+               StackOverflow::stack_reserved_zone_size() +
+               StackOverflow::stack_yellow_zone_size() +
+               StackOverflow::stack_red_zone_size()
+               , os::vm_page_size());
+}
+
+bool ContReservedStack::add_pre_mapped_stack() {
+  uintx alloc_real_stack_size = stack_size * CONT_PREMAPPED_STACK_NUM;
+  uintx reserved_size = align_up(alloc_real_stack_size, os::vm_allocation_granularity());
+
+  ContPreMappedStack* node = new ContPreMappedStack(reserved_size, current_pre_mapped_stack);
+  if (node == NULL) {
+    return false;
+  }
+
+  if (!node->initialize_virtual_space(alloc_real_stack_size)) {
+    delete node;
+    return false;
+  }
+
+  current_pre_mapped_stack = node;
+  MemTracker::record_virtual_memory_type((address)node->get_base_address() - reserved_size, mtCoroutineStack);
+  return true;
+}
+
+void ContReservedStack::insert_stack(address node) {
+  MutexLocker ml(_lock, Mutex::_no_safepoint_check_flag);
+  free_array->append(node);
+
+  /*if (free_array->length() - free_array_uncommit_index > CONT_RESERVED_PHYSICAL_MEM_MAX) {
+    address target = free_array->at(free_array_uncommit_index);
+    os::free_heap_physical_memory((char *)(target - ContReservedStack::stack_size), ContReservedStack::stack_size);
+    free_array_uncommit_index++;
+  }*/
+}
+
+address ContReservedStack::get_stack_from_free_array() {
+  MutexLocker ml(_lock, Mutex::_no_safepoint_check_flag);
+  if (free_array->is_empty()) {
+    return NULL;
+  }
+
+  address stack_base = free_array->pop();
+  //if (free_array->length() <= free_array_uncommit_index) {
+    /* The node which is ahead of uncommit index has no physical memory */
+  //  free_array_uncommit_index = free_array->length();
+  //}
+  return stack_base;
+}
+
+bool ContReservedStack::pre_mapped_stack_is_full() {
+  if (current_pre_mapped_stack->allocated_num >= CONT_PREMAPPED_STACK_NUM) {
+    return true;
+  }
+
+  return false;
+}
+
+address ContReservedStack::acquire_stack() {
+  address result = current_pre_mapped_stack->get_base_address() - current_pre_mapped_stack->allocated_num * stack_size;
+  current_pre_mapped_stack->allocated_num++;
+
+  return result;
+}
+
+address ContReservedStack::get_stack_from_pre_mapped() {
+  address stack_base;
+  {
+    MutexLocker ml(_lock, Mutex::_no_safepoint_check_flag);
+    if ((current_pre_mapped_stack == NULL) || pre_mapped_stack_is_full()) {
+      if (!add_pre_mapped_stack()) {
+        return NULL;
+      }
+    }
+
+    stack_base = acquire_stack();
+  }
+
+  /* guard reserved, yellow page and red page of virtual space */
+  if (os::uses_stack_guard_pages()) {
+    address low_addr = stack_base - ContReservedStack::stack_size;
+    size_t len = StackOverflow::stack_guard_zone_size();
+    assert(is_aligned(low_addr, os::vm_page_size()), "Stack base should be the start of a page");
+    assert(is_aligned(len, os::vm_page_size()), "Stack size should be a multiple of page size");
+
+    if (os::guard_memory((char *) low_addr, len)) {
+      //_stack_guard_state = stack_guard_enabled;
+    } else {
+      log_warning(os, thread)("Attempt to protect stack guard pages failed ("
+        PTR_FORMAT "-" PTR_FORMAT ").", p2i(low_addr), p2i(low_addr + len));
+      if (os::uncommit_memory((char *) low_addr, len)) {
+        log_warning(os, thread)("Attempt to deallocate stack guard pages failed.");
+      }
+    }
+  }
+  return stack_base;
+}
+
+address ContReservedStack::get_stack() {
+  address stack_base = ContReservedStack::get_stack_from_free_array();
+  if (stack_base != NULL) {
+    return stack_base;
+  }
+
+  return ContReservedStack::get_stack_from_pre_mapped();
+}
+
+bool ContPreMappedStack::initialize_virtual_space(intptr_t real_stack_size) {
+  if (!_virtual_space.initialize(_reserved_space, real_stack_size)) {
+    _reserved_space.release();
+    return false;
+  }
+
+  return true;
+}
+
+ContBucket::ContBucket() : _lock(Mutex::nosafepoint, "ContBucket") {
+  _head = NULL;
+  _count = 0;
+
+  // This initial value ==> never claimed.
+  _oops_do_parity = 0;
+}
+
+void ContBucket::insert(Coroutine* cont) {
+  cont->insert_into_list(_head);
+  _count++;
+}
+
+void ContBucket::remove(Coroutine* cont) {
+  cont->remove_from_list(_head);
+  _count--;
+  assert(_count >= 0, "illegal count");
+}
+
+// GC Support
+bool ContBucket::claim_oops_do_par_case(int new_parity) {
+  jint old_parity = _oops_do_parity;
+  if (old_parity != new_parity) {
+    jint res = Atomic::cmpxchg(&_oops_do_parity, old_parity, new_parity);
+    if (res == old_parity) {
+      return true;
+    } else {
+      guarantee(res == new_parity, "Or else what?");
+    }
+  }
+  return false;
+}
+
+// Used by ParallelScavenge
+/*void ContBucket::create_cont_bucket_roots_tasks(GCTaskQueue* q) {
+  for (size_t i = 0; i < CONT_CONTAINER_SIZE; i++) {
+    q->enqueue(new ContBucketRootsTask((int)i));
+  }
+}
+
+// Used by Parallel Old
+void ContBucket::create_cont_bucket_roots_marking_tasks(GCTaskQueue* q) {
+  for (size_t i = 0; i < CONT_CONTAINER_SIZE; i++) {
+    q->enqueue(new ContBucketRootsMarkingTask((int)i));
+  }
+}*/
+
+#define ALL_BUCKET_CONTS(OPR)      \
+  {                                \
+    Coroutine* head = _head;       \
+    if (head != NULL) {            \
+      Coroutine* current = head;   \
+      do {                         \
+        current->OPR;              \
+        current = current->next(); \
+      } while (current != head);   \
+    }                              \
+  }
+
+void ContBucket::frames_do(void f(frame*, const RegisterMap*)) {
+  ALL_BUCKET_CONTS(frames_do(f));
+}
+
+void ContBucket::oops_do(OopClosure* f, CodeBlobClosure* cf) {
+  ALL_BUCKET_CONTS(oops_do(f, cf));
+}
+
+void ContBucket::nmethods_do(CodeBlobClosure* cf) {
+  ALL_BUCKET_CONTS(nmethods_do(cf));
+}
+
+void ContBucket::metadata_do(MetadataClosure* f) {
+  ALL_BUCKET_CONTS(metadata_do(f));
+}
+
+/*void ContBucket::print_stack_on(outputStream* st) {
+  ALL_BUCKET_CONTS(print_stack_on(st));
+}*/
+
+void ContContainer::init() {
+  assert(is_power_of_2(CONT_CONTAINER_SIZE), "Must be a power of two");
+  _buckets = new ContBucket[CONT_CONTAINER_SIZE];
+}
+
+ContBucket* ContContainer::bucket(size_t i) {
+  return &(_buckets[i]);
+}
+
+size_t ContContainer::hash_code(Coroutine* cont) {
+  return ((uintptr_t)cont >> CONT_MASK_SHIFT) & CONT_MASK;
+}
+
+void ContContainer::insert(Coroutine* cont) {
+  size_t index = hash_code(cont);
+  guarantee(index < CONT_CONTAINER_SIZE, "Must in the range from 0 to CONT_CONTAINER_SIZE - 1");
+  {
+    ContBucket* bucket = ContContainer::bucket(index);
+    MutexLocker ml(bucket->lock(), Mutex::_no_safepoint_check_flag);
+    bucket->insert(cont);
+    if (log_is_enabled(Trace, coroutine)) {
+      ResourceMark rm;
+      Log(coroutine) log;
+      log.trace("[insert] cont: %p, index: %d, count : %d", cont, (int)index, bucket->count());
+    }
+  }
+}
+
+void ContContainer::remove(Coroutine* cont) {
+  size_t index = hash_code(cont);
+  guarantee(index < CONT_CONTAINER_SIZE, "Must in the range from 0 to CONT_CONTAINER_SIZE - 1");
+  {
+    ContBucket* bucket = ContContainer::bucket(index);
+    MutexLocker ml(bucket->lock(), Mutex::_no_safepoint_check_flag);
+    bucket->remove(cont);
+    if (log_is_enabled(Trace, coroutine)) {
+      ResourceMark rm;
+      Log(coroutine) log;
+      log.trace("[remove] cont: %p, index: %d, count : %d", cont, (int)index, bucket->count());
+    }
+  }
+}
+
+#define ALL_BUCKETS_DO(OPR)                                     \
+  {                                                             \
+    for (size_t i = 0; i < CONT_CONTAINER_SIZE; i++) {          \
+      ContBucket* bucket = ContContainer::bucket(i);            \
+      MutexLocker ml(bucket->lock(), Mutex::_no_safepoint_check_flag); \
+      bucket->OPR;                                              \
+    }                                                           \
+  }
+
+void ContContainer::frames_do(void f(frame*, const RegisterMap*)) {
+  ALL_BUCKETS_DO(frames_do(f));
+}
+
+void ContContainer::oops_do(OopClosure* f, CodeBlobClosure* cf) {
+  ALL_BUCKETS_DO(oops_do(f, cf));
+}
+
+void ContContainer::nmethods_do(CodeBlobClosure* cf) {
+  ALL_BUCKETS_DO(nmethods_do(cf));
+}
+
+void ContContainer::metadata_do(MetadataClosure* f) {
+  ALL_BUCKETS_DO(metadata_do(f));
+}
+
+/*void ContContainer::print_stack_on(outputStream* st) {
+  ALL_BUCKETS_DO(print_stack_on(st));
+}*/
+
+void Coroutine::add_stack_frame(void* frames, int* depth, javaVFrame* jvf) {
+  StackFrameInfo* frame = new StackFrameInfo(jvf, false);
+  ((GrowableArray<StackFrameInfo*>*)frames)->append(frame);
+  (*depth)++;
+}
+
+#if defined(LINUX) || defined(_ALLBSD_SOURCE) || defined(_WINDOWS)
+void coroutine_start(void* dummy, const void* coroutineObjAddr) {
+#if !defined(AMD64) && !defined(AARCH64)
+  fatal("Corotuine not supported on current platform");
+#endif
+  JavaThread* thread = JavaThread::current();
+  thread->set_thread_state(_thread_in_vm);
+  // passing raw object address form stub to C method
+  // normally oop is OopDesc*, can use raw object directly
+  // in fastdebug mode, oop is "class oop", raw object addrss is stored in class oop structure
+#ifdef CHECK_UNHANDLED_OOPS
+  oop coroutineObj = oop(coroutineObjAddr);
+#else
+  oop coroutineObj = (oop)coroutineObjAddr;
+#endif
+  JavaCalls::call_continuation_start(coroutineObj, thread);
+  ShouldNotReachHere();
+}
+#endif
+
+void Coroutine::TerminateCoroutine(Coroutine* coro, JavaThread* thread) {
+  if (!jdk_internal_vm_Continuation::done(coro->_continuation)) {
+    return;
+  }
+
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(coroutine) log;
+    log.trace("[Co]: TerminateCoroutine %p in thread %s(%p)", coro, thread->name(), thread);
+  }
+  guarantee(thread == JavaThread::current(), "thread not match");
+
+  {
+    ContContainer::remove(coro);
+    if (thread->coroutine_cache_size() < MaxFreeCoroutinesCacheSize) {
+      coro->insert_into_list(thread->coroutine_cache());
+      thread->coroutine_cache_size() ++;
+    } else {
+      delete coro;
+    }
+  }
+}
+
+void Coroutine::Initialize() {
+  guarantee(_continuation_start == NULL, "continuation start already initialized");
+  /*Klass* resolved_klass = vmClasses::Continuation_klass();
+  Symbol* method_name = vmSymbols::enter_name();
+  Symbol* method_signature = vmSymbols::continuationEnter_signature();
+  Klass*  current_klass = resolved_klass;
+  LinkInfo link_info(resolved_klass, method_name, method_signature, current_klass);
+  methodHandle method(JavaThread::current(), LinkResolver::linktime_resolve_virtual_method_or_null(link_info));
+  _continuation_start = method();*/
+  Klass* resolved_klass = vmClasses::Continuation_klass();
+  Symbol* method_name = vmSymbols::enter_name();
+  Symbol* method_signature = vmSymbols::continuationEnter_signature();
+  Klass*  current_klass = resolved_klass;
+  LinkInfo link_info(resolved_klass, method_name, method_signature, current_klass);
+  //  methodHandle method(JavaThread::current(), LinkResolver::linktime_resolve_static_method(link_info));
+  _continuation_start = LinkResolver::resolve_static_call_or_null(link_info);
+  //_continuation_start = resolve_method(link_info, Bytecodes::_invokestatic, JavaThread::current());
+  guarantee(_continuation_start != NULL, "continuation start not resolveds");
+}
+
+void Coroutine::start_concurrent(ConcCoroStage stage) {
+  guarantee(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
+  assert(_conc_claim_parity >= 1 && _conc_claim_parity <= 2, "unexpected _conc_claim_parity");
+  _conc_stage = stage;
+  _conc_claim_parity++;
+  if (_conc_claim_parity == 3) {
+    _conc_claim_parity = 1;
+  }
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(gc) log;
+    log.trace("[Coroutine::start_concurrent] stage %d, parity %d", stage, _conc_claim_parity);
+  }
+}
+
+void Coroutine::end_concurrent() {
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(gc) log;
+    log.trace("[Coroutine::end_concurrent]");
+  }
+}
+
+class ConcCoroutineCodeBlobClosure : public CodeBlobToOopClosure {
+private:
+  BarrierSetNMethod* _bs;
+
+public:
+  ConcCoroutineCodeBlobClosure(OopClosure* cl) :
+    CodeBlobToOopClosure(cl, true /* fix_relocations */),
+    _bs(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
+
+  virtual void do_code_blob(CodeBlob* cb) {
+    nmethod* const nm = cb->as_nmethod_or_null();
+    if (nm != NULL) {
+      _bs->nmethod_entry_barrier(nm);
+    }
+  }
+};
+
+Coroutine* Coroutine::createContinuation() {
+  Coroutine* coro = NULL;
+  JavaThread* thread = JavaThread::current();
+  if (thread->coroutine_cache_size() > 0) {
+    coro = thread->coroutine_cache();
+    coro->remove_from_list(thread->coroutine_cache());
+    thread->coroutine_cache_size()--;
+    Coroutine::reset_coroutine(coro);
+    Coroutine::init_coroutine(coro, thread);
+  }
+  if (coro == NULL) {
+    coro = Coroutine::create_coroutine(thread, 0);
+    if (coro == NULL) {
+      HandleMark mark(thread);
+      //THROW_0(vmSymbols::java_lang_OutOfMemoryError());
+    }
+  }
+  ContContainer::insert(coro);
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(coroutine) log;
+    log.trace("CONT_createContinuation: create continuation %p", coro);
+  }
+  return coro;
+}
+
+void Coroutine::concurrent_task_run(OopClosure* f, int* claim) {
+  ConcCoroutineCodeBlobClosure cf(f);
+  while (true) {
+    int res = Atomic::add(claim, 1);
+    int cur = res - 1;
+    if (cur >= (int)CONT_CONTAINER_SIZE) {
+      break;
+    }
+    ContBucket* bucket = ContContainer::bucket(cur);
+    MutexLocker ml(bucket->lock(), Mutex::_no_safepoint_check_flag);
+    Coroutine* head = bucket->head();
+    if (head == NULL) {
+      continue;
+    }
+    Coroutine* current = head;
+    do {
+      if (current->conc_claim(true)) {
+        ResourceMark rm;
+        current->oops_do(f, ClassUnloading ? &cf : NULL);
+        bool res = current->conc_claim(false);
+        guarantee(res == true, "must success release");
+      }
+      current = current->next();
+    } while (current != head);
+  }
+}
+
+Coroutine::Coroutine() {
+  _has_javacall = false;
+  _continuation = NULL;
+#if defined(_WINDOWS)
+  _guaranteed_stack_bytes = 0;
+#endif
+#ifdef CHECK_UNHANDLED_OOPS
+  _t = NULL;
+#endif
+}
+
+Coroutine::~Coroutine() {
+  if (_verify_state != NULL) {
+    delete _verify_state; 
+  } else {
+    assert(VerifyCoroutineStateOnYield == false || _is_thread_coroutine,
+      "VerifyCoroutineStateOnYield is on and _verify_state is NULL");
+  }
+  free_stack();
+}
+
+Coroutine* Coroutine::create_thread_coroutine(JavaThread* thread) {
+  Coroutine* coro = new Coroutine();
+  coro->_state = _current;
+  coro->_verify_state = NULL;
+  coro->_is_thread_coroutine = true;
+  coro->_thread = thread;
+  coro->_coro_claim = _conc_claim_parity;
+  coro->init_thread_stack(thread);
+  coro->_has_javacall = true;
+  coro->_t = thread;
+#ifdef ASSERT
+  coro->_java_call_counter = 0;
+#endif
+#if defined(_WINDOWS)
+  coro->_last_SEH = NULL;
+#endif
+  ContContainer::insert(coro);
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(coroutine) log;
+    log.trace("[Co]: CreateThreadCoroutine %p in thread %s(%p)", coro, thread->name(), thread);
+  }
+  return coro;
+}
+
+void Coroutine::reset_coroutine(Coroutine* coro) {
+  coro->_has_javacall = false;
+}
+
+void Coroutine::init_coroutine(Coroutine* coro, JavaThread* thread) {
+  intptr_t** d = (intptr_t**)coro->_stack_base;
+  // 7 is async profiler's lookup slots count, avoid cross stack
+  // boundary when using async profiler
+  // must be odd number to keep frame pointer align to 16 bytes.
+  for (int32_t i = 0; i < 7; i++) {
+    *(--d) = NULL;
+  }
+#if defined TARGET_ARCH_aarch64
+  // aarch64 pops 2 slots when doing coroutine switch
+  // must keep frame pointer align to 16 bytes
+  *(--d) = NULL;
+#endif
+  *(--d) = (intptr_t*)coroutine_start;
+  *(--d) = NULL;
+
+  coro->set_last_sp((address) d);
+
+  coro->_state = _onstack;
+  coro->_is_thread_coroutine = false;
+  coro->_thread = thread;
+  coro->_coro_claim = _conc_claim_parity;
+
+#ifdef ASSERT
+  coro->_java_call_counter = 0;
+#endif
+#if defined(_WINDOWS)
+  coro->_last_SEH = NULL;
+#endif
+  if (log_is_enabled(Trace, coroutine)) {
+    ResourceMark rm;
+    Log(coroutine) log;
+    log.trace("[Co]: CreateCoroutine %p in thread %s(%p)", coro, coro->thread()->name(), coro->thread());
+  }
+}
+
+Coroutine* Coroutine::create_coroutine(JavaThread* thread, long stack_size) {
+  assert(stack_size <= 0, "Can not specify stack size by users");
+
+  Coroutine* coro = new Coroutine();
+  if (VerifyCoroutineStateOnYield) {
+    coro->_verify_state = new CoroutineVerify();
+  } else {
+    coro->_verify_state = NULL;
+  }
+  if (!coro->init_stack(thread)) {
+    return NULL;
+  }
+
+  Coroutine::init_coroutine(coro, thread);
+  return coro;
+}
+
+void Coroutine::frames_do(FrameClosure* fc) {
+  if (_state == Coroutine::_onstack) {
+    on_stack_frames_do(fc, _is_thread_coroutine);
+  }
+}
+
+bool Coroutine::conc_claim(bool gc_thread) {
+  int old_parity = _coro_claim;
+  if (old_parity != _conc_claim_parity) {
+    int new_parity = gc_thread ? 4 : _conc_claim_parity;
+    int res = Atomic::cmpxchg(&_coro_claim, old_parity, new_parity);
+    if (res == old_parity) {
+      return true;
+    } else {
+      if (gc_thread) {
+        guarantee(res == _conc_claim_parity, "Or else what?");
+      } else {
+        guarantee(res == _conc_claim_parity || res == 4, "Or else what?");
+      }
+    }
+  }
+  return false;
+}
+
+class oops_do_Closure: public FrameClosure {
+private:
+  OopClosure* _f;
+  CodeBlobClosure* _cf;
+
+public:
+  oops_do_Closure(OopClosure* f, CodeBlobClosure* cf): _f(f), _cf(cf) { }
+  void frames_do(frame* fr, RegisterMap* map) { fr->oops_do(_f, _cf, map); }
+};
+
+void Coroutine::oops_do(OopClosure* f, CodeBlobClosure* cf) {
+  if (is_thread_coroutine() == false) {
+    f->do_oop(&_continuation);
+  }
+  if(state() != Coroutine::_onstack) {
+    //tty->print_cr("oops_do on %p is skipped", this);
+    return;
+  }
+  //tty->print_cr("oops_do on %p is performed", this);
+  oops_do_Closure fc(f, cf);
+  frames_do(&fc);
+}
+
+class nmethods_do_Closure: public FrameClosure {
+private:
+  CodeBlobClosure* _cf;
+public:
+  nmethods_do_Closure(CodeBlobClosure* cf): _cf(cf) { }
+  void frames_do(frame* fr, RegisterMap* map) { fr->nmethods_do(_cf); }
+};
+
+void Coroutine::nmethods_do(CodeBlobClosure* cf) {
+  nmethods_do_Closure fc(cf);
+  frames_do(&fc);
+}
+
+class metadata_do_Closure: public FrameClosure {
+private:
+  MetadataClosure* _f;
+public:
+  metadata_do_Closure(MetadataClosure *f): _f(f) { }
+  void frames_do(frame* fr, RegisterMap* map) { 
+    fr->metadata_do(_f); 
+  }
+};
+
+void Coroutine::metadata_do(MetadataClosure* f) {
+  if(state() != Coroutine::_onstack) {
+    return;
+  }
+  metadata_do_Closure fc(f);
+  frames_do(&fc);
+}
+
+class frames_do_Closure: public FrameClosure {
+private:
+  void (*_f)(frame*, const RegisterMap*);
+public:
+  frames_do_Closure(void f(frame*, const RegisterMap*)): _f(f) { }
+  void frames_do(frame* fr, RegisterMap* map) { _f(fr, map); }
+};
+
+void Coroutine::frames_do(void f(frame*, const RegisterMap* map)) {
+  frames_do_Closure fc(f);
+  frames_do(&fc);
+}
+
+bool Coroutine::is_disposable() {
+  return false;
+}
+
+
+ObjectMonitor* Coroutine::current_pending_monitor() {
+  // if coroutine is detached(_onstack), it doesn't pend on monitor
+  // if coroutine is attached(_current), its pending monitor is thread's pending monitor
+  if (_state == _onstack) {
+    return NULL;
+  } else {
+    assert(_state == _current, "unexpected");
+    return _thread->current_pending_monitor();
+  }
+}
+
+bool Coroutine::is_attaching_via_jni() const {
+    if (_is_thread_coroutine) {
+      return _t->is_attaching_via_jni();
+    }
+
+    return false;
+}
+
+void Coroutine::init_thread_stack(JavaThread* thread) {
+  _stack_base = thread->stack_base();
+  _stack_size = thread->stack_size();
+  _stack_overflow_limit = thread->stack_overflow_state()->stack_overflow_limit();
+  _stack_end = thread->stack_overflow_state()->stack_end();
+  _shadow_zone_safe_limit = thread->stack_overflow_state()->shadow_zone_safe_limit();
+  _shadow_zone_growth_watermark = thread->stack_overflow_state()->shadow_zone_growth_watermark(); 
+  _last_sp = NULL;
+}
+
+bool Coroutine::init_stack(JavaThread* thread) {
+  _stack_base = ContReservedStack::get_stack();
+  if (_stack_base == NULL) {
+    return false;
+  }
+  _stack_size = ContReservedStack::stack_size;
+  _stack_overflow_limit = _stack_base - _stack_size + MAX2(StackOverflow::stack_guard_zone_size(), StackOverflow::stack_shadow_zone_size());
+  _stack_end = _stack_base - _stack_size;
+  _shadow_zone_safe_limit = _stack_end + StackOverflow::stack_guard_zone_size() + StackOverflow::stack_shadow_zone_size();
+  _shadow_zone_growth_watermark = _stack_base;
+  _last_sp = NULL;
+  return true;
+}
+
+void Coroutine::free_stack() {
+  if(!is_thread_coroutine()) {
+    ContReservedStack::insert_stack(_stack_base);
+  }
+}
+
+static const char* VirtualThreadStateNames[] = {
+  "NEW",
+  "STARTED",
+  "RUNNABLE",
+  "RUNNING",
+  "PARKING",
+  "PARKED",
+  "PINNED"
+};
+
+#if defined TARGET_ARCH_x86
+#define FRAME_POINTER rbp
+#elif defined TARGET_ARCH_aarch64
+#define FRAME_POINTER rfp
+#else
+#error "Arch is not supported."
+#endif
+
+void Coroutine::on_stack_frames_do(FrameClosure* fc, bool isThreadCoroutine) {
+  assert(_last_sp != NULL, "CoroutineStack with NULL last_sp");
+
+  // optimization to skip coroutine not started yet, check if return address is coroutine_start
+  // fp is only valid for call from interperter, from compiled code fp register is not gurantee valid
+  // JIT method utilize sp and oop map for oops iteration.
+  address pc = ((address*)_last_sp)[1];
+  intptr_t* fp = ((intptr_t**)_last_sp)[0];
+  if (pc != (address)coroutine_start) {
+    intptr_t* sp = ((intptr_t*)_last_sp) + 2;
+    frame fr(sp, fp, pc);
+    StackFrameStream fst(_thread, fr);
+    fst.register_map()->set_location(FRAME_POINTER->as_VMReg(), (address)_last_sp);
+    fst.register_map()->set_include_argument_oops(false);
+    for(; !fst.is_done(); fst.next()) {
+      fc->frames_do(fst.current(), fst.register_map());
+    }
+  } else {
+    guarantee(!isThreadCoroutine, "thread conrotuine with coroutine_start as return address");
+    guarantee(fp == NULL, "conrotuine fp not in init status");
+  }
+}
+#endif// INCLUDE_KONA_FIBER

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright 1999-2010 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ *
+ */
+
+#if INCLUDE_KONA_FIBER
+#ifndef SHARE_RUNTIME_COROUTINE_HPP
+#define SHARE_RUNTIME_COROUTINE_HPP
+
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/handles.hpp"
+#include "memory/allocation.hpp"
+#include "memory/resourceArea.hpp"
+#include "runtime/javaFrameAnchor.hpp"
+#include "runtime/monitorChunk.hpp"
+
+#define CORO_ONLY(x) x
+#define CORO_NOT_ONLY(x)
+
+class Coroutine; // ? why
+
+const size_t CONT_BITMAP_LEN             = 10;
+const size_t CONT_CONTAINER_SIZE         = 1 << CONT_BITMAP_LEN;
+const size_t CONT_MASK_SHIFT             = 5;
+const size_t CONT_MASK                   = CONT_CONTAINER_SIZE - 1;
+const int CONT_PREMAPPED_STACK_NUM       = 100;
+const int CONT_RESERVED_PHYSICAL_MEM_MAX = 100;
+
+// same with PIN value in Continuation.java
+const int CONT_PIN_JNI                   = 2;
+const int CONT_PIN_MONITOR               = 3;
+
+/* Mapping numbers of stacks and set its permission as PROT_READ | PROT_WRITE */
+class ContPreMappedStack : public CHeapObj<mtCoroutine> {
+private:
+  ReservedSpace _reserved_space;
+  VirtualSpace _virtual_space;
+  ContPreMappedStack* _next;
+
+public:
+  int allocated_num;
+  ContPreMappedStack(intptr_t size, ContPreMappedStack* next) : _reserved_space(size) {
+    _next = next;
+    allocated_num = 0;
+  };
+  ~ContPreMappedStack() {
+    _reserved_space.release();
+  };
+  bool initialize_virtual_space(intptr_t real_stack_size);
+  // stack is from high address to low address on X86
+  address get_base_address() {
+    return (address)_virtual_space.high();
+  };
+};
+
+class ContReservedStack : AllStatic {
+private:
+  static Mutex* _lock;
+  /*
+   * free_array contains stacks which are initialized, we can reuse it directly.
+   * free_array is an array, the most recently used stack is at the bottom of
+   * this array.
+   */
+  static GrowableArray<address>* free_array;
+  /* 
+   * A list of pre mapped stack, each node contains stacks which number is CONT_PREMAPPED_STACK_NUM,
+   * current_pre_mapped_stack pointed to the node which is used currently, 
+   * we should alloc a new pre mapped node when current_pre_mapped_stack is full.
+   */
+  static ContPreMappedStack* current_pre_mapped_stack;
+  static int free_array_uncommit_index;
+
+  static address get_stack_from_free_array();
+  static address get_stack_from_pre_mapped();
+  static bool add_pre_mapped_stack();
+
+  static inline address acquire_stack();
+  static inline bool pre_mapped_stack_is_full();
+
+public:
+  static uintx stack_size;
+
+  static void init();
+  /*
+   * 1. Try to get stack from free array.
+   * 2. If free array is not empty, get a stack from free array and return.
+   * 3. If free array is empty, try to get stack from pre-mapped memory.
+   * 4. If pre-mapped memory has no space to assign, add a new pre-mapped block.
+   * 5. Get pre-mapped memory.
+   * 6. Set the permisson of yellow page and red page as PROT_NONE.
+   */ 
+  static address get_stack();
+  /* Release stack and insert the stack into free array */
+  static void insert_stack(address node);
+};
+
+class ContBucket : public CHeapObj<mtCoroutine> {
+private:
+  Mutex      _lock;
+  Coroutine* _head;
+  int        _count;
+
+  // The parity of the last strong_roots iteration in which this ContBucket was
+  // claimed as a task.
+  jint _oops_do_parity;
+  bool claim_oops_do_par_case(int collection_parity);
+
+public:
+  Mutex* lock() { return &_lock; }
+  Coroutine* head() const { return _head; }
+  int count() const { return _count; } // Is this count useful?
+  void insert(Coroutine* cont);
+  void remove(Coroutine* cont);
+  ContBucket();
+  bool claim_oops_do(bool is_par, int collection_parity) {
+    if (!is_par) {
+      _oops_do_parity = collection_parity;
+      return true;
+    } else {
+      return claim_oops_do_par_case(collection_parity);
+    }
+  }
+  uintx parity() const { return (uintx)_oops_do_parity; }
+  //static void create_cont_bucket_roots_tasks(GCTaskQueue* q);
+  //static void create_cont_bucket_roots_marking_tasks(GCTaskQueue* q);
+
+  void frames_do(void f(frame*, const RegisterMap*));
+  void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  void nmethods_do(CodeBlobClosure* cf);
+  void metadata_do(MetadataClosure* f);
+  void print_stack_on(outputStream* st);
+};
+
+class ContContainer : AllStatic {
+private:
+  static ContBucket* _buckets;
+public:
+  static size_t hash_code(Coroutine* cont);
+  static ContBucket* bucket(size_t index);
+  static ContBucket* buckets() { return _buckets; };
+  static void insert(Coroutine* cont);
+  static void remove(Coroutine* cont);
+  static void init();
+
+  static void frames_do(void f(frame*, const RegisterMap*));
+  static void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  static void nmethods_do(CodeBlobClosure* cf);
+  static void metadata_do(MetadataClosure* f);
+  static void print_stack_on(outputStream* st);
+};
+
+template<class T>
+class DoublyLinkedList {
+private:
+  T*  _last;
+  T*  _next;
+
+public:
+  DoublyLinkedList() {
+    _last = NULL;
+    _next = NULL;
+  }
+
+  typedef T* pointer;
+
+  void remove_from_list(pointer& list);
+  void insert_into_list(pointer& list);
+
+  T* last() const   { return _last; }
+  T* next() const   { return _next; }
+};
+
+class FrameClosure: public StackObj {
+public:
+  virtual void frames_do(frame* fr, RegisterMap* map) = 0;
+};
+
+class CoroutineVerify: public CHeapObj<mtCoroutine> {
+public:
+  // for verify check
+  JNIHandleBlock* saved_active_handles;
+  size_t saved_active_handle_count;
+  char* saved_handle_area_hwm;
+  char* saved_resource_area_hwm;
+};
+
+class Coroutine: public CHeapObj<mtCoroutine>, public DoublyLinkedList<Coroutine> {
+public:
+  enum CoroutineState {
+    _onstack    = 0x00000001,
+    _current    = 0x00000002,
+    _dead       = 0x00000003,      // TODO is this really needed?
+    _dummy      = 0xffffffff
+  };
+
+  enum ConcCoroStage {
+    _Uninitialized    = 0x00000000,
+    _ZConcurrent      = 0x00000001
+  };
+  // similar with _thread_claim_parity, flip-flop between 1,2. As mutator thread might racing
+  // with concurrent GC thread, define a third state 4 (GC claimed and processing).
+  // 1. In GC Pause STW, invoke start_concurrent and flip _conc_claim_parity
+  // 2. Concurrent GC thread CAS _coro_claim from old parity to 4 before processing.
+  // 3. Concurrent GC thread set _coro_claim from 4 to new parity after processing.
+  // 4. Mutator thread claim CAS _coro_claim from old parity to _conc_claim_parity
+  // 5. Mutator thread wait if _coro_claim is 4 until it changes to _conc_claim_parity.
+  static int              _conc_claim_parity;
+private:
+  static Method*  _try_compensate_method;
+  static Method*  _update_active_count_method;
+  CoroutineState  _state;
+  bool            _is_thread_coroutine;
+  //for javacall stack reclaim
+  bool            _has_javacall;
+
+  address         _stack_base;
+  intptr_t        _stack_size;
+#if defined(_WINDOWS)
+  intptr_t        _guaranteed_stack_bytes;
+#endif
+  address         _last_sp;
+  address         _stack_overflow_limit;
+  address         _stack_end;
+  address         _shadow_zone_safe_limit;
+  address         _shadow_zone_growth_watermark;
+#ifndef CHECK_UNHANDLED_OOPS
+  union {
+#endif
+    oop             _continuation;
+    JavaThread*     _t;
+#ifndef CHECK_UNHANDLED_OOPS
+  };
+#endif
+
+  JavaThread*     _thread;
+  CoroutineVerify* _verify_state;
+  volatile int    _coro_claim;
+  int             _depth_first_number;
+#ifdef ASSERT
+  int             _java_call_counter;
+#endif
+
+  // objects of this type can only be created via static functions
+  Coroutine();
+
+  void frames_do(FrameClosure* fc);
+
+  static JavaThread* _main_thread;
+  static Method* _continuation_start;
+
+  // _conc_stage help muator thread decide which closure use for coroutine processing.
+  static ConcCoroStage    _conc_stage;
+
+  bool init_stack(JavaThread* thread);
+
+  void add_stack_frame(void* frames, int* depth, javaVFrame* jvf);
+  void print_stack_on(outputStream* st, void* frames, int* depth);
+  const char* get_vt_name_string(char* buf = NULL, int buflen = 0) const;
+  static JavaThreadState update_thread_state(Thread *Self, JavaThreadState new_jts);
+  static void init_forkjoinpool_method(Method** init_method, Symbol* method_name, Symbol* signature);
+  static void call_forkjoinpool_method(Thread* Self, Method* target_method, JavaCallArguments* args, JavaValue* result);
+
+public:
+  virtual ~Coroutine();
+  static void Initialize();
+  static void start_concurrent(ConcCoroStage stage);
+  static void end_concurrent();
+  static void concurrent_task_run(OopClosure* f, int* claim);
+  static Coroutine* createContinuation();
+  // 1. try claim or wait finish
+  // 2. claim success invoke _conc_cl on coroutine
+#if INCLUDE_ZGC
+  static void Concurrent_Coroutine_slowpath(Coroutine* coro);
+#endif
+#if defined(_WINDOWS)
+  intptr_t get_guaranteed_stack_bytes() { return _guaranteed_stack_bytes; }
+#endif
+
+  static void yield_verify(Coroutine* from, Coroutine* to, bool terminate);
+  static JavaThread* main_thread() { return _main_thread; }
+  static void set_main_thread(JavaThread* t) { _main_thread = t; }
+  static Method* cont_start_method() { return _continuation_start; }
+  static int try_compensate(Thread* Self);
+  static void update_active_count(Thread* Self);
+
+  void print_stack_on(outputStream* st);
+  void print_stack_on(void* frames, int* depth);
+  void print_VT_info(outputStream* st);
+
+  bool has_javacall() const { return _has_javacall; }
+  void set_has_javacall(bool hjc) { _has_javacall = hjc; }
+
+  static Coroutine* create_thread_coroutine(JavaThread* thread);
+  static Coroutine* create_coroutine(JavaThread* thread, long stack_size);
+  static void reset_coroutine(Coroutine* coro);
+  static void init_coroutine(Coroutine* coro, JavaThread* thread);
+
+  CoroutineState state() const      { return _state; }
+  void set_state(CoroutineState x)  { _state = x; }
+
+  bool is_thread_coroutine() const  { return _is_thread_coroutine; }
+
+  JavaThread* thread() const        { return _thread; }
+  void set_thread(JavaThread* x)    { _thread = x; }
+
+  void set_continuation(oop o)      {
+    assert(!is_thread_coroutine(), "could not be thread coroutine");
+    _continuation = o;
+  }
+
+  // For deadlock detection
+  int depth_first_number() { return _depth_first_number; }
+  void set_depth_first_number(int dfn) { _depth_first_number = dfn; }
+  ObjectMonitor* current_pending_monitor();
+  oop current_park_blocker();
+  oop threadObj() const;
+  const char* get_thread_name() const;
+  bool current_pending_monitor_is_from_java();
+  static Coroutine* owning_coro_from_monitor_owner(address owner);
+
+#ifdef ASSERT
+  int java_call_counter() const           { return _java_call_counter; }
+  void set_java_call_counter(int x)       { _java_call_counter = x; }
+#endif
+
+  bool is_disposable();
+
+  // GC support
+  bool conc_claim(bool is_gc_thread);
+  void oops_do(OopClosure* f, CodeBlobClosure* cf);
+  void nmethods_do(CodeBlobClosure* cf);
+  void metadata_do(MetadataClosure* f);
+  void frames_do(void f(frame*, const RegisterMap* map));
+  static void TerminateCoroutine(Coroutine* coro, JavaThread* thread);
+  static ByteSize state_offset()              { return byte_offset_of(Coroutine, _state); }
+
+  static ByteSize thread_offset()             { return byte_offset_of(Coroutine, _thread); }
+  static ByteSize has_javacall_offset()       { return byte_offset_of(Coroutine, _has_javacall); }
+  static ByteSize continuation_oop_offset()   { return byte_offset_of(Coroutine, _continuation); }
+
+  void init_thread_stack(JavaThread* thread);
+  void free_stack();
+  void on_stack_frames_do(FrameClosure* fc, bool isThreadCoroutine);
+  void set_last_sp(address x)               { _last_sp = x; }
+
+  static ByteSize stack_base_offset()         { return byte_offset_of(Coroutine, _stack_base); }
+  static ByteSize stack_size_offset()         { return byte_offset_of(Coroutine, _stack_size); }
+#if defined(_WINDOWS)
+  static ByteSize guaranteed_stack_bytes_offset() { return byte_offset_of(Coroutine, _guaranteed_stack_bytes); }
+#endif
+
+  static ByteSize last_sp_offset()            { return byte_offset_of(Coroutine, _last_sp); }
+  static ByteSize stack_overflow_limit_offset() { return byte_offset_of(Coroutine, _stack_overflow_limit); }
+  static ByteSize stack_end_offset() { return byte_offset_of(Coroutine, _stack_end); }
+  static ByteSize stack_shadow_zone_safe_limit_offset() { return byte_offset_of(Coroutine, _shadow_zone_safe_limit); }
+  static ByteSize stack_shadow_zone_growth_watermark_offset() { return byte_offset_of(Coroutine, _shadow_zone_growth_watermark); }
+
+  bool is_lock_owned(address adr) const {
+    return _stack_base >= adr && adr > (_stack_base - _stack_size);
+  }
+
+  bool is_attaching_via_jni() const;
+
+  static ByteSize coro_claim_offset()         { return byte_offset_of(Coroutine, _coro_claim); }
+#ifdef ASSERT
+  static ByteSize java_call_counter_offset()  { return byte_offset_of(Coroutine, _java_call_counter); }
+#endif
+
+#if defined(_WINDOWS)
+private:
+  address _last_SEH;
+public:
+  static ByteSize last_SEH_offset()           { return byte_offset_of(Coroutine, _last_SEH); }
+#endif
+};
+
+template<class T> void DoublyLinkedList<T>::remove_from_list(pointer& list) {
+  if (list == this) {
+    if (list->_next == list)
+      list = NULL;
+    else
+      list = list->_next;
+  }
+  _last->_next = _next;
+  _next->_last = _last;
+  _last = NULL;
+  _next = NULL;
+}
+
+template<class T> void DoublyLinkedList<T>::insert_into_list(pointer& list) {
+  if (list == NULL) {
+    _next = (T*)this;
+    _last = (T*)this;
+    list = (T*)this;
+  } else {
+    _next = list->_next;
+    list->_next = (T*)this;
+    _last = list;
+    _next->_last = (T*)this;
+  }
+}
+
+void CONT_RegisterNativeMethods(JNIEnv *env, jclass cls, JavaThread* thread);
+#endif // SHARE_RUNTIME_COROUTINE_HPP
+#else
+#define CORO_ONLY(x)
+#define CORO_NOT_ONLY(x) x
+#endif // INCLUDE_KONA_FIBER

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1984,6 +1984,21 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                           \
                 "Trace optimized upcall stub generation")                   \
+                                                                            \
+  product(bool, UseKonaFiber, true,                                         \
+          "Enable Kona Fiber")                                              \
+                                                                            \
+  product(uintx, DefaultCoroutineStackSize, 4*8*8*K,                        \
+        "Default size of the stack that is associated with new coroutines") \
+                                                                            \
+  product(uintx, MaxFreeCoroutinesCacheSize, 20,                            \
+          "The number of free coroutine stacks a thread can keep")          \
+                                                                            \
+  product(bool, TraceCoroutine, false, DIAGNOSTIC,                          \
+          "Trace Coroutine create/switch/terminate")                        \
+                                                                            \
+  product(bool, VerifyCoroutineStateOnYield, false, DIAGNOSTIC,             \
+          "Verify coroutine state after yield success")                     \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/javaCalls.hpp
+++ b/src/hotspot/share/runtime/javaCalls.hpp
@@ -55,7 +55,11 @@ class JavaCallWrapper: StackObj {
   // Construction/destruction
    JavaCallWrapper(const methodHandle& callee_method, Handle receiver, JavaValue* result, TRAPS);
   ~JavaCallWrapper();
-
+  // Used for continuation wrapper
+#if INCLUDE_KONA_FIBER
+  JavaCallWrapper(Method* method, Handle receiver, TRAPS);
+  void initialize(JavaThread* thread, JNIHandleBlock* handles, Method* callee_method, oop receiver, JavaValue* result);
+#endif
   // Accessors
   JavaThread*      thread() const           { return _thread; }
   JNIHandleBlock*  handles() const          { return _handles; }
@@ -252,6 +256,11 @@ class JavaCalls: AllStatic {
 
   // Low-level interface
   static void call(JavaValue* result, const methodHandle& method, JavaCallArguments* args, TRAPS);
+
+  // Continuation Entry call
+#if INCLUDE_KONA_FIBER
+  static void call_continuation_start(oop cont_obj, TRAPS);
+#endif
 };
 
 #endif // SHARE_RUNTIME_JAVACALLS_HPP

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -479,6 +479,15 @@ JavaThread::JavaThread() :
 
   _SleepEvent(ParkEvent::Allocate(this))
 {
+#if INCLUDE_KONA_FIBER
+  _current_coroutine = NULL;
+  _thread_coroutine = NULL;
+  if (UseKonaFiber) {
+    _coroutine_cache = NULL;
+    _coroutine_cache_size = 0;
+  }
+#endif
+
   set_jni_functions(jni_functions());
 
 #if INCLUDE_JVMCI
@@ -655,7 +664,11 @@ void JavaThread::run() {
   initialize_tlab();
 
   _stack_overflow_state.create_stack_guard_pages();
-
+#if INCLUDE_KONA_FIBER
+  if (UseKonaFiber) {
+    this->initialize_coroutine_support();
+  }
+#endif
   cache_global_variables();
 
   // Thread is now sufficiently initialized to be handled by the safepoint code as being

--- a/src/hotspot/share/runtime/stackFrameStream.cpp
+++ b/src/hotspot/share/runtime/stackFrameStream.cpp
@@ -41,3 +41,19 @@ StackFrameStream::StackFrameStream(JavaThread *thread, bool update, bool process
 #endif
 }
 
+#if INCLUDE_KONA_FIBER
+StackFrameStream::StackFrameStream(JavaThread *thread, frame last_frame, bool update, bool process_frames, bool allow_missing_reg)
+  : _reg_map(thread,
+             update ? RegisterMap::UpdateMap::include : RegisterMap::UpdateMap::skip,
+             process_frames ? RegisterMap::ProcessFrames::include : RegisterMap::ProcessFrames::skip,
+             RegisterMap::WalkContinuation::skip) {
+  _fr = last_frame;
+  _is_done = false;
+#ifndef PRODUCT
+  if (allow_missing_reg) {
+    _reg_map.set_skip_missing(true);
+  }
+#endif
+}
+#endif
+

--- a/src/hotspot/share/runtime/stackFrameStream.hpp
+++ b/src/hotspot/share/runtime/stackFrameStream.hpp
@@ -57,7 +57,9 @@ class StackFrameStream : public StackObj {
   bool        _is_done;
  public:
   StackFrameStream(JavaThread *thread, bool update, bool process_frames, bool allow_missing_reg = false);
-
+#if INCLUDE_KONA_FIBER
+  StackFrameStream(JavaThread *thread, frame last_frame, bool update = true, bool process_frames = true, bool allow_missing_reg = false);
+#endif
   // Iteration
   inline bool is_done();
   void next()                     { if (!_is_done) _fr = _fr.sender(&_reg_map); }

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -63,6 +63,9 @@ class StackOverflow {
     set_shadow_zone_limits();
     set_reserved_stack_activation(base);
   }
+  address stack_end()  const           { return _stack_end; }
+  address shadow_zone_growth_watermark() const { return _shadow_zone_growth_watermark; }
+
  private:
 
   StackGuardState  _stack_guard_state;
@@ -78,7 +81,6 @@ class StackOverflow {
   address          _stack_base;
   address          _stack_end;
 
-  address stack_end()  const           { return _stack_end; }
   address stack_base() const           { assert(_stack_base != nullptr, "Sanity check"); return _stack_base; }
 
   // Stack overflow support

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -634,5 +634,8 @@
 #define NOT_CDS_JAVA_HEAP_RETURN        {}
 #define NOT_CDS_JAVA_HEAP_RETURN_(code) { return code; }
 #endif
+#ifndef INCLUDE_KONA_FIBER
+#define INCLUDE_KONA_FIBER 1
+#endif
 
 #endif // SHARE_UTILITIES_MACROS_HPP

--- a/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -121,6 +121,7 @@ public class Continuation {
     private final ContinuationScope scope;
     private Continuation parent; // null for native stack
     private Continuation child; // non-null when we're yielded in a child continuation
+    private long data;
 
     private StackChunk tail;
 
@@ -301,6 +302,9 @@ public class Continuation {
 
     private void finish() {
         done = true;
+        if (data != 0) {
+            Continuation.yield(scope); // try to release corourine when yield
+        }
         assert isEmpty();
     }
 
@@ -328,7 +332,7 @@ public class Continuation {
     }
 
     private boolean isStarted() {
-        return tail != null;
+        return tail != null || data != 0;
     }
 
     private boolean isEmpty() {

--- a/test/micro/org/openjdk/bench/loom/obsolete/OneShot.java
+++ b/test/micro/org/openjdk/bench/loom/obsolete/OneShot.java
@@ -199,6 +199,7 @@ public class OneShot {
         cont.run();
         if (cont.isDone())
             throw new RuntimeException("continuation done???");
+        cont.run();
     }
 
     /**


### PR DESCRIPTION
# Introduce
Kona Fiber is a java stackful fiber implementation in KonaJDK8/11 and has been deployed in a lot java services in Tenent. It sync with most key Loom APIs on early JKU code base. Our team (Tencent Kona JDK) have ported Kona Fiber into OpenJDK20, it passes most Loom test and shows different performance with Loom. We'd pleasure to share Kona Fiber with Loom developers and users as a Loom compitable(mostly) java fiber implementation."

In our port, new option "-XX:+/-UseKonaFiber" is added to turn on Kona Fiber, default is off.  Kona Fiber has better performance on continuation switch but larger memory consumption compared with Loom,  in most scenarios developer can switch from Loom to Kona Fiber without code change.

Below, we elaborate key features on Kona Fiber, its difference with JKU and Loom and share some performance result.

# 1. differences with JKU
Kona Fiber is developed based on early JKU code but we added some key new features and optimization including:
## 1.1 decouple carrier thread and coroutine
JKU coroutine can only run on the Java Thread where coroutine is created. With Loom API(default scheduler is ForkJoinPool), Coroutine or Continuation can run on arbitrary worker thread by scheduler. Kona Fiber decouples coroutine and its creating thread by
1. move coroutine from thread local coroutine list to a global coroutine table.
2. save and restore carrier thread when swtiching between thread and coroutine.


## 1.2 simplify coroutine data structure
JKU allows coroutine switch with monitor\JNI frame, the correctness is guaranteed by developers and JKU only print a warning.So, JKU coroutine keeps local resource area/JNI local handle area/Metadata handle area/MonitorChunk. With Loom restricition, continuation with monitor\JNI frame is not allowed switch. These extra corotuine local data structure is removed, Kona Fiber refactor JKU by
1. refactor inital coroutine start logical, cleanup all handles  and resource areas usage
2. add verification code that checks resoruce area/JNI handle/metadata doesn't change when switch back from coroutine to thread

## 1.3 GC thread parallel walk stack of virtual thread
JKU iterate coroutines when processing its belonging threads during GC or other JVMTI actions, this might causes long GC pause due to unbalanced coroutine creations in JKU. After move coroutines into global table, coroutines is visited parallelly in table buckets.

## 1.4 performance optimization
There are many performance optimizations comparing with JKU, for example: coroutine batch created, cache and reuse stack of coroutine, create coroutine on Demand and so on.

# 2. Adapting Kona Fiber with Loom
## 2.1 runtime modification
Kona Fiber is almostly an independent module. We change the hook of freeze and thaw. Additionally, we implement the stack walking of virtual thread when GC happens. We only achieve the stack walking of G1GC now.

## 2.2 core library modification
In core library, add an extra yield while continuation finish. Because of Kona Fiber is a stackful scheme, we explicit release the stack memory of continuation.

# 3. what Kona Fiber not supported comparing to Loom

## 3.1 Use Continuation Directly
### 3.1.1 Continuation not finish but collected by GC
In this scene, Loom also has some problems(see discussion:https://mail.openjdk.org/pipermail/loom-dev/2020-May/001323.html). The extra problem of Kona Fiber is native stack of coroutine not released.

### 3.1.2 ContinuationScope
Kona Fiber do not support scope for continuation hierarchy now, we can support it in future. Continuation can only switch between carrier thread and continuation. 

## 3.2 Switch from carrier thread to virtual thread while carrier thread is pinned
Pin is checked at doYield(switch from virtual thread to carrier thread), but not checked at enterSpecial(switch from carrier thread to virtual thread) on Loom. Kona Fiber adds a dummy continuation for each thread, switch from vt to thread and thread to vt is actually equivalent to Kona Fiber. Virtual thread of Loom can reenter the object monitor which is hold by carrier thread, and Kona Fiber is not because of lightweight object monitor which record address on stack. So Kona Fiber must check Pin when switch from carrier thread to virtual thread, it is different with Loom. 

# 4. Performance result
## 4.1 Continuation switch
Mainly use JMH benchmark at test/micro/org/openjdk/bench/loom/

### 4.1.1 OneShot

The result of OneShot is shown as below while paramCount is 1. 

OneShot.yield: An operation of OneShot.yield is "creat a continuation, run the continuation, and continuation yield". The continuation is created but not finished. We add a cont.run() to make sure continuation is finished, so Kona Fiber can get continuation from cache which can accelerate the process of continuation create.

| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 248 | 261 | 278 | 411 |
| Loom | 1508 | 1559 | 1586 | 2379 |

OneShot.yieldAfterEachCall
| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 534 | 927 | 1638 | 7441 |
| Loom | 2213 | 3193 | 5237 | 25600 |

OneShot.yieldBeforeAndAfterEachCall
| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 903 | 1636 | 3065 | 14581 |
| Loom | 2494 | 3495 | 6062 | 39543 |

OneShot.yieldBeforeEachCall
| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 540 | 904 | 1650 | 7547 |
| Loom | 2213 | 3193 | 5237 | 25600 |
 
OneShot.yieldThenContinue
| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 284 | 261 | 287 | 405 |
| Loom | 1495 | 1552 | 1589 | 2358 |

### 4.1.2 FreezeAndThaw

The result is yieldAndContinuation minus baseline of testcase FreezeAndThaw. Kona Fiber is 4.x faster than Loom, and Kona Fiber works better when stackdepth get deeper(while stackdepth is 100, Kona Fiber is 20.x faster than Loom), unit is "ns/op":

| stackdepth | 5 | 10 | 20 | 100 |
| ------------ | ------------ | ------------ | ------------ | ------------ | 
| Kona Fiber | 68 | 78 | 56 | 87 |
| Loom | 221 | 269 | 372 | 1807 |

### 4.1.3 Oscillation
Kona Fiber is 2.x to 3.x better than Loom, because there is many time spend on jump from maxDepth to minDepth and the cost is same with Kona Fiber and Loom.(unis is "ns/op")
|  maxDepth | minDepth | Kona Fiber | Loom |
| ------------ | ------------ | ------------ | ------------ |
| 5| 2 | 1012.891 | 3319.44 |
| 5|2|  8047.345 |  22573.425|
|5| 2|  78043.954|  198971.856 |
|5| 3|  1002.794|   3286.773 |
|5| 3|  8095.574|   21109.516|
|5| 3|  77219.734|  196529.532|
|5| 4|  1010.236|   3203.197|
|5| 4|  7661.433|   20111.7|
|5| 4|  73664.17|   187357.237|
|6| 2|  1089.909|   3524.884|
|6| 2|  8515.355|   23636.167|
|6| 2|  83007.198|  223553.905|
|6| 3|  1022.743|   3489.051|
|6| 3|  8222.142|   22415.682|
|6| 3|  79560.057|  215778.073|
|6| 4|  989.495|    3309.326|
|6| 4|  7907.928|   21463.64|
|6| 4|  76620.636|  199450.446|
|7| 2|  1085.62|    3552.785|
|7| 2|  8822.602|   24165.294|
|7| 2|  84875.676|  226516.057|
|7| 3|  1050.816|   3538.169|
|7| 3|  8469.229|   23692.779|
|7| 3|  82485.214|  222592.842|
|7| 4|  1010.377|   3339.384|
|7| 4|  7999.824|   21347.933|
|7| 4|  77563.254|  204326.762|
|8| 2|  1077.988|   3701.969|
|8| 2|  8822.24 |24493.97|
|8| 2|  87558.258|  225938.926|
|8| 3|  1076.211|   3580.486|
|8| 3|  8804.987|   24073.394|
|8| 3|  84496.946|  225824.735|
|8| 4|  1120.996|   3594.21|
|8| 4|  8488.365|   23860.013|
|8| 4|  82291.311|  222835.707|

## 4.2 Continuation create
We have two new JMH benchmark about Continuation create（The benchmark can be seen in the PR）.First case is create and terminate a single coro repeatedly, Second case is batch create 1000 coros and terminate 1000 coros repeatedly. The performance result of Loom with two testcases is similar. Kona Fiber is better at test case 1, and worse at test case 2。

### 4.2.1 single continuation create repeatedly
unit is op/s（means how many continuations are created in one second）
|loom   |kona|
| ------------ | ------------ | 
|2727383|   10658633|

### 4.2.2 batch continuation(batch is 1000)

|loom   |kona|
| ------------ | ------------ | 
|2444375|   1272231|


## 4.3 Memory usage
We create one million virtual threads(each virtual thread execute simple function), and monitor memory usage of the progress. The result is shown below:

|   |java heap|native memory|
| ------------ | ------------ | ------------ | 
|loom|  833M | 177M |
|kona|  275M | 8725M |