### PR TITLE
StructuredTaskScope Javadoc: consistently use the phrase "contained in the task scope"

### DIFF
--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -413,7 +413,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
      * then the {@link #handleComplete(Future) handleComplete} method is invoked to
      * consume the completed task. The {@code handleComplete} method is run when the task
      * completes with a result or exception. If the Future's {@link Future#cancel(boolean)
-     * cancel} method is used the cancel a task before the task scope is shut down, then
+     * cancel} method is used to cancel a task before the task scope is shut down, then
      * the {@code handleComplete} method is run by the thread that invokes {@code cancel}.
      * If the task scope shuts down at or around the same time that the task completes or
      * is cancelled then the {@code handleComplete} method may or may not be invoked.

--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -505,7 +505,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
 
     /**
      * Wait for all threads to finish or the task scope to shut down. This method waits
-     * until all threads started in the task scope finish execution (of both task and
+     * until all threads contained in the task scope finish execution (of both task and
      * {@link #handleComplete(Future) handleComplete} method), the {@link #shutdown()
      * shutdown} method is invoked to shut down the task scope, or the current thread
      * is {@linkplain Thread#interrupt() interrupted}.
@@ -528,7 +528,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
 
     /**
      * Wait for all threads to finish or the task scope to shut down, up to the given
-     * deadline. This method waits until all threads started in the task scope finish
+     * deadline. This method waits until all threads contained in the task scope finish
      * execution (of both task and {@link #handleComplete(Future) handleComplete} method),
      * the {@link #shutdown() shutdown} method is invoked to shut down the task scope,
      * the current thread is {@linkplain Thread#interrupt() interrupted}, or the deadline
@@ -625,8 +625,8 @@ public class StructuredTaskScope<T> implements AutoCloseable {
      * <ul>
      * <li> {@linkplain Future#cancel(boolean) Cancels} the tasks that have threads
      * {@linkplain Future#get() waiting} on a result so that the waiting threads wakeup.
-     * <li> {@linkplain Thread#interrupt() Interrupts} all unfinished threads in the
-     * task scope (except the current thread).
+     * <li> {@linkplain Thread#interrupt() Interrupts} all unfinished threads contained in the
+     * task scope.
      * <li> Wakes up the owner if it is waiting in {@link #join()} or {@link
      * #joinUntil(Instant)}. If the owner is not waiting then its next call to {@code
      * join} or {@code joinUntil} will return immediately.

--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -625,8 +625,8 @@ public class StructuredTaskScope<T> implements AutoCloseable {
      * <ul>
      * <li> {@linkplain Future#cancel(boolean) Cancels} the tasks that have threads
      * {@linkplain Future#get() waiting} on a result so that the waiting threads wakeup.
-     * <li> {@linkplain Thread#interrupt() Interrupts} all unfinished threads contained in the
-     * task scope.
+     * <li> {@linkplain Thread#interrupt() Interrupts} all unfinished threads in the
+     * task scope (except the current thread).
      * <li> Wakes up the owner if it is waiting in {@link #join()} or {@link
      * #joinUntil(Instant)}. If the owner is not waiting then its next call to {@code
      * join} or {@code joinUntil} will return immediately.


### PR DESCRIPTION
The class-level Javadoc of StructuredTaskScope contains the following:

> The phrase "threads contained in the task scope" in method descriptions means threads started in the task scope or descendant scopes.

However, the method-level Javadoc sometimes uses slightly different wordings.
This PR updates the Javadoc to consistently use the phrase "contained in the task scope" (and fixes an unrelated typo).

PS: I'll need help from someone to create a JBS issue & sponsor this PR

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/loom pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/194.diff">https://git.openjdk.org/loom/pull/194.diff</a>

</details>
