### PR TITLE
Fix typo in StructuredTaskScope Javadoc

### DIFF
--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructuredTaskScope.java
@@ -413,7 +413,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
      * then the {@link #handleComplete(Future) handleComplete} method is invoked to
      * consume the completed task. The {@code handleComplete} method is run when the task
      * completes with a result or exception. If the Future's {@link Future#cancel(boolean)
-     * cancel} method is used the cancel a task before the task scope is shut down, then
+     * cancel} method is used to cancel a task before the task scope is shut down, then
      * the {@code handleComplete} method is run by the thread that invokes {@code cancel}.
      * If the task scope shuts down at or around the same time that the task completes or
      * is cancelled then the {@code handleComplete} method may or may not be invoked.


### PR DESCRIPTION
As the title says.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/loom pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/195.diff">https://git.openjdk.org/loom/pull/195.diff</a>

</details>
