### PR TITLE
Add a new subclass of StructuredTaskScope that shows the finished subtasks as a Stream

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1473,13 +1473,24 @@ public class StructuredTaskScope<T> implements AutoCloseable {
         }
 
         /**
+         * Wait for each subtask in this task scope to finish, push it into the stream,
+         * until either the stream final operation ends, there is no more subtasks or
+         * the scope is shutdown.
          *
-         * TODO
+         * <p> This method waits for each subtask by waiting for each thread {@linkplain
+         * #fork(Callable) started} in this task scope to finish its execution.
+         * It stops waiting when the stream is short-circuited, all threads finish,
+         * the task scope is {@linkplain #shutdown() shut down}, or the current thread is
+         * {@linkplain Thread#interrupt() interrupted}.
+         *
+         * <p> This method may only be invoked by the task scope owner.
          *
          * @param mapper a function that takes a stream and return a value
+         * @param <U>    the type of the return value
          * @return the value returned by the mapper function
-         * @param <U> the type of the return value
-         * @throws InterruptedException if an IO exception occurs
+         * @throws IllegalStateException if this task scope is closed
+         * @throws WrongThreadException  if the current thread is not the task scope owner
+         * @throws InterruptedException  if interrupted while waiting
          */
         public <U> U joinWhen(Function<? super Stream<Subtask<T>>, ? extends U> mapper) throws InterruptedException {
             Objects.requireNonNull(mapper, "mapper is null");
@@ -1503,18 +1514,21 @@ public class StructuredTaskScope<T> implements AutoCloseable {
 
         @Override
         public void shutdown() {
-            throw new UnsupportedOperationException();
+            super.shutdown();
         }
 
         @Override
         public Streamable<T> join() throws InterruptedException {
-            throw new UnsupportedOperationException();
+            super.join();
+            return this;
         }
 
         @Override
         public Streamable<T> joinUntil(Instant deadline)
-                throws InterruptedException, TimeoutException {
-            throw new UnsupportedOperationException();
+                throws InterruptedException, TimeoutException
+        {
+            super.joinUntil(deadline);
+            return this;
         }
     }
 }

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1576,12 +1576,12 @@ public class StructuredTaskScope<T> implements AutoCloseable {
             ensureOpen();  // throws ISE if closed
             Stream<Subtask<T>> stream = StreamSupport.stream(new SubTaskSpliterator(deadline), false);
             U result= mapper.apply(stream);
-            lastJoinCompleted = forkRound;
-            super.shutdown();
-            queue.clear();
             if (Thread.interrupted()) {
                 throw new InterruptedException();
             }
+            super.shutdown();
+            queue.clear();
+            lastJoinCompleted = forkRound;
             return result;
         }
 

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1578,6 +1578,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
             U result= mapper.apply(stream);
             lastJoinCompleted = forkRound;
             super.shutdown();
+            queue.clear();
             if (Thread.interrupted()) {
                 throw new InterruptedException();
             }

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -898,10 +898,9 @@ public class StructuredTaskScope<T> implements AutoCloseable {
                 ex = e;
             }
 
-            // nothing to do if task scope is shutdown, apart if it's a Streamable
-            if (scope.isShutdown()) {
+            // nothing to do if task scope is shutdown
+            if (scope.isShutdown())
                 return;
-            }
 
             // capture result or exception, invoke handleComplete
             if (ex == null) {


### PR DESCRIPTION
This is a minimal patch that adds a new subclass of StructuredTaskScope named Stremable (better name needed) pushing failed/succceding subtasks into a Stream.

This subclass aim to:
- make easier for users to use STS without having to override handleCompleted, which is called concurrently so hard to get right, at a price of being a little less efficient
- ease the implementation of shortcuited stream semantics like get the first two values, get the first value greater than a threshold, etc by auto shutdowning the STS once the condition is true

The Streamable STS adds two new methods joinWhile/joinUntilWhile(function) that takes a function that takes a Stream and return a value
```java
  public <U> U joinWhile(Function<? super Stream<Subtask<T>>, ? extends U> mapper) throws InterruptedException {
```
When this method is called, each finished subtask (with state SUCCESS or FAILED) are pushed into the Stream until there is no more subtasks, the stream has finished (has been short-circuited), the scope has been shutdown, interrupted or the dealine occurs. If some tasks are still pending because the stream has been short-cirtuited, they are shutdown.

Here are two examples:
- get a list of all the values that suceeed
```java
    try(var streamable = new StructuredTaskScope.Streamable<Integer>()) {
            streamable.fork(() -> {
                Thread.sleep(200);
                return 12;
            });
            streamable.fork(() -> {
                Thread.sleep(100);
                return 17;
            });
            List<Integer> list = streamable.joinWhile(stream -> stream.filter(task -> task.state() == State.SUCCESS).map(Subtask::get).toList());
            System.out.println(list);  // [17, 12]
        }
```
- find the first subtask (that suceed or fail)
```java
    try(var streamable = new StructuredTaskScope.Streamable<Integer>()) {
            streamable.fork(() -> {
                Thread.sleep(1_000);
                return 12;
            });
            streamable.fork(() -> {
                Thread.sleep(100);
                return 17;
            });
            Optional<Subtask<Integer>> first = streamable.joinWhile(Stream::findFirst);
            System.out.println(first);  // Optional[PlainSubTask[state=SUCCESS, result=17, exception=null]]
        }
```
Internally, handleCompleted post each subtask into a queue which is read by the Stream spliterator inside joinWhile.

The current implementation uses thread flock methods ThreadFlock.awaitAll()/ThreadFlock.wakeup().
If we want the implementation to only depends on protected methods, still not sure if its a good idea, we need
- expose ensureOwner and ensureOpen,
- expose round values (forkRound, lastJoinAttempted, lastJoinCompleted), this can be done using a method that takes a lambda
- expose ThreadFlock.awaitAll() ThreadFlock.wakeup().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * @donPain (no known openjdk.org user name / role) ⚠️ Review applies to [6cdf85ae](https://git.openjdk.org/loom/pull/202/files/6cdf85ae8cebc0843d4276024f948f09d0d1d48d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/202/head:pull/202` \
`$ git checkout pull/202`

Update a local copy of the PR: \
`$ git checkout pull/202` \
`$ git pull https://git.openjdk.org/loom.git pull/202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 202`

View PR using the GUI difftool: \
`$ git pr show -t 202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/202.diff">https://git.openjdk.org/loom/pull/202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/loom/pull/202#issuecomment-1702743502)