### PR TITLE
fix for casLockState intrinsic

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_64.cpp
@@ -538,21 +538,16 @@ address TemplateInterpreterGenerator::generate_cas_lock_state() {
   const Register robj   = rcx;
   const Register rtmp   = r8;
   const Register rto    = r10;
-  const Register rr2tmp = r11;
   const Register rfrom  = rax; // Must be rax
 
   __ movptr(robj,   Address(rsp, 3*wordSize));
-  __ movptr(rto,    Address(rsp, 2*wordSize));
-  __ movptr(rfrom,  Address(rsp, 1*wordSize));
+  __ movl  (rto,    Address(rsp, 2*wordSize));
+  __ movl  (rfrom,  Address(rsp, 1*wordSize));
 
   __ movptr(rtmp, Address(robj, oopDesc::mark_offset_in_bytes()));
 
-  __ movq(rr2tmp, markWord::lock_mask_in_place);
-  __ notq(rr2tmp);
-
-  __ andptr(rtmp, rr2tmp);
-
   // Clean MW in rtmp
+  __ andptr(rtmp, ~(int32_t)markWord::lock_mask_in_place);
   __ orptr(rto,   rtmp);
   __ orptr(rfrom, rtmp);
 


### PR DESCRIPTION
Read of to/from args needs to be 32-bit.  Also simplified masking logic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/204/head:pull/204` \
`$ git checkout pull/204`

Update a local copy of the PR: \
`$ git checkout pull/204` \
`$ git pull https://git.openjdk.org/loom.git pull/204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 204`

View PR using the GUI difftool: \
`$ git pr show -t 204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/204.diff">https://git.openjdk.org/loom/pull/204.diff</a>

</details>
