### PR TITLE
modify VirtualThreadPinnedEventThrows.java

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/VirtualThreadPinnedEventThrows.java
+++ b/test/jdk/java/lang/Thread/virtual/VirtualThreadPinnedEventThrows.java
@@ -29,6 +29,20 @@
  * @run junit VirtualThreadPinnedEventThrows
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.lang.management.ManagementFactory;
+
+import jdk.jfr.EventType;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
 import java.lang.ref.Reference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
@@ -82,29 +96,66 @@ class VirtualThreadPinnedEventThrows {
      * Test parking a virtual thread when pinned.
      */
     private void testParkWhenPinned() throws Exception {
-        Object lock = new Object();
-        try {
-            var completed = new AtomicBoolean();
-            Thread thread = Thread.startVirtualThread(() -> {
-                synchronized (lock) {
-                    LockSupport.park();
-                    completed.set(true);
-                }
-            });
+        try (Recording recording = new Recording()) {
+            recording.enable("jdk.VirtualThreadPinned");
+            recording.start();
 
-            // wait for thread to park
-            Thread.State state;
-            while ((state = thread.getState()) != Thread.State.WAITING) {
-                assertTrue(state != Thread.State.TERMINATED);
-                Thread.sleep(10);
+            Object lock = new Object();
+            try {
+                var completed = new AtomicBoolean();
+                Thread thread = Thread.startVirtualThread(() -> {
+                    synchronized (lock) {
+                        LockSupport.park();
+                        completed.set(true);
+                    }
+                });
+
+                // wait for thread to park
+                Thread.State state;
+                while ((state = thread.getState()) != Thread.State.WAITING) {
+                    assertTrue(state != Thread.State.TERMINATED);
+                    Thread.sleep(10);
+                }
+
+                // unpark and check that thread completed without exception
+                LockSupport.unpark(thread);
+                thread.join();
+                assertTrue(completed.get());
+            } finally {
+                Reference.reachabilityFence(lock);
             }
 
-            // unpark and check that thread completed without exception
-            LockSupport.unpark(thread);
-            thread.join();
-            assertTrue(completed.get());
-        } finally {
-            Reference.reachabilityFence(lock);
+            recording.stop();
+
+            Map<String, Integer> events = sumEvents(recording);
+            int virtualThreadPinnedEventCount = events.getOrDefault("jdk.VirtualThreadPinned", 0);
+            assertEquals(0, virtualThreadPinnedEventCount);
         }
+    }
+
+    /**
+     * Read the events from the recording and return a map of event name to count.
+     */
+    private static Map<String, Integer> sumEvents(Recording recording) throws IOException {
+        Path recordingFile = recordingFile(recording);
+        List<RecordedEvent> events = RecordingFile.readAllEvents(recordingFile);
+        return events.stream()
+                .map(RecordedEvent::getEventType)
+                .collect(Collectors.groupingBy(EventType::getName,
+                        Collectors.summingInt(x -> 1)));
+    }
+
+    /**
+     * Return the file path to the recording file.
+     */
+    private static Path recordingFile(Recording recording) throws IOException {
+        Path recordingFile = recording.getDestination();
+        if (recordingFile == null) {
+            File directory = new File(".");
+            String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+            recordingFile = new File(directory.getAbsolutePath(), "recording-" + recording.getId() + "-pid" + pid + ".jfr").toPath();
+            recording.dump(recordingFile);
+        }
+        return recordingFile;
     }
 }


### PR DESCRIPTION
This test is for testing parking when pinned and VirtualThreadPinnedEvent.commit fails with OOME.However, this test can also pass if OOM is not thrown.Therefore, it is not possible to determine whether VirtualThreadPinnedEvent has thrown an exception.

In reference to the parkOnCarrierThread method in VirtualThread in JDK 22, if OOM (Out of Memory Error) is thrown, then the event will be null.
```java
private void parkOnCarrierThread(boolean timed, long nanos) {
        assert state() == RUNNING;

        VirtualThreadPinnedEvent event;
        try {
            event = new VirtualThreadPinnedEvent();
            event.begin();
        } catch (OutOfMemoryError e) {
            event = null;
        }
```
So, I added a condition to confirm that OOM (Out of Memory Error) has been thrown and that the event is null (assertEquals(0, virtualThreadPinnedEventCount);).