### PR TITLE
RISC-V: Fix typo in InterpreterMacroAssembler::call_VM_preemptable

### DIFF
--- a/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
@@ -304,7 +304,7 @@ inline intptr_t* ThawBase::possibly_adjust_frame(frame& top) {
   CodeBlob* cb = top.cb();
 
   if (cb->frame_size() == 2) {
-    // C2 runtime stub case. For aarch64 the real size of the c2 runtime stub is 2 words bigger
+    // C2 runtime stub case. For riscv64 the real size of the c2 runtime stub is 2 words bigger
     // than what we think, i.e. size is 4. This is because the _last_Java_sp is not set to the
     // sp right before making the call to the VM, but rather it is artificially set 2 words above
     // this real sp so that we can store the return address at last_Java_sp[-1], and keep this

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1587,7 +1587,7 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
 
   // Make VM call. In case of preemption set last_pc to
   // the one we want to resume to.
-  la(t0, not_preempted);
+  la(t0, resume_pc);
   sd(t0, Address(xthread, JavaThread::last_Java_pc_offset()));
   call_VM_base(oop_result, noreg, noreg, entry_point, 1, false /*check_exceptions*/);
 


### PR DESCRIPTION
Seems to me that there exists two typos in loom commit https://github.com/openjdk/loom/commit/0b14b49e2ba05a62268dc02f1cfe1e258173deb7 (define call_VM_preemptable for interpreter). @pchilano : Could you please confirm that? Thanks.

Testing performed on linux-riscv64:
- [x] make test TEST="hotspot_loom jdk_loom" (release build)
- [x] make test TEST="hotspot_loom jdk_loom" TEST_VM_OPTS="-XX:+VerifyStack" (fastdebug build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/loom.git pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/213.diff">https://git.openjdk.org/loom/pull/213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/loom/pull/213#issuecomment-2399135443)