### PR TITLE
RISC-V: Reserve one extra temp register for C2_MacroAssembler::fast_lock

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -44,7 +44,8 @@
 
  public:
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.
-  void fast_lock(Register object, Register box, Register tmp1, Register tmp2, Register tmp3);
+  void fast_lock(Register object, Register box,
+                 Register tmp1, Register tmp2, Register tmp3, Register tmp4);
   void fast_unlock(Register object, Register box, Register tmp1, Register tmp2);
 
   // Code used by cmpFastLockLightweight and cmpFastUnlockLightweight mach instructions in .ad file.

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10541,17 +10541,19 @@ instruct tlsLoadP(javaThread_RegP dst)
 
 // inlined locking and unlocking
 // using t1 as the 'flag' register to bridge the BoolNode producers and consumers
-instruct cmpFastLock(rFlagsReg cr, iRegP object, iRegP box, iRegPNoSp tmp1, iRegPNoSp tmp2, iRegPNoSp tmp3)
+instruct cmpFastLock(rFlagsReg cr, iRegP object, iRegP box,
+                     iRegPNoSp tmp1, iRegPNoSp tmp2, iRegPNoSp tmp3, iRegPNoSp tmp4)
 %{
   predicate(LockingMode != LM_LIGHTWEIGHT);
   match(Set cr (FastLock object box));
-  effect(TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4);
 
   ins_cost(10 * DEFAULT_COST);
-  format %{ "fastlock $object,$box\t! kills $tmp1,$tmp2,$tmp3, #@cmpFastLock" %}
+  format %{ "fastlock $object,$box\t! kills $tmp1,$tmp2,$tmp3,$tmp4 #@cmpFastLock" %}
 
   ins_encode %{
-    __ fast_lock($object$$Register, $box$$Register, $tmp1$$Register, $tmp2$$Register, $tmp3$$Register);
+    __ fast_lock($object$$Register, $box$$Register,
+                 $tmp1$$Register, $tmp2$$Register, $tmp3$$Register, $tmp4$$Register);
   %}
 
   ins_pipe(pipe_serial);


### PR DESCRIPTION
This is a small improvement for `C2_MacroAssembler::fast_lock`. Currently, we reuse `disp_hdr` to hold the loaded current thread id, which means we need to reload markWord from object into displaced_header into `disp_hdr` for later use in recursive lock case. This change simply reserves one extra temp register 'tmp4reg' to hold the loaded current thread id, which would help avoid such a reloading of markWord. This also fixes one code comment of `C2_MacroAssembler::fast_lock_lightweight`.

Testing performed on linux-riscv64:
- [x] make test TEST="hotspot_loom jdk_loom" (release build)
- [x] make test TEST="hotspot_loom jdk_loom" TEST_VM_OPTS="-XX:+VerifyStack -XX:+VerifyContinuations" (fastdebug build)
