### PR TITLE
RISC-V: Avoid return misprediction

### DIFF
--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -70,3 +70,5 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ relocate(entry_guard_Relocation::spec());
   __ emit_int32(0);  // nmethod guard value
 }
+
+#undef __

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1603,10 +1603,10 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
   pop_cont_fastpath();
 
   // Check if preempted.
-  ld(t0, Address(xthread, JavaThread::preempt_alternate_return_offset()));
-  beqz(t0, not_preempted);
+  ld(t1, Address(xthread, JavaThread::preempt_alternate_return_offset()));
+  beqz(t1, not_preempted);
   sd(zr, Address(xthread, JavaThread::preempt_alternate_return_offset()));
-  jr(t0);
+  jr(t1);
 
   // In case of preemption, this is where we will resume once we finally acquire the monitor.
   bind(resume_pc);
@@ -1616,8 +1616,8 @@ void InterpreterMacroAssembler::call_VM_preemptable(Register oop_result,
 }
 
 void InterpreterMacroAssembler::restore_after_resume(bool is_native) {
-  la(t0, ExternalAddress(Interpreter::cont_resume_interpreter_adapter()));
-  jalr(t0);
+  la(t1, ExternalAddress(Interpreter::cont_resume_interpreter_adapter()));
+  jalr(t1);
   if (is_native) {
     // On resume we need to set up stack as expected
     push(dtos);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1806,10 +1806,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   if (LockingMode != LM_LEGACY && method->is_object_wait0()) {
     // Check preemption for Object.wait()
-    __ ld(t0, Address(xthread, JavaThread::preempt_alternate_return_offset()));
-    __ beqz(t0, native_return);
+    __ ld(t1, Address(xthread, JavaThread::preempt_alternate_return_offset()));
+    __ beqz(t1, native_return);
     __ sd(zr, Address(xthread, JavaThread::preempt_alternate_return_offset()));
-    __ jr(t0);
+    __ jr(t1);
     __ bind(native_return);
 
     intptr_t the_pc = (intptr_t) __ pc();

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3896,9 +3896,9 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(preemption_cancelled);
     __ sb(zr, Address(xthread, JavaThread::preemption_cancelled_offset()));
     __ la(fp, Address(sp, checked_cast<int32_t>(ContinuationEntry::size() + 2 * wordSize)));
-    __ la(t0, ExternalAddress(ContinuationEntry::thaw_call_pc_address()));
-    __ ld(t0, Address(t0));
-    __ jr(t0);
+    __ la(t1, ExternalAddress(ContinuationEntry::thaw_call_pc_address()));
+    __ ld(t1, Address(t1));
+    __ jr(t1);
 
     return start;
   }

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3896,7 +3896,6 @@ void TemplateTable::monitorenter() {
 
    // store object
    __ sd(x10, Address(c_rarg1, BasicObjectLock::obj_offset()));
-
    __ lock_object(c_rarg1);
 
    // check to make sure this monitor doesn't cause stack overflow after locking


### PR DESCRIPTION
This is a small enhancement for the loom riscv-specifc changes. This fixes a return misprediction performance issue which was recently discovered. See https://github.com/openjdk/jdk/pull/21406 for more details. It simply changes usage of scratch registers prefering `t1` instead of `t0` for jumps and calls, which should not affect basic functionality. This also reverted an unnecessary change previously made in two files  `src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp` and `src/hotspot/cpu/riscv/templateTable_riscv.cpp`.

Testing performed on linux-riscv64:
- [x] make test TEST="hotspot_loom jdk_loom" (release build)
- [x] make test TEST="hotspot_loom jdk_loom" TEST_VM_OPTS="-XX:+VerifyStack -XX:+VerifyContinuations" (fastdebug build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/loom.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/215.diff">https://git.openjdk.org/loom/pull/215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/loom/pull/215#issuecomment-2425478877)