### PR TITLE
8349763: Expose more ForkJoinPool parameters to configure virtual thread scheduler

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -1444,10 +1444,15 @@ final class VirtualThread extends BaseVirtualThread {
      */
     private static ForkJoinPool createDefaultForkJoinPoolScheduler() {
         ForkJoinWorkerThreadFactory factory = pool -> new CarrierThread(pool);
-        int parallelism, maxPoolSize, minRunnable;
+        int parallelism, maxPoolSize, minRunnable, corePoolSize;
+        long keepAliveTime;
+        TimeUnit timeUnit;
         String parallelismValue = System.getProperty("jdk.virtualThreadScheduler.parallelism");
         String maxPoolSizeValue = System.getProperty("jdk.virtualThreadScheduler.maxPoolSize");
         String minRunnableValue = System.getProperty("jdk.virtualThreadScheduler.minRunnable");
+        String corePoolSizeValue = System.getProperty("jdk.virtualThreadScheduler.corePoolSize");
+        String keepAliveTimeValue = System.getProperty("jdk.virtualThreadScheduler.keepAliveTime");
+        String timeUnitValue = System.getProperty("jdk.virtualThreadScheduler.timeUnit");
         if (parallelismValue != null) {
             parallelism = Integer.parseInt(parallelismValue);
         } else {
@@ -1464,10 +1469,30 @@ final class VirtualThread extends BaseVirtualThread {
         } else {
             minRunnable = Integer.max(parallelism / 2, 1);
         }
+        if (corePoolSizeValue != null) {
+            corePoolSize = Integer.parseInt(corePoolSizeValue);
+        } else {
+            corePoolSize = 0;
+        }
+        if (keepAliveTimeValue != null) {
+            keepAliveTime = Long.parseLong(keepAliveTimeValue);
+        } else {
+            keepAliveTime = 30;
+        }
+        switch(timeUnitValue) {
+            case "NANOSECONDS": timeUnit = NANOSECONDS; break;
+            case "MICROSECONDS": timeUnit = MICROSECONDS; break;
+            case "MILLISECONDS": timeUnit = MILLISECONDS; break;
+            case "SECONDS": timeUnit = SECONDS; break;
+            case "MINUTES": timeUnit = MINUTES; break;
+            case "HOURS": timeUnit = HOURS; break;
+            case "DAYS": timeUnit = DAYS; break;
+            default: timeUnit = SECONDS;
+        }
         Thread.UncaughtExceptionHandler handler = (t, e) -> { };
         boolean asyncMode = true; // FIFO
         return new ForkJoinPool(parallelism, factory, handler, asyncMode,
-                     0, maxPoolSize, minRunnable, pool -> true, 30, SECONDS);
+                    corePoolSize, maxPoolSize, minRunnable, pool -> true, keepAliveTime, timeUnit);
     }
 
     /**


### PR DESCRIPTION
Since the parameters -Djdk.virtualThreadScheduler.parallelism=N , -Djdk.virtualThreadScheduler.maxPoolSize=M, -Djdk.virtualThreadScheduler.minimumRunnable=Y have already been made available, it would be worth considering opening up additional ForkJoinPool-related parameters: -Djdk.virtualThreadScheduler.corePoolSize=X, -Djdk.virtualThreadScheduler.keepAliveTime=Z and -Djdk.virtualThreadScheduler.timeUnit.

In particular, configuring corePoolSize can help reduce jitter caused by thread ramp-up during application startup, while keepAliveTime and timeUnit ensures more threads are available within the time expected by users. Opening these parameters would be highly meaningful for optimizing virtual thread scheduling.