### PR TITLE
bad oop with JvmtiVTMSTransitionDisabler

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2036,7 +2036,7 @@ public:
       int vt_state = java_lang_VirtualThread::state(_java_thread());
       _thread_status = java_lang_VirtualThread::map_state_to_thread_status(vt_state);
     }
-    _name = nullptr; //java_lang_Thread::name(_java_thread());
+    _name = java_lang_Thread::name(_java_thread());
 
     if (_thread != nullptr && !_thread->has_last_Java_frame()) {
       // stack trace is empty
@@ -2232,12 +2232,16 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
   public:
     TransitionDisabler() : _transition_disabler(nullptr) {}
     ~TransitionDisabler() {
-      if (_transition_disabler != nullptr) {
-        delete _transition_disabler;
-      }
+      reset();
     }
     void init(jobject jthread) {
       _transition_disabler = new (mtInternal) JvmtiVTMSTransitionDisabler(jthread);
+    }
+    void reset() {
+      if (_transition_disabler != nullptr) {
+        delete _transition_disabler;
+        _transition_disabler = nullptr;
+      }
     }
   } transition_disabler;
 
@@ -2267,14 +2271,17 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
     } while (cl.read_reset_retry());
   }
 
+  // Handle thread name
+  Handle thread_name(THREAD, cl._name);
+
   // Convert to StackTraceElement array
-  InstanceKlass* k = vmClasses::StackTraceElement_klass();
-  assert(k != nullptr, "must be loaded in 1.4+");
-  if (k->should_be_initialized()) {
-    k->initialize(CHECK_NULL);
+  InstanceKlass* ste_klass = vmClasses::StackTraceElement_klass();
+  assert(ste_klass != nullptr, "must be loaded in 1.4+");
+  if (ste_klass->should_be_initialized()) {
+    ste_klass->initialize(CHECK_NULL);
   }
 
-  objArrayHandle trace = oopFactory::new_objArray_handle(k, cl._depth, CHECK_NULL);
+  int max_locks = cl._locks != nullptr ? cl._locks->length() : 0;
 
   InstanceKlass* lock_klass = nullptr;
   if (with_locks) {
@@ -2283,7 +2290,8 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
     lock_klass = InstanceKlass::cast(k);
   }
 
-  int max_locks = cl._locks != nullptr ? cl._locks->length() : 0;
+  objArrayHandle trace = oopFactory::new_objArray_handle(ste_klass, cl._depth, CHECK_NULL);
+
   for (int i = 0; i < cl._depth; i++) {
     methodHandle method(THREAD, cl._methods->at(i));
     oop element = java_lang_StackTraceElement::create(method, cl._bcis->at(i), CHECK_NULL);
@@ -2294,7 +2302,7 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
   {
     JavaValue result(T_OBJECT);
     JavaCalls::call_static(&result,
-                           k, // vmClasses::StackTraceElement_klass()
+                           ste_klass,
                            vmSymbols::java_lang_StackTraceElement_of_name(),
                            vmSymbols::java_lang_StackTraceElement_of_signature(),
                            trace,
@@ -2323,6 +2331,9 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
     }
   }
 
+  // all oops are handled, can enable transitions.
+  transition_disabler.reset();
+
   Symbol* snapshot_name = vmSymbols::jdk_internal_vm_ThreadSnapshot();
   Klass* snapshot_klass = SystemDictionary::resolve_or_fail(snapshot_name, true, CHECK_NULL);
   if (snapshot_klass->should_be_initialized()) {
@@ -2333,7 +2344,7 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
   JavaCallArguments args;
   args.push_oop(trace);
   args.push_oop(locks);
-  //args.push_oop(Handle(THREAD, cl._name));
+  args.push_oop(thread_name);
   args.push_int((int)cl._thread_status);
   Handle snapshot = JavaCalls::construct_new_instance(InstanceKlass::cast(snapshot_klass),
       vmSymbols::jdk_internal_vm_ThreadSnapshot_ctor_signature(), &args, CHECK_NULL);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2251,8 +2251,6 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
     oop carrier_thread = java_lang_VirtualThread::carrier_thread(java_thread());
     if (carrier_thread != nullptr) {
       thread = java_lang_Thread::thread(carrier_thread);
-    } else {
-      // TODO: need to "suspend" the VT like VirtualThread.getStackTrace does
     }
   } else {
     thread = java_lang_Thread::thread(java_thread());

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -747,7 +747,7 @@ class SerializeClosure;
   template(dumpThreads_name,                       "dumpThreads")                                                 \
   template(dumpThreadsToJson_name,                 "dumpThreadsToJson")                                           \
   template(jdk_internal_vm_ThreadSnapshot,         "jdk/internal/vm/ThreadSnapshot")                              \
-  template(jdk_internal_vm_ThreadSnapshot_ctor_signature, "([Ljava/lang/StackTraceElement;[Ljdk/internal/vm/ThreadSnapshot$ThreadLock;I)V") \
+  template(jdk_internal_vm_ThreadSnapshot_ctor_signature, "([Ljava/lang/StackTraceElement;[Ljdk/internal/vm/ThreadSnapshot$ThreadLock;Ljava/lang/String;I)V") \
   template(jdk_internal_vm_ThreadLock,             "jdk/internal/vm/ThreadSnapshot$ThreadLock")                   \
   template(jdk_internal_vm_ThreadLock_ctor_signature, "(IILjava/lang/Object;)V")                                  \
   template(java_lang_StackTraceElement_of_name,    "of")                                                          \

--- a/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
@@ -42,7 +42,7 @@ class ThreadSnapshot {
     // called by the VM
     private ThreadSnapshot(StackTraceElement[] stackTrace,
                            ThreadLock[] locks,
-                           //String name,
+                           String name,
                            int threadStatus) {
         this.stackTrace = stackTrace;
         this.locks = locks;
@@ -60,9 +60,6 @@ class ThreadSnapshot {
         }
         if (snapshot.locks == null) {
             snapshot.locks = EMPTY_LOCKS;
-        }
-        if (snapshot.name == null) {
-            snapshot.name = thread.getName();  // temp
         }
         return snapshot;
     }


### PR DESCRIPTION
Bad oop can happen after JvmtiVTMSTransitionDisabler is installed (at java_lang_VirtualThread::carrier_thread(java_thread) call).
Fixed by converting java_thread to Handle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/loom.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/217.diff">https://git.openjdk.org/loom/pull/217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/loom/pull/217#issuecomment-2819719082)
</details>
