### PR TITLE
ThreadSnapshot: create objects in VM

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2421,7 +2421,7 @@ oop java_lang_Thread::get_thread_snapshot(jobject jthread, bool with_locks, TRAP
   if (snapshot_klass->should_be_initialized()) {
     snapshot_klass->initialize(CHECK_NULL);
   }
-  
+
   Handle snapshot = jdk_internal_vm_ThreadSnapshot::allocate(InstanceKlass::cast(snapshot_klass), CHECK_NULL);
   jdk_internal_vm_ThreadSnapshot::set_name(snapshot(), thread_name());
   jdk_internal_vm_ThreadSnapshot::set_thread_status(snapshot(), (int)cl._thread_status);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -747,9 +747,8 @@ class SerializeClosure;
   template(dumpThreads_name,                       "dumpThreads")                                                 \
   template(dumpThreadsToJson_name,                 "dumpThreadsToJson")                                           \
   template(jdk_internal_vm_ThreadSnapshot,         "jdk/internal/vm/ThreadSnapshot")                              \
-  template(jdk_internal_vm_ThreadSnapshot_ctor_signature, "([Ljava/lang/StackTraceElement;[Ljdk/internal/vm/ThreadSnapshot$ThreadLock;Ljava/lang/String;I)V") \
   template(jdk_internal_vm_ThreadLock,             "jdk/internal/vm/ThreadSnapshot$ThreadLock")                   \
-  template(jdk_internal_vm_ThreadLock_ctor_signature, "(IILjava/lang/Object;)V")                                  \
+  template(jdk_internal_vm_ThreadLock_array,       "[Ljdk/internal/vm/ThreadSnapshot$ThreadLock;")                \
   template(java_lang_StackTraceElement_of_name,    "of")                                                          \
   template(java_lang_StackTraceElement_of_signature, "([Ljava/lang/StackTraceElement;)[Ljava/lang/StackTraceElement;") \
                                                                                                                   \

--- a/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
@@ -39,17 +39,6 @@ class ThreadSnapshot {
     private StackTraceElement[] stackTrace;
     private ThreadLock[] locks;
 
-    // called by the VM
-    private ThreadSnapshot(StackTraceElement[] stackTrace,
-                           ThreadLock[] locks,
-                           String name,
-                           int threadStatus) {
-        this.stackTrace = stackTrace;
-        this.locks = locks;
-        this.name = name;
-        this.threadStatus = threadStatus;
-    }
-
     /**
      * Take a snapshot of a Thread to get all information about the thread.
      */
@@ -58,9 +47,9 @@ class ThreadSnapshot {
         if (snapshot.stackTrace == null) {
             snapshot.stackTrace = EMPTY_STACK;
         }
-        if (snapshot.locks == null) {
-            snapshot.locks = EMPTY_LOCKS;
-        }
+        snapshot.locks = snapshot.locks == null
+                         ? snapshot.locks = EMPTY_LOCKS
+                         : ThreadLock.of(snapshot.locks);
         return snapshot;
     }
 
@@ -127,7 +116,7 @@ class ThreadSnapshot {
      */
     boolean ownsMonitors() {
         return Arrays.stream(locks)
-                .anyMatch(lock -> lock.type == LockType.LOCKED);
+                .anyMatch(lock -> lock.type() == LockType.LOCKED);
     }
 
     /**
@@ -139,7 +128,7 @@ class ThreadSnapshot {
 
     private Stream<Object> findLockObject(int depth, LockType type) {
         return Arrays.stream(locks)
-                .filter(lock -> lock.depth == depth
+                .filter(lock -> lock.depth() == depth
                         && lock.type() == type
                         && lock.lockObject() != null)
                 .map(ThreadLock::lockObject);
@@ -165,12 +154,29 @@ class ThreadSnapshot {
     /**
      * Represents a locking operation of a thread at a specific stack depth.
      */
-    private record ThreadLock(int depth, LockType type, Object obj) {
+    private class ThreadLock {
         private static final LockType[] lockTypeValues = LockType.values(); // cache
 
-        // called by the VM
-        private ThreadLock(int depth, int typeOrdinal, Object obj) {
-            this(depth, lockTypeValues[typeOrdinal], obj);
+        // set by the VM
+        private int depth;
+        private int typeOrdinal;
+        private Object obj;
+
+        private LockType type;
+
+        static ThreadLock[] of(ThreadLock[] locks) {
+            for (ThreadLock lock: locks) {
+                lock.type = lockTypeValues[lock.typeOrdinal];
+            }
+            return locks;
+        }
+
+        int depth() {
+            return depth;
+        }
+
+        LockType type() {
+            return type;
         }
 
         Object lockObject() {


### PR DESCRIPTION
The change removes upcalls to ThreadLock and ThreadSnapshot ctors, allocates and fills objects in the VM

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.org/loom.git pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/218.diff">https://git.openjdk.org/loom/pull/218.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/loom/pull/218#issuecomment-2843184177)
</details>
