### PR TITLE
ThreadDumper: wrong LOCKED

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2009,7 +2009,7 @@ public:
                   // we have marked ourself as pending on this monitor
                   mon == pending_moninor ||
                   // we are not the owner of this monitor
-                  false/*!mon->is_entered(thread())*/) {
+                  (_thread != nullptr && !mon->is_entered(_thread))) {
                 type = LockInfo::WAITING_TO_LOCK;
               }
             }


### PR DESCRIPTION
The changes fixes a bug when monitor is reported as `LOCKED` instead of `WAITING_TO_LOCK` when `pending_monitor` is not set (the condition was commented initially)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.org/loom.git pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/219.diff">https://git.openjdk.org/loom/pull/219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/loom/pull/219#issuecomment-2848312690)
</details>
