### PR TITLE
eliminated monitors

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1883,9 +1883,8 @@ public:
     // should be synced with ordinals of jdk.internal.vm.ThreadSnapshot.OwnedLockType enum
     enum Type {
       NOTHING = -1,
-      ELIMINATED_SCALAR_REPLACED = 0,
-      ELIMINATED_MONITOR = 1,
-      LOCKED = 2,
+      LOCKED = 0,
+      ELIMINATED = 1,
     };
 
     int _depth;
@@ -1987,11 +1986,12 @@ private:
         if (monitor->eliminated() && jvf->is_compiled_frame()) { // Eliminated in compiled code
           if (monitor->owner_is_scalar_replaced()) {
             Klass* k = java_lang_Class::as_Klass(monitor->owner_klass());
-            _locks->push(OwnedLock(depth, OwnedLock::ELIMINATED_SCALAR_REPLACED, OopHandle(Universe::vm_global(), k->klass_holder())));
+            _locks->push(OwnedLock(depth, OwnedLock::ELIMINATED, OopHandle(Universe::vm_global(), k->klass_holder())));
           } else {
-            oop owner = monitor->owner();
-            if (owner != nullptr) {
-              _locks->push(OwnedLock(depth, OwnedLock::ELIMINATED_MONITOR, OopHandle(Universe::vm_global(), owner)));
+            Handle owner(current, monitor->owner());
+            if (owner.not_null()) {
+              Klass* k = owner->klass();
+              _locks->push(OwnedLock(depth, OwnedLock::ELIMINATED, OopHandle(Universe::vm_global(), k->klass_holder())));
             }
           }
           continue;

--- a/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
+++ b/src/java.base/share/classes/jdk/internal/vm/ThreadSnapshot.java
@@ -162,10 +162,9 @@ class ThreadSnapshot {
      * Represents information about a locking operation.
      */
     private enum OwnedLockType {
-        // Lock object is a class of the eliminated monitor
-        ELIMINATED_SCALAR_REPLACED,
-        ELIMINATED_MONITOR,
         LOCKED,
+        // Lock object is a class of the eliminated monitor
+        ELIMINATED,
     }
 
     private enum BlockerLockType {
@@ -203,7 +202,7 @@ class ThreadSnapshot {
         }
 
         Object lockObject() {
-            if (type == OwnedLockType.ELIMINATED_SCALAR_REPLACED) {
+            if (type == OwnedLockType.ELIMINATED) {
                 // we have no lock object, lock contains lock class
                 return null;
             }

--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreads.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/DumpThreads.java
@@ -445,7 +445,7 @@ class DumpThreads {
     }
 
     /**
-     * Test thread dump wth a thread owning a monitor.
+     * Test thread dump with a thread owning a monitor.
      */
     @ParameterizedTest
     @MethodSource("threadFactories")
@@ -515,7 +515,7 @@ class DumpThreads {
     }
 
     /**
-     * Test thread dump wth a thread owning a monitor for an object that is scalar replaced.
+     * Test thread dump with a thread owning a monitor for an object that is scalar replaced.
      */
     @ParameterizedTest
     @MethodSource("threadFactories")


### PR DESCRIPTION
- combined ELIMINATED_SCALAR_REPLACED and ELIMINATED_MONITOR;
- for eliminated monitors report only lock class (so the lock object doesn't escape);
- typos in the test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/loom.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/221.diff">https://git.openjdk.org/loom/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/loom/pull/221#issuecomment-2899549345)
</details>
