### PR TITLE
Add VirtualThreadScheduler.currentVirtualThreadTask() default method

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -990,6 +990,30 @@ public class Thread implements Runnable {
         }
 
         /**
+         * Returns the {@code VirtualThreadTask} for the current virtual thread, or
+         * {@code null} if the current thread is not a virtual thread.
+         *
+         * @apiNote This method is intended for frameworks that make use of a custom
+         * {@link VirtualThreadScheduler VirtualThreadScheduler} and need to access the
+         * task's {@link VirtualThreadTask#attachment() attachment} from within a running
+         * virtual thread.
+         *
+         * @return the {@code VirtualThreadTask} for the current virtual thread,
+         *         or {@code null} if the current thread is not a virtual thread
+         * @throws UnsupportedOperationException if this is the built-in default scheduler
+         */
+        default VirtualThreadTask currentVirtualThreadTask() {
+            if (this == VirtualThread.builtinScheduler(false)) {
+                throw new UnsupportedOperationException();
+            }
+            Thread t = Thread.currentThread();
+            if (t instanceof VirtualThread vt) {
+                return vt.virtualThreadTask();
+            }
+            return null;
+        }
+
+        /**
          * Schedules a task that becomes enabled for execution after the given delay.
          *
          * <p> This method is invoked to schedule delayed tasks in support of timed

--- a/test/jdk/java/lang/Thread/virtual/CustomScheduler.java
+++ b/test/jdk/java/lang/Thread/virtual/CustomScheduler.java
@@ -268,6 +268,64 @@ class CustomScheduler {
     }
 
     /**
+     * Test currentVirtualThreadTask from a virtual thread with custom scheduler.
+     */
+    @Test
+    void testCurrentVirtualThreadTask1() throws Exception {
+        var ref = new AtomicReference<Thread.VirtualThreadTask>();
+        Thread thread = VThreadScheduler.virtualThreadBuilder(scheduler1).start(() -> {
+            ref.set(scheduler1.currentVirtualThreadTask());
+        });
+        thread.join();
+        assertNotNull(ref.get());
+        assertTrue(ref.get().thread() == thread);
+    }
+
+    /**
+     * Test currentVirtualThreadTask from a platform thread, should return null.
+     */
+    @Test
+    void testCurrentVirtualThreadTask2() {
+        assumeFalse(Thread.currentThread().isVirtual(), "Main thread is a virtual thread");
+        assertNull(scheduler1.currentVirtualThreadTask());
+    }
+
+    /**
+     * Test currentVirtualThreadTask attachment survives yield.
+     */
+    @Test
+    void testCurrentVirtualThreadTask3() throws Exception {
+        var ref = new AtomicReference<Object>();
+        Thread thread = VThreadScheduler.virtualThreadBuilder(scheduler1).start(() -> {
+            var task = scheduler1.currentVirtualThreadTask();
+            task.attach("test-attachment");
+            Thread.yield();
+            var taskAfterYield = scheduler1.currentVirtualThreadTask();
+            ref.set(taskAfterYield.attachment());
+        });
+        thread.join();
+        assertEquals("test-attachment", ref.get());
+    }
+
+    /**
+     * Test currentVirtualThreadTask on the default scheduler, should throw UOE.
+     */
+    @Test
+    void testCurrentVirtualThreadTaskDefaultScheduler() throws Exception {
+        var ref = new AtomicReference<Throwable>();
+        Thread thread = Thread.startVirtualThread(() -> {
+            try {
+                defaultScheduler.currentVirtualThreadTask();
+                fail("Expected UnsupportedOperationException");
+            } catch (UnsupportedOperationException e) {
+                ref.set(e);
+            }
+        });
+        thread.join();
+        assertNotNull(ref.get());
+    }
+
+    /**
      * Returns the scheduler for the current virtual thread.
      */
     private static Thread.VirtualThreadScheduler currentScheduler() {


### PR DESCRIPTION
I have worked on this change in order to test the custom scheduler impl at https://github.com/franz1981/Netty-VirtualThread-Scheduler to verify how it will behave while fully replacing the built-in scheduler, since I've implemented go-like work stealing on it.

The relevant custom scheduler impl change which shows the (unique) benefits of this API are at https://github.com/franz1981/Netty-VirtualThread-Scheduler/commit/3eae86ba312c7e67d4fdc16d89bbe3e3b64ec400 , which are:

- no need for a non-inheritable `ScopedValue` to know the current `VirtualThread`'s running scheduler (if any)
- to distinguish "internal" vs "external" submissions from `VirtualThread`s created via `Thread.ofVirtual.start`

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/loom.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/224.diff">https://git.openjdk.org/loom/pull/224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/loom/pull/224#issuecomment-4689895504)
</details>
