### PR TITLE
Route all VT creation through scheduler.newThread() for custom schedulers

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -968,25 +968,40 @@ public class Thread implements Runnable {
          * @implSpec The default implementation creates a new virtual thread. It should
          * be rare to override this method.
          *
-         * @param builder the virtual thread builder
-         * @param preferredCarrier the preferred carrirer, can be {@code null}
+         * @param name the thread name, can be {@code null}
+         * @param characteristics the thread characteristics
+         * @param preferredCarrier the preferred carrier, can be {@code null}
          * @param task the object to run when the thread executes
          * @return the {@code VirtualThreadTask} that scheduler executes
          * @throws UnsupportedOperationException if this is the built-in default scheduler
+         */
+        default VirtualThreadTask newThread(String name, int characteristics,
+                                            Thread preferredCarrier,
+                                            Runnable task) {
+            Objects.requireNonNull(task);
+            if (this == VirtualThread.builtinScheduler(false)) {
+                throw new UnsupportedOperationException();
+            }
+            var vthread = new VirtualThread(this, preferredCarrier, name, characteristics, task);
+            return vthread.virtualThreadTask();
+        }
+
+        /**
+         * Creates a new virtual thread using the given builder's configuration.
+         * Delegates to {@link #newThread(String, int, Thread, Runnable)}.
          *
-         * @see <a href="Thread.html#inheritance">Inheritance when creating threads</a>
+         * @param builder the virtual thread builder
+         * @param preferredCarrier the preferred carrier, can be {@code null}
+         * @param task the object to run when the thread executes
+         * @return the {@code VirtualThreadTask} that scheduler executes
          */
         default VirtualThreadTask newThread(Builder.OfVirtual builder,
                                             Thread preferredCarrier,
                                             Runnable task) {
             Objects.requireNonNull(builder);
-            Objects.requireNonNull(task);
-            if (this == VirtualThread.builtinScheduler(false)) {
-                throw new UnsupportedOperationException();
-            }
             var vbuilder = (ThreadBuilders.VirtualThreadBuilder) builder;
-            var vthread = (VirtualThread) vbuilder.unstarted(task, preferredCarrier);
-            return vthread.virtualThreadTask();
+            return newThread(vbuilder.nextThreadName(), vbuilder.characteristics(),
+                    preferredCarrier, task);
         }
 
         /**

--- a/src/java.base/share/classes/java/lang/ThreadBuilders.java
+++ b/src/java.base/share/classes/java/lang/ThreadBuilders.java
@@ -405,12 +405,23 @@ class ThreadBuilders {
     /**
      * Creates a new virtual thread to run the given task.
      */
+    // true when a custom scheduler is installed via implClass, JIT constant-folds
+    static final boolean CUSTOM_SCHEDULER =
+            VirtualThread.defaultScheduler() != VirtualThread.builtinScheduler(true);
+
     private static Thread newVirtualThread(Thread.VirtualThreadScheduler scheduler,
                                            Thread preferredCarrier,
                                            String name,
                                            int characteristics,
                                            Runnable task) {
         if (ContinuationSupport.isSupported()) {
+            // Route through the custom scheduler's newThread() when implClass is set.
+            // scheduler is non-null only with the legacy per-builder scheduler field,
+            // superseded by the global custom scheduler API (implClass).
+            if (scheduler == null && CUSTOM_SCHEDULER) {
+                return VirtualThread.defaultScheduler()
+                        .newThread(name, characteristics, preferredCarrier, task).thread();
+            }
             return new VirtualThread(scheduler, preferredCarrier, name, characteristics, task);
         } else {
             if (scheduler != null)


### PR DESCRIPTION
When a custom scheduler is installed via implClass, all VT creation routes through scheduler.newThread(String, int, Thread, Runnable) — the new raw-params overload. 
The existing builder overload delegates to it, extracting name and characteristics from the builder.

Single routing point in newVirtualThread(): when scheduler is null and CUSTOM_SCHEDULER is true, routes through the default scheduler's raw newThread(). No cycle — the raw default creates VirtualThread directly.

For paths without a builder (startVirtualThread, factory), uses no builder allocation — raw params are passed directly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).


This is a PoC which show 2 things:
1. if the (custom) scheduler overrides the `newThread` method can wrap its `Runnable` with a `ScopedValue` which can help with #224: still duplication (as it is now, which is not great), but enable **every VT** to run with such context.
2. using the `preferredCarrier != null` info, a custom scheduler can "treat" differently (by forcing some specific scheduling policy) such `VirtualThread` e.g. JDK pollers

Other 2 things:
- I dislike to pass/intercepts raw VT parameters
- Since we have some "legacy" thread builder `scheduler` field, this looks more messy than it could, sorry for that: with the unified "custom scheduler" API probably there's no reason to have per-builder `scheduler` fields

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.org/loom.git pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/225.diff">https://git.openjdk.org/loom/pull/225.diff</a>

</details>
