### PR TITLE
Stackchunk reuse old gen

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -608,6 +608,17 @@ freeze_result Freeze<ConfigT>::try_freeze_fast() {
   DEBUG_ONLY(_fast_freeze_size = size_if_fast_freeze_available();)
   assert(_fast_freeze_size == 0, "");
 
+  // Parallel/Serial GC: if the tail is a reusable old-gen chunk, go straight
+  // to freeze_slow which has the reuse logic in finalize_freeze. Allocating
+  // here would orphan the reusable chunk (set_tail in freeze_fast_new_chunk
+  // runs before the _barriers check can bail out).
+  {
+    stackChunkOop tail = _cont.tail();
+    if (tail != nullptr && tail->is_gc_mode() && tail->is_empty()) {
+      return freeze_slow();
+    }
+  }
+
   stackChunkOop chunk = allocate_chunk(cont_size() + frame::metadata_words + _monitors_in_lockstack, _cont.argsize() + frame::metadata_words_at_top);
   if (freeze_fast_new_chunk(chunk)) {
     return freeze_ok;
@@ -1049,6 +1060,25 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
     "Chunk allocated in freeze_fast is of insufficient size "
     "unextended_sp: %d size: %d is_empty: %d", unextended_sp, _freeze_size, chunk->is_empty());
   assert(!allocated_old_in_freeze_fast || (!UseZGC && !UseG1GC), "Unexpected allocation");
+
+  // Parallel/Serial GC: an empty gc_mode chunk with enough capacity can be
+  // reused instead of allocating a new one. We keep gc_mode set (the chunk
+  // is still in old gen) and set _barriers so that finish_freeze applies
+  // transform + card marking after the copy. This is the same mechanism used
+  // when allocate_chunk's slow path places a chunk directly in old gen.
+  // G1/ZGC cannot do this — G1 asserts against writing into old-gen chunks,
+  // and ZGC's concurrent relocation makes it unsafe.
+  bool reuse_old_chunk = !UseG1GC && !UseZGC
+                         && chunk != nullptr
+                         && chunk->is_gc_mode()
+                         && chunk->is_empty()
+                         && unextended_sp >= _freeze_size;
+  if (reuse_old_chunk) {
+    chunk->set_gc_mode(false);
+    chunk->set_has_bitmap(false);
+    _barriers = true;
+    allocated_old_in_freeze_fast = true;
+  }
 
   DEBUG_ONLY(bool empty_chunk = true);
   if (unextended_sp < _freeze_size || chunk->is_gc_mode() || (!allocated_old_in_freeze_fast && chunk->requires_barriers())) {
@@ -3008,12 +3038,20 @@ void ThawBase::finish_thaw(frame& f) {
   stackChunkOop chunk = _cont.tail();
 
   if (chunk->is_empty()) {
-    // Only remove chunk from list if it can't be reused for another freeze
+    // Only remove chunk from list if it can't be reused for another freeze.
+    // For Parallel/Serial GC, keep the empty chunk for reuse even when
+    // seen_by_gc() — the next freeze will write into it via the slow path
+    // with post-hoc barrier processing. This avoids allocating a new
+    // StackChunk on every freeze after promotion, which otherwise creates
+    // an allocation-churn cascade for long-lived virtual threads.
+    // G1/ZGC require detachment because their concurrent collectors
+    // cannot safely handle writes into old-gen chunks via post-hoc barriers.
     if (seen_by_gc()) {
-      _cont.set_tail(chunk->parent());
-    } else {
-      chunk->set_has_mixed_frames(false);
+      if (UseG1GC || UseZGC) {
+        _cont.set_tail(chunk->parent());
+      }
     }
+    chunk->set_has_mixed_frames(false);
     chunk->set_max_thawing_size(0);
   } else {
     chunk->set_max_thawing_size(chunk->max_thawing_size() - _align_size);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1074,6 +1074,8 @@ freeze_result FreezeBase::finalize_freeze(const frame& callee, frame& caller, in
                          && chunk->is_empty()
                          && unextended_sp >= _freeze_size;
   if (reuse_old_chunk) {
+    // added for telemetry purpose: can be either be a debug/trace or a proper JFR event if this will ever land
+    // log_info(continuations)("CHUNK_REUSE capacity=%d freeze_size=%d", unextended_sp, _freeze_size);
     chunk->set_gc_mode(false);
     chunk->set_has_bitmap(false);
     _barriers = true;
@@ -1579,6 +1581,9 @@ public:
 template <typename ConfigT>
 stackChunkOop Freeze<ConfigT>::allocate_chunk(size_t stack_size, int argsize_md) {
   log_develop_trace(continuations)("allocate_chunk allocating new chunk");
+  log_info(continuations)("CHUNK_ALLOC stack_size=%zu size_words=%zu preempt=%d",
+    stack_size, InstanceStackChunkKlass::cast(vmClasses::StackChunk_klass())->instance_size(stack_size),
+    _preempt ? 1 : 0);
 
   InstanceStackChunkKlass* klass = InstanceStackChunkKlass::cast(vmClasses::StackChunk_klass());
   size_t size_in_words = klass->instance_size(stack_size);


### PR DESCRIPTION
This is an experimental patch, used to write https://quarkus.io/blog/to-cache-or-not-to-cache-virtual-threads/

The purpose of the patch is to enable stack chunk reuse for collectors which have not concurrent phases and are usually suitable for "small heaps".
**The patch doesn't try to be smart**, as it doesn't have any heuristic to decide if is worthy to reuse only C2 compiled stack frames nor any average mean exponential decay (or similar) algorithm to decide IF is better to stick with a specific stack chunk capacity, and allow detachment to happen.
Which means that, similarly to heuristics built for native allocators, which have the same exact pooling problem vs unknown user-driven lifecycle usage, maybe there's a way to make it right.

I'm not (at all!) a GC expert, but I hope the article help to clarify what's the intent :pray: 

That said, pooling (as caching), is one (if not THE) most complex CS problem - since none knows the future - and specifically for FJP, it introduces a "stealthy" scheduling advantage to pooled VTs which I haven't (on purpose) mentioned in the article, as unparking a VT from a carrier can enable local (with signaling) submission, which was the primary reason I was playing with fire trying to understand and dissect scientifically the pros/cons of the known rule "never pool virtual threads".

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).


@theRealAph @tstuefe this is the patch I've mentioned. If it's ugly, it's all my fault :P

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/loom.git pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.org/loom.git pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/loom/pull/228.diff">https://git.openjdk.org/loom/pull/228.diff</a>

</details>
